### PR TITLE
Added ability to run salt orchestrations to Salt provisioner

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :grains_config
       attr_accessor :run_highstate
       attr_accessor :run_overstate
+      attr_accessor :orchestrations
       attr_accessor :always_install
       attr_accessor :bootstrap_script
       attr_accessor :verbose

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
         run_bootstrap_script
         call_overstate
         call_highstate
+        call_orchestrate
       end
 
       # Return a list of accepted keys
@@ -334,6 +335,34 @@ module VagrantPlugins
           end
         else
           @machine.env.ui.info "run_highstate set to false. Not running state.highstate."
+        end
+      end
+
+      def call_orchestrate
+        if not @config.orchestrations
+          @machine.env.ui.info "orchestrate is nil. Not running state.orchestrate."
+          return
+        end
+
+        if not @config.install_master
+          @machine.env.ui.info "orchestrate does not make sense on a minion. Not running state.orchestrate"
+          return
+        end
+
+        log_output = lambda do |type, data|
+          if @config.verbose
+            @machine.env.ui.info(data)
+          end
+        end
+
+        @machine.env.ui.info "Running the following orchestrations: #{@config.orchestrations}"
+        @machine.env.ui.info "Running saltutil.sync_all before orchestrating"
+        @machine.communicate.sudo("salt '*' saltutil.sync_all", &log_output)
+
+        @config.orchestrations.each do |orchestration|
+          cmd = "salt-run -l info state.orchestrate #{orchestration}"
+          @machine.env.ui.info "Calling #{cmd}... (this may take a while)"
+          @machine.communicate.sudo(cmd, &log_output)
         end
       end
     end


### PR DESCRIPTION
Fix for https://github.com/mitchellh/vagrant/issues/4370 . Adds a config option orchestrations, which when set on the master node (config.install_master = true), will cause each orchestration in the provided list of orchestrations to be run