### PR TITLE
Add machine readable action notifications. Associate device oriented log messages with the given device.

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -105,7 +105,8 @@ module Vagrant
       @provider_config = provider_config
       @provider_name   = provider_name
       @provider_options = provider_options
-      @ui              = Vagrant::UI::Prefixed.new(@env.ui, @name)
+      @ui              = @env.ui.is_a?(Vagrant::UI::MachineReadable) ? @env.ui.clone : Vagrant::UI::Prefixed.new(@env.ui, @name)
+      @ui.opts[:target] = name
       @ui_mutex        = Mutex.new
 
       # Read the ID, which is usually in local storage
@@ -170,7 +171,10 @@ module Vagrant
             provider: @provider.to_s
         end
 
-        action_raw(name, callable, extra_env)
+        ui.machine("action","#{name.to_s}:start:#{@provider.to_s}")
+        action_result = action_raw(name, callable, extra_env)
+        ui.machine("action","#{name.to_s}:end:#{@provider.to_s}")
+        action_result
       end
     rescue Errors::EnvironmentLockedError
       raise Errors::MachineActionLockedError,

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -105,8 +105,7 @@ module Vagrant
       @provider_config = provider_config
       @provider_name   = provider_name
       @provider_options = provider_options
-      @ui              = @env.ui.is_a?(Vagrant::UI::MachineReadable) ? @env.ui.clone : Vagrant::UI::Prefixed.new(@env.ui, @name)
-      @ui.opts[:target] = name
+      @ui              = Vagrant::UI::Prefixed.new(@env.ui, @name)
       @ui_mutex        = Mutex.new
 
       # Read the ID, which is usually in local storage

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -89,7 +89,7 @@ module Vagrant
         opts = {}
         opts = data.pop if data.last.kind_of?(Hash)
 
-        target = opts[:target] || ""
+        target = opts[:target] || @opts[:target] || ""
 
         # Prepare the data by replacing characters that aren't outputted
         data.each_index do |i|
@@ -103,6 +103,17 @@ module Vagrant
           safe_puts("#{Time.now.utc.to_i},#{target},#{type},#{data.join(",")}")
         end
       end
+
+      [:detail, :info, :warn, :error, :output, :success].each do |method|
+        class_eval <<-CODE
+          def #{method}(message, *args)
+            opts = {}
+            opts.merge(args.pop) if args.last.kind_of?(Hash)
+            machine(#{method.inspect}, message, opts)
+          end
+        CODE
+      end
+
     end
 
     # This is a UI implementation that outputs the text as is. It

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -89,7 +89,7 @@ module Vagrant
         opts = {}
         opts = data.pop if data.last.kind_of?(Hash)
 
-        target = opts[:target] || @opts[:target] || ""
+        target = opts[:target] || ""
 
         # Prepare the data by replacing characters that aren't outputted
         data.each_index do |i|
@@ -307,10 +307,17 @@ module Vagrant
         target = @prefix
         target = opts[:target] if opts.has_key?(:target)
 
+
+
         # Get the lines. The first default is because if the message
         # is an empty string, then we want to still use the empty string.
         lines = [message]
         lines = message.split("\n") if message != ""
+
+        if @ui.is_a?(Vagrant::UI::MachineReadable)
+          return machine(type, message, { :target => target })
+        end
+         
 
         # Otherwise, make sure to prefix every line properly
         lines.map do |line|


### PR DESCRIPTION
```
1404762105,,info,Bringing machine 'mon1.vagrant-tj' up with 'lxc' provider...
1404762105,mon1.vagrant-tj,action,up:start:LXC (new VM)
1404762105,mon1.vagrant-tj,info,Importing base box 'superbase-mysql55-cloud-base-railsexpress-omnibus'...
1404762105,,info,
1404762105,mon1.vagrant-tj,warn,WARNING: You are using a base box that has a format that has been deprecated%!(VAGRANT_COMMA) please upgrade to a new one.
1404762105,,warn,
1404762106,mon1.vagrant-tj,output,Setting up mount entries for shared folders...1404762106,,output,
1404762106,mon1.vagrant-tj,detail,/vagrant => /home/vagrant/chef-repo/vagrant/openstack
1404762106,,detail,
1404762106,mon1.vagrant-tj,info,Starting container...
1404762106,,info,1404762106,mon1.vagrant-tj,output,Waiting for machine to boot. This may take a few minutes...
1404762106,,output,
1404762107,mon1.vagrant-tj,action,fetch_ip:start:LXC (openstack_mon1vagrant-tj_1404762105734_17930)
1404762113,mon1.vagrant-tj,action,fetch_ip:end:LXC (openstack_mon1vagrant-tj_1404762105734_17930)
..
1404762202,singleton1.vagrant-tj,warn,WARNING: You are using a base box that has a format that has been deprecated%!(VAGRANT_COMMA) please upgrade to a new one.
1404762139,mon1.vagrant-tj,info,[2014-07-07T19:42:19+00:00] FATAL: Net::HTTPServerException: 403 "Forbidden"
1404762203,mon1.vagrant-tj,action,up:end:LXC (openstack_mon1vagrant-tj_1404762105734_17930)
```