### PR TITLE
Add option to enable trusted HTTP/HTTPS redirects

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -404,6 +404,7 @@ module Vagrant
           downloader_options[:client_cert] = env[:box_client_cert]
           downloader_options[:headers] = ["Accept: application/json"] if opts[:json]
           downloader_options[:ui] = env[:ui] if opts[:ui]
+          downloader_options[:location_trusted] = env[:box_download_location_trusted]
 
           Util::Downloader.new(url, temp_path, downloader_options)
         end

--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -64,6 +64,7 @@ module Vagrant
           box_download_ca_path = machine.config.vm.box_download_ca_path
           box_download_client_cert = machine.config.vm.box_download_client_cert
           box_download_insecure = machine.config.vm.box_download_insecure
+          box_download_location_trusted = machine.config.vm.box_download_location_trusted
           box_formats = machine.provider_options[:box_format] ||
             machine.provider_name
 
@@ -85,6 +86,7 @@ module Vagrant
               box_download_ca_cert: box_download_ca_cert,
               box_download_ca_path: box_download_ca_path,
               box_download_insecure: box_download_insecure,
+              box_download_location_trusted: box_download_location_trusted,
             }))
           rescue Errors::BoxAlreadyExists
             # Just ignore this, since it means the next part will succeed!

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -49,6 +49,7 @@ module Vagrant
         @insecure    = options[:insecure]
         @ui          = options[:ui]
         @client_cert = options[:client_cert]
+        @location_trusted = options[:location_trusted]
       end
 
       # This executes the actual download, downloading the source file
@@ -202,6 +203,7 @@ module Vagrant
         options << "--insecure" if @insecure
         options << "--cert" << @client_cert if @client_cert
         options << "-u" << @auth if @auth
+        options << "--location-trusted" if @location_trusted
 
         if @headers
           Array(@headers).each do |header|

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -38,6 +38,10 @@ module VagrantPlugins
               options[:client_cert] = c
             end
 
+            o.on("--location-trusted", "Trust 'Location' header from HTTP redirects and use the same credentials for subsequent urls as for the initial one") do |l|
+                options[:location_trusted] = l
+            end
+
             o.on("--provider PROVIDER", String, "Provider the box should satisfy") do |p|
               options[:provider] = p
             end
@@ -95,6 +99,7 @@ module VagrantPlugins
             box_download_ca_path: options[:ca_path],
             box_download_client_cert: options[:client_cert],
             box_download_insecure: options[:insecure],
+            box_download_location_trusted: options[:location_trusted],
             ui: Vagrant::UI::Prefixed.new(@env.ui, "box"),
           })
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -27,6 +27,7 @@ module VagrantPlugins
       attr_accessor :box_download_checksum_type
       attr_accessor :box_download_client_cert
       attr_accessor :box_download_insecure
+      attr_accessor :box_download_location_trusted
       attr_accessor :communicator
       attr_accessor :graceful_halt_timeout
       attr_accessor :guest
@@ -36,25 +37,26 @@ module VagrantPlugins
       attr_reader :provisioners
 
       def initialize
-        @base_mac                     = UNSET_VALUE
-        @boot_timeout                 = UNSET_VALUE
-        @box                          = UNSET_VALUE
-        @box_check_update             = UNSET_VALUE
-        @box_download_ca_cert         = UNSET_VALUE
-        @box_download_ca_path         = UNSET_VALUE
-        @box_download_checksum        = UNSET_VALUE
-        @box_download_checksum_type   = UNSET_VALUE
-        @box_download_client_cert     = UNSET_VALUE
-        @box_download_insecure        = UNSET_VALUE
-        @box_url                      = UNSET_VALUE
-        @box_version                  = UNSET_VALUE
-        @communicator                 = UNSET_VALUE
-        @graceful_halt_timeout        = UNSET_VALUE
-        @guest                        = UNSET_VALUE
-        @hostname                     = UNSET_VALUE
-        @post_up_message              = UNSET_VALUE
-        @provisioners                 = []
-        @usable_port_range            = UNSET_VALUE
+        @base_mac                      = UNSET_VALUE
+        @boot_timeout                  = UNSET_VALUE
+        @box                           = UNSET_VALUE
+        @box_check_update              = UNSET_VALUE
+        @box_download_ca_cert          = UNSET_VALUE
+        @box_download_ca_path          = UNSET_VALUE
+        @box_download_checksum         = UNSET_VALUE
+        @box_download_checksum_type    = UNSET_VALUE
+        @box_download_client_cert      = UNSET_VALUE
+        @box_download_insecure         = UNSET_VALUE
+        @box_download_location_trusted = UNSET_VALUE
+        @box_url                       = UNSET_VALUE
+        @box_version                   = UNSET_VALUE
+        @communicator                  = UNSET_VALUE
+        @graceful_halt_timeout         = UNSET_VALUE
+        @guest                         = UNSET_VALUE
+        @hostname                      = UNSET_VALUE
+        @post_up_message               = UNSET_VALUE
+        @provisioners                  = []
+        @usable_port_range             = UNSET_VALUE
 
         # Internal state
         @__compiled_provider_configs   = {}
@@ -331,6 +333,7 @@ module VagrantPlugins
         @box_download_checksum_type = nil if @box_download_checksum_type == UNSET_VALUE
         @box_download_client_cert = nil if @box_download_client_cert == UNSET_VALUE
         @box_download_insecure = false if @box_download_insecure == UNSET_VALUE
+        @box_download_location_trusted = false if @box_download_location_trusted == UNSET_VALUE
         @box_url = nil if @box_url == UNSET_VALUE
         @box_version = nil if @box_version == UNSET_VALUE
         @communicator = nil if @communicator == UNSET_VALUE

--- a/website/docs/source/v2/vagrantfile/machine_settings.html.md
+++ b/website/docs/source/v2/vagrantfile/machine_settings.html.md
@@ -62,6 +62,13 @@ URL, then SSL certs will be verified.
 
 <hr>
 
+`config.vm.box_download_location_trusted` - If true, then all HTTP redirects will be
+treated as trusted. That means credentials used for initial URL will be used for
+all subsequent redirects. By default, redirect locations are untrusted so credentials
+(if specified) used only for initial HTTP request.
+
+<hr>
+
 `config.vm.box_url` - The URL that the configured box can be found at.
 If `config.vm.box` is a shorthand to a box in [Vagrant Cloud](https://vagrantcloud.com)
 then this value doesn't need to be specified. Otherwise, it should


### PR DESCRIPTION
This is needed in case if we have password-protected URL which is actually redirect to another password-protected URL which accept the same credentials as initial URL.