### PR TITLE
[Vagrant][HyperV] Customization

### DIFF
--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
             end
 
             b2.use action_halt
+            b1.use Customize, "pre-boot"
             b2.use action_start
           end
         end
@@ -136,6 +137,7 @@ module VagrantPlugins
               b1.use Import
             end
 
+            b1.use Customize, "pre-boot"
             b1.use action_start
           end
         end
@@ -217,6 +219,7 @@ module VagrantPlugins
       autoload :SuspendVM, action_root.join("suspend_vm")
       autoload :WaitForIPAddress, action_root.join("wait_for_ip_address")
       autoload :MessageWillNotDestroy, action_root.join("message_will_not_destroy")
+      autoload :Customize, action_root.join("customize")
     end
   end
 end

--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
             end
 
             b2.use action_halt
-            b1.use Customize, "pre-boot"
+            b2.use Customize, "pre-boot"
             b2.use action_start
           end
         end

--- a/plugins/providers/hyperv/action/customize.rb
+++ b/plugins/providers/hyperv/action/customize.rb
@@ -1,0 +1,154 @@
+require "log4r"
+
+module VagrantPlugins
+  module HyperV
+    module Action
+      class Customize
+
+        def initialize(app, env, event)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant::hyperv::connection")
+          @event  = event
+        end
+
+        def call(env)
+          customizations = []
+          @env = env
+          env[:machine].provider_config.customizations.each do |event, command|
+            if event == @event
+              customizations << command
+            end
+          end
+
+          if !customizations.empty?
+            env[:ui].info I18n.t("vagrant.actions.vm.customize.running", event: @event)
+            customizations.each do |query|
+              command = query[0]
+              params = query[1]
+              if self.respond_to?("custom_action_#{command}")
+                self.send("custom_action_#{command}", params)
+              end
+            end
+          end
+
+          validate_virtual_switch
+          @app.call(env)
+        end
+
+        def custom_action_virtual_switch(params)
+          options = { vm_id: @env[:machine].id,
+                      type: (params[:type] || "").downcase  || "external",
+                      name: params[:name],
+                      adapter: (params[:bridge] || "").downcase
+                    }
+
+          if options[:type] == "private"
+            @env[:ui].detail I18n.t("vagrant_hyperv.private_switch_not_allowed")
+            return
+          end
+
+          response = @env[:machine].provider.driver.switch_exist({ name: options[:name],
+                                              type: options[:type]})
+
+          if options[:type] == "internal"
+            @env[:ui].detail(" ")
+            @env[:ui].detail I18n.t("vagrant_hyperv.internal_switch_warn")
+            @env[:ui].detail(" ")
+            if response["message"] == "switch exist"
+              add_swith_to_vm(options)
+              return
+            else
+              raise Errors::NoSwitchFound,
+                type: options[:type], name: options[:name]
+            end
+          end
+
+          if options[:type] == "external"
+            if response["message"] == "switch exist"
+              if (response["switch_name"].casecmp(options[:name]) == 0)
+                add_swith_to_vm(options)
+                return
+              else
+                raise Errors::ExternalSwitchExist, name: response["switch_name"]
+              end
+            end
+
+            adapters = @env[:machine].provider.driver.list_net_adapters
+            available_adapters = adapters.map { |a| a["Name"].downcase }
+
+            unless available_adapters.include? (options[:adapter])
+              @env[:ui].detail I18n.t("vagrant_hyperv.net_adapter_warn")
+              selected_adapter = choose_option_from(adapters, "adapter")
+              options[:adapter] = selected_adapter["Name"]
+            end
+
+            @env[:ui].info I18n.t("vagrant_win_hyperv.creating_switch",
+              { type: options[:type], name: options[:name] })
+            response = @env[:machine].provider.driver.create_network_switch(options)
+            case response["message"]
+              when "Network down"
+                raise Errors::NetworkDown
+              when "Success"
+                add_swith_to_vm(options)
+            end
+          end
+        end
+
+        def add_swith_to_vm(options)
+          current_vm_switch = @env[:machine].provider.driver.find_vm_switch_name
+          if current_vm_switch["network_adapter"].nil?
+            raise VagrantPlugins::VagrantHyperV::Errors::NoNetworkAdapter
+          end
+          @env[:machine].provider.driver.add_swith_to_vm(options)
+        end
+
+        def validate_virtual_switch
+          @env[:ui].info "Validating Virtual Switch"
+          current_vm_switch = @env[:machine].provider.driver.find_vm_switch_name
+
+          if current_vm_switch["switch_name"].nil?
+            switches = @env[:machine].provider.driver.execute("get_switches.ps1", {})
+            raise Errors::NoSwitches if switches.empty?
+
+            switch = choose_option_from(switches, "switch")
+            switch_type = nil
+            case switch["SwitchType"]
+            when 1
+              switch_type = "Internal"
+            when 2
+              switch_type = "External"
+            end
+
+            options = { vm_id: @env[:machine].id,
+                        type: switch_type.downcase,
+                        name: switch["Name"]
+                      }
+            @env[:ui].info I18n.t("vagrant_hyperv.add_switch_to_vm",
+              { type: options[:type], name: options[:name] })
+
+            add_swith_to_vm(options)
+          end
+        end
+
+        private
+        def choose_option_from(options, key)
+          @env[:ui].detail(I18n.t("vagrant_hyperv.choose_#{key}") + "\n ")
+          options.each_index do |i|
+            option = options[i]
+            @env[:ui].detail("#{i+1}) #{option["Name"]}")
+          end
+          @env[:ui].detail(" ")
+
+          selected = nil
+          while !selected
+            selected = @env[:ui].ask("What #{key} would you like to use? ")
+            next if !selected
+            selected = selected.to_i - 1
+            selected = nil if selected < 0 || selected >= options.length
+          end
+          options[selected]
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -43,28 +43,6 @@ module VagrantPlugins
 
           env[:ui].output("Importing a Hyper-V instance")
 
-          switches = env[:machine].provider.driver.execute("get_switches.ps1", {})
-          raise Errors::NoSwitches if switches.empty?
-
-          switch = switches[0]["Name"]
-          if switches.length > 1
-            env[:ui].detail(I18n.t("vagrant_hyperv.choose_switch") + "\n ")
-            switches.each_index do |i|
-              switch = switches[i]
-              env[:ui].detail("#{i+1}) #{switch["Name"]}")
-            end
-            env[:ui].detail(" ")
-
-            switch = nil
-            while !switch
-              switch = env[:ui].ask("What switch would you like to use? ")
-              next if !switch
-              switch = switch.to_i - 1
-              switch = nil if switch < 0 || switch >= switches.length
-            end
-            switch = switches[switch]["Name"]
-          end
-
           env[:ui].detail("Cloning virtual hard drive...")
           source_path = image_path.to_s
           dest_path   = env[:machine].data_dir.join("disk#{image_ext}").to_s
@@ -77,7 +55,6 @@ module VagrantPlugins
             vm_xml_config:  config_path.to_s.gsub("/", "\\"),
             image_path:      image_path.to_s.gsub("/", "\\")
           }
-          options[:switchname] = switch if switch
 
           env[:ui].detail("Creating and registering the VM...")
           server = env[:machine].provider.driver.import(options)

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -8,9 +8,19 @@ module VagrantPlugins
       #
       # @return [Integer]
       attr_accessor :ip_address_timeout
+      attr_reader :customizations
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
+        @customizations   = []
+      end
+
+      def customize(*command)
+        @customizations ||= []
+        event   = command.first.is_a?(String) ? command.shift : "pre-boot"
+        command = command[0]
+        options = command[1]
+        @customizations << [event, command, options]
       end
 
       def finalize!
@@ -21,6 +31,13 @@ module VagrantPlugins
 
       def validate(machine)
         errors = _detected_errors
+
+        valid_events = ["pre-boot"]
+        @customizations.each do |event, _|
+          if !valid_events.include?(event)
+            errors << "Invalid custom event #{event} use pre-boot"
+          end
+        end
 
         { "Hyper-V" => errors }
       end

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -93,6 +93,10 @@ module VagrantPlugins
          execute("switch_exist.ps1", options)
        end
 
+       def create_network_switch(options)
+         execute('create_switch.ps1', options)
+       end
+
       protected
 
       def execute_powershell(path, options, &block)

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -77,6 +77,22 @@ module VagrantPlugins
          execute('import_vm.ps1', options)
        end
 
+       def list_net_adapters
+         execute("get_adapters.ps1", {})
+       end
+
+       def find_vm_switch_name
+        execute("find_vm_switch_name.ps1", { VmId: vm_id })
+       end
+
+       def add_swith_to_vm(options)
+         execute("add_switch_to_vm.ps1", options)
+       end
+
+       def switch_exist(options)
+         execute("switch_exist.ps1", options)
+       end
+
       protected
 
       def execute_powershell(path, options, &block)

--- a/plugins/providers/hyperv/errors.rb
+++ b/plugins/providers/hyperv/errors.rb
@@ -37,6 +37,11 @@ module VagrantPlugins
       class WindowsRequired < HyperVError
         error_key(:windows_required)
       end
+
+      class NetworkDown < HyperVError
+        error_key(:network_down)
+      end
+
     end
   end
 end

--- a/plugins/providers/hyperv/errors.rb
+++ b/plugins/providers/hyperv/errors.rb
@@ -42,6 +42,18 @@ module VagrantPlugins
         error_key(:network_down)
       end
 
+      class NoSwitchFound < HyperVError
+        error_key(:switch_not_found)
+      end
+
+      class ExternalSwitchExist < HyperVError
+        error_key(:external_switch_exist)
+      end
+
+      class NoNetworkAdapter < HyperVError
+        error_key(:no_network_adapter)
+      end
+
     end
   end
 end

--- a/plugins/providers/hyperv/scripts/add_switch_to_vm.ps1
+++ b/plugins/providers/hyperv/scripts/add_switch_to_vm.ps1
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Open Technologies, Inc.
+# All Rights Reserved. Licensed under the MIT License.
+#--------------------------------------------------------------------------
+
+param (
+  [Parameter(Mandatory=$true)]
+  [string]$type,
+  [Parameter(Mandatory=$true)]
+  [string]$name,
+  [Parameter(Mandatory=$true)]
+  [string]$vm_id,
+  [Parameter(Mandatory=$false)]
+  [string]$adapter
+ )
+
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+try {
+
+   $vm = Get-VM -Id $vm_id -ErrorAction "stop"
+    Get-VMSwitch "$name" | Where-Object { $_.SwitchType -eq "$type" } `
+    | Connect-VMNetworkAdapter -VMName $vm.Name
+
+   $resultHash = @{
+     message = "OK"
+   }
+   Write-Output-Message $(ConvertTo-JSON $resultHash)
+ }
+ catch {
+  $errortHash = @{
+    type = "PowerShellError"
+    error = "$_"
+  }
+  Write-Error-Message $(ConvertTo-JSON $errortHash)
+ }

--- a/plugins/providers/hyperv/scripts/create_switch.ps1
+++ b/plugins/providers/hyperv/scripts/create_switch.ps1
@@ -1,0 +1,75 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Open Technologies, Inc.
+# All Rights Reserved. Licensed under the MIT License.
+#--------------------------------------------------------------------------
+
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$type,
+    [Parameter(Mandatory=$true)]
+    [string]$name,
+    [Parameter(Mandatory=$true)]
+    [string]$vm_id,
+    [Parameter(Mandatory=$true)]
+    [string]$adapter
+ )
+
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+try {
+
+  # Find the current IP address of the host. This will be used later to test the
+  # network connectivity upon creating a new switch to a network adapter
+  $ip = (Get-WmiObject -class win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"').ipaddress[0]
+
+  $max_attempts = 5
+  $operation_pass = $false
+  do {
+    try {
+      if ($type -eq "external") {
+        New-VMSwitch -Name "$name" -NetAdapterName $adapter -ErrorAction "stop"
+      }
+      $operation_pass = $true
+    } catch {
+      $max_attempts = $max_attempts - 1
+      sleep 5
+    }
+  }
+  while (!$operation_pass -and $max_attempts -gt 0)
+
+   # On creating a new switch / a new network adapter, there are chances that
+   # the network may get disconnected for a while.
+
+   # Keep checking for network availability before exiting this script
+   $max_attempts = 10
+   $network_available = $false
+   do {
+     try {
+      $ping_response = Test-Connection "$ip" -ErrorAction "stop"
+      $network_available = $true
+     } catch {
+        $max_attempts = $max_attempts - 1
+        sleep 5
+     }
+   }
+   while (!$network_available -and $max_attempts -gt 0)
+   if (-not $network_available) {
+    $resptHash = @{
+      message = "Network down"
+    }
+   } else {
+    $resptHash = @{
+      message = "Success"
+    }
+   }
+   Write-Output-Message $(ConvertTo-JSON $resptHash)
+   return
+} catch {
+    $errortHash = @{
+      type = "PowerShellError"
+      error = "$_"
+    }
+    Write-Error-Message $(ConvertTo-JSON $errortHash)
+}

--- a/plugins/providers/hyperv/scripts/find_vm_switch_name.ps1
+++ b/plugins/providers/hyperv/scripts/find_vm_switch_name.ps1
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Open Technologies, Inc.
+# All Rights Reserved. Licensed under the MIT License.
+#--------------------------------------------------------------------------
+
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$VmId
+ )
+
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+
+try {
+  $vm = Get-VM -Id $VmId -ErrorAction "stop"
+  $network_adapter = Get-VMNetworkAdapter -vm $vm
+  $resultHash = @{}
+  $resultHash["switch_name"] = $network_adapter.SwitchName
+  $resultHash["network_adapter"] = $network_adapter.Name
+  Write-Output-Message $(ConvertTo-JSON $resultHash)
+} catch [Microsoft.HyperV.PowerShell.VirtualizationOperationFailedException] {
+  $errortHash = @{
+    type = "PowerShellError"
+    error = "$_"
+  }
+  Write-Error-Message $(ConvertTo-JSON $errortHash)
+}

--- a/plugins/providers/hyperv/scripts/get_adapters.ps1
+++ b/plugins/providers/hyperv/scripts/get_adapters.ps1
@@ -1,0 +1,13 @@
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+$adapters = @()
+
+  Get-NetAdapter `
+    | Select-Object Name,InterfaceDescription,Status `
+    | Where-Object {$_.Status-eq "up"}  `
+    | ForEach-Object  -Process {
+      $adapters += $_
+    }
+Write-Output-Message $(ConvertTo-JSON $adapters)

--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -2,9 +2,7 @@ Param(
     [Parameter(Mandatory=$true)]
     [string]$vm_xml_config,
     [Parameter(Mandatory=$true)]
-    [string]$image_path,
-
-    [string]$switchname=$null
+    [string]$image_path
 )
 
 # Include the following modules
@@ -44,11 +42,6 @@ $MemoryMaximumBytes = ($memory.limit."#text" -as [int]) * 1MB
 $MemoryStartupBytes = ($memory.size."#text" -as [int]) * 1MB
 $MemoryMinimumBytes = ($memory.reservation."#text" -as [int]) * 1MB
 
-if (!$switchname) {
-    # Get the name of the virtual switch
-    $switchname = (Select-Xml -xml $vmconfig -XPath "//AltSwitchName").node."#text"
-}
-
 # Determine boot device
 Switch ((Select-Xml -xml $vmconfig -XPath "//boot").node.device0."#text") {
     "Floppy"    { $bootdevice = "floppy" }
@@ -65,7 +58,6 @@ $vm_params = @{
     Generation = $generation
     NoVHD = $True
     MemoryStartupBytes = $MemoryStartupBytes
-    SwitchName = $switchname
     BootDevice = $bootdevice
     ErrorAction = "Stop"
 }

--- a/plugins/providers/hyperv/scripts/switch_exist.ps1
+++ b/plugins/providers/hyperv/scripts/switch_exist.ps1
@@ -1,0 +1,54 @@
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Open Technologies, Inc.
+# All Rights Reserved. Licensed under the MIT License.
+#--------------------------------------------------------------------------
+
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$type,
+    [Parameter(Mandatory=$true)]
+    [string]$name
+ )
+
+ # Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+try {
+  if ($type -eq "external") {
+    $switch_exist = Get-VMSwitch -SwitchType  "$type"
+    if ($switch_exist) {
+      $switch_name = $switch_exist.name
+      $resptHash = @{
+        message = "switch exist"
+        switch_name = "$switch_name"
+      }
+      Write-Output-Message $(ConvertTo-JSON $resptHash)
+      return
+    }
+  }
+
+  $switch_exist = (Get-VMSwitch -SwitchType  "$type" `
+    | Select-Object Name `
+    | Where-Object { $_.name -eq $name })
+  if ($switch_exist) {
+    $switch_name = $switch_exist.name
+    $resptHash = @{
+      message = "switch exist"
+      switch_name = "$switch_name"
+    }
+  } else {
+    $resptHash = @{
+      message = "switch not exist"
+      switch_name = "$name"
+    }
+  }
+    Write-Output-Message $(ConvertTo-JSON $resptHash)
+    return
+} catch {
+  $errortHash = @{
+    type = "PowerShellError"
+    error = "$_"
+  }
+  Write-Error-Message $(ConvertTo-JSON $errortHash)
+}

--- a/templates/locales/providers_hyperv.yml
+++ b/templates/locales/providers_hyperv.yml
@@ -17,13 +17,17 @@ en:
       will not allow the host to communicate with the VM. Please refer to Hyper-V's
       virtual switch configuration for more information.
     internal_switch_warn: |-
-      Vagrant works well with Hyper-V's External Switch. If you are using an
+      Vagrant works best with Hyper-V's External Switch. If you are using an
       Internal switch please make sure that this switch is properly configured
-      for network connection.  The virtual machine must be reachable from the
+      for network connection. The virtual machine must be reachable from the
       host for Vagrant to work.
     net_adapter_warn: |-
-      You seems to have provided an invalid adapter, please choose a one from
+      You seems to have provided an invalid adapter, please choose one from
       the available list of adapters.
+    creating_switch: |-
+      Creating a virtual switch of type "%{type}" with name %{name}
+    add_switch_to_vm: |-
+      Setting the VM to use a Virtual switch of type "%{type}" with name %{name}
 
     errors:
       admin_required: |-
@@ -88,7 +92,13 @@ en:
       network_down: |-
         The host network seems to be down, this generally happens while creating
         an external network, it looked like Hyper-V manager took a long time to
-        bring back the network. Please check the netwotk connection and try again.
+        bring back the network. Please check the network connection and try again.
       no_network_adapter: |-
         No Network adapter is connected to this VM. Please use the HyperV Manage
         to add a network adapter.
+      external_switch_exist: |-
+        Hyper-V allows to have only one external switch. There already exist one
+        with name "%{name}"
+      switch_not_found: |-
+        A Virtual switch of type "%{type}" and name "%{name}" is not found, please
+        create the same using Hyper-V "Virtual Switch Manager".

--- a/templates/locales/providers_hyperv.yml
+++ b/templates/locales/providers_hyperv.yml
@@ -4,12 +4,26 @@ en:
       Please choose a switch to attach to your Hyper-V instance.
       If none of these are appropriate, please open the Hyper-V manager
       to create a new virtual switch.
+    choose_adapter: |-
+      Please choose an adapter to attach to your External switch.
     message_already_running: |-
       Hyper-V instance already running.
     message_not_created: |-
       VM not created. Moving on...
     message_not_running: |-
       Hyper-V machine isn't running. Can't SSH in!
+    private_switch_not_allowed: |-
+      Vagrant cannot work with Hyper-V's private switch, since this configuration
+      will not allow the host to communicate with the VM. Please refer to Hyper-V's
+      virtual switch configuration for more information.
+    internal_switch_warn: |-
+      Vagrant works well with Hyper-V's External Switch. If you are using an
+      Internal switch please make sure that this switch is properly configured
+      for network connection.  The virtual machine must be reachable from the
+      host for Vagrant to work.
+    net_adapter_warn: |-
+      You seems to have provided an invalid adapter, please choose a one from
+      the available list of adapters.
 
     errors:
       admin_required: |-
@@ -71,3 +85,10 @@ en:
       windows_required: |-
         The Hyper-V provider only works on Windows. Please try to
         use another provider.
+      network_down: |-
+        The host network seems to be down, this generally happens while creating
+        an external network, it looked like Hyper-V manager took a long time to
+        bring back the network. Please check the netwotk connection and try again.
+      no_network_adapter: |-
+        No Network adapter is connected to this VM. Please use the HyperV Manage
+        to add a network adapter.


### PR DESCRIPTION
New feature for vagrant-hyperv for including networking customization during pre-boot. With this feature one can customize which virtual switch the VM can take from the Vagrantfile.

Example usage
 ```ruby
config.vm.provider "hyperv" do |hv, override|
   hv.customize  ["virtual_switch", { type: "External", name: "External Switch", :adapter => "Ethernet" }]
end
 ```