### PR TITLE
Make `start` action run provisioners if VM is running

### DIFF
--- a/plugins/providers/docker/action.rb
+++ b/plugins/providers/docker/action.rb
@@ -209,9 +209,6 @@ module VagrantPlugins
       def self.action_start
         Vagrant::Action::Builder.new.tap do |b|
           b.use Call, IsState, :running do |env, b2|
-            # If the container is running and we're doing a run, we're done
-            next if env[:result] && env[:machine_action] != :run_command
-
             if env[:machine_action] != :run_command
               b2.use Call, HasSSH do |env2, b3|
                 if env2[:result]
@@ -223,6 +220,9 @@ module VagrantPlugins
                 end
               end
             end
+
+            # If the container is running and we're doing a run, we're done
+            next if env[:result] && env[:machine_action] != :run_command
 
             b2.use Call, IsState, :not_created do |env2, b3|
               if !env2[:result]

--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -105,7 +105,7 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use Call, IsState, :running do |env1, b1|
             if env1[:result]
-              b1.use Message, I18n.t("vagrant_hyperv.message_already_running")
+              b1.use action_provision
               next
             end
 

--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -248,9 +248,9 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use BoxCheckOutdated
           b.use Call, IsRunning do |env, b2|
-            # If the VM is running, then our work here is done, exit
+            # If the VM is running, run the necessary provisioners
             if env[:result]
-              b2.use MessageAlreadyRunning
+              b2.use action_provision
               next
             end
 


### PR DESCRIPTION
Previously, there was no one gesture that would start a VM if it was not
running and run the appropriate provisioners regardless of its original
state. `vagrant up` did nothing if the VM was running, while
`vagrant provision` did nothing if the VM was not running.

Change the semantics of `vagrant up`, via the start actions of the providers,
to go through the provisioning logic even if the VM is already running.
The semantics of `run: "once"` vs `run: "always"` are respected.

Tested with the VirtualBox provider but not the others.

Resolves #4421