### PR TITLE
Remove all available versions of a box

### DIFF
--- a/plugins/commands/box/command/remove.rb
+++ b/plugins/commands/box/command/remove.rb
@@ -27,6 +27,10 @@ module VagrantPlugins
                  "The specific version of the box to remove") do |v|
               options[:version] = v
             end
+
+            o.on("--all", "Remove all available versions of the box") do |a|
+              options[:all] = a
+            end
           end
 
           # Parse the options
@@ -50,6 +54,7 @@ module VagrantPlugins
             box_provider: options[:provider],
             box_version:  options[:version],
             force_confirm_box_remove: options[:force],
+            box_remove_all_versions: options[:all],
           })
 
           # Success, exit status 0

--- a/website/docs/source/v2/cli/box.html.md
+++ b/website/docs/source/v2/cli/box.html.md
@@ -128,12 +128,15 @@ This command removes a box from Vagrant that matches the given name.
 
 If a box has multiple providers, the exact provider must be specified
 with the `--provider` flag. If a box has multiple versions, you can select
-what versions to delete with the `--box-version` flag.
+what versions to delete with the `--box-version` flag or remove all versions
+with the `--all` flag.
 
 ## Options
 
 * `--box-version VALUE` - Version of version constraints of the boxes to
   remove. See documentation on this flag for `box add` for more details.
+
+* `--all` - Remove all available versions of a box.
 
 * `--force` - Forces removing the box even if an active Vagrant
   environment is using it.


### PR DESCRIPTION
This patch introduces a new parameter --all for the remove command of the box plugin.

While using the parameter --all when removing a box will remove all available versions of the box.

Example usage:

```
$ vagrant box list
berendt/ubuntu-14.04-amd64          (virtualbox, 0.2.11)
berendt/ubuntu-14.04-amd64          (virtualbox, 0.2.12)
berendt/ubuntu-14.04-amd64          (virtualbox, 0.2.13)
```

```
$ vagrant box remove berendt/ubuntu-14.04-amd64
You requested to remove the box 'berendt/ubuntu-14.04-amd64' with provider
'virtualbox'. This box has multiple versions. You must
explicitly specify which version you want to remove with
the `--box-version` flag.

Versions:
0.2.13, 0.2.12,  0.2.11
```

Using the --all parameter now it's possible to remove all versions at once.

```
$ vagrant box remove berendt/ubuntu-14.04-amd64 --all
Removing box 'berendt/ubuntu-14.04-amd64' with provider 'virtualbox' in version '0.2.13'...
Removing box 'berendt/ubuntu-14.04-amd64' with provider 'virtualbox' in version '0.2.12'...
Removing box 'berendt/ubuntu-14.04-amd64' with provider 'virtualbox' in version '0.2.11'...
```

Fixes https://github.com/mitchellh/vagrant/issues/3343