### PR TITLE
Set Salt default config_dir

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -242,6 +242,11 @@ module VagrantPlugins
       end
 
       def call_highstate
+        if @config.minion_config
+          @machine.env.ui.info "Copying salt minion config to #{@config.config dir}"
+          @machine.communicate.upload(expanded_path(@config.minion_config).to_s, @config.config_dir + "/minion")
+        end
+
         if @config.run_highstate
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master


### PR DESCRIPTION
This adds a config_dir settings to the salt provisioner, with a 'sensible' default to /etc or C:\\etc on windows. This is then used to upload the minion file at the right place.

TBH, I think the current configuration setup of the vagrant salt plugin is a bit clumsy. What about adding this instead:

```
# Vagrantfile
 config.vm.provision :salt do |salt|

      salt.masterless = true # default false ?
      salt.minion_id = 'something' # default is using salt default

 end
```

This way, people don't need to care about how to actually set up masterless at the minion level, and translating this config into actual salt call is simple (e.g. salt-call ... --local --id=$id). Thoughts ? Would be happy to prepare a PR toward this if this makes sense to vagrant devs.