### PR TITLE
Adding support for gateway in RHEL/CentOS ifcfg script

### DIFF
--- a/templates/guests/redhat/network_static.erb
+++ b/templates/guests/redhat/network_static.erb
@@ -6,5 +6,6 @@ ONBOOT=yes
 IPADDR=<%= options[:ip] %>
 NETMASK=<%= options[:netmask] %>
 DEVICE=eth<%= options[:interface] %>
+<%= options[:gateway] ? "GATEWAY=#{options[:gateway]}" : '' %>
 PEERDNS=no
 #VAGRANT-END


### PR DESCRIPTION
CentOS/RHEL should be able to set GATEWAY in ifcfg-#device for static routes.