### PR TITLE
Salt masterless configuration

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -19,6 +19,8 @@ module VagrantPlugins
       attr_accessor :verbose
       attr_accessor :seed_master
       attr_reader   :pillar_data
+      attr_accessor :masterless
+      attr_accessor :minion_id
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -50,6 +52,8 @@ module VagrantPlugins
         @install_syndic = UNSET_VALUE
         @no_minion = UNSET_VALUE
         @bootstrap_options = UNSET_VALUE
+        @masterless = UNSET_VALUE
+        @minion_id = UNSET_VALUE
       end
 
       def finalize!
@@ -73,7 +77,8 @@ module VagrantPlugins
         @install_syndic     = nil if @install_syndic == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
-
+        @masterless 	    = false if @masterless == UNSET_VALUE
+        @minion_id 	    = nil if @minion_id == UNSET_VALUE
       end
 
       def pillar(data)

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -238,8 +238,24 @@ module VagrantPlugins
         end
       end
 
+      def call_masterless
+        @machine.env.ui.info "Calling state.highstate in local mode... (this may take a while)"
+        cmd = "salt-call state.highstate --local"
+        if @config.minion_id
+          cmd += " --id #{@config.minion_id}"
+        end
+        cmd += " -l debug#{get_pillar}"
+        @machine.communicate.sudo(cmd) do |type, data|
+          if @config.verbose
+            @machine.env.ui.info(data)
+          end
+        end
+      end
+
       def call_highstate
-        if @config.run_highstate
+        if @config.masterless
+          call_masterless
+        elsif @config.run_highstate
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
             @machine.communicate.sudo("salt '*' saltutil.sync_all")


### PR DESCRIPTION
This PR simplifies vagrant-salt configuration for masterless setup: instead of having people messing with the configuration files (which does not work ATM because of #2970), people can simply do the following:

    config.vm.provision :salt do |salt|
      salt.masterless = true # false by default
      salt.minion_id = "base" # allows to override the id
    end