### PR TITLE
Eliminate guesswork with Vagrantfile errors

### DIFF
--- a/lib/vagrant/config/loader.rb
+++ b/lib/vagrant/config/loader.rb
@@ -212,6 +212,8 @@ module Vagrant
             # Report the generic exception
             raise Errors::VagrantfileLoadError,
               path: path,
+              line: e.backtrace[0].split(':')[1],
+              exception_class: e.class,
               message: e.message
           end
         end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -55,6 +55,7 @@ module VagrantPlugins
         @post_up_message              = UNSET_VALUE
         @provisioners                 = []
         @usable_port_range            = UNSET_VALUE
+        @logger        = Log4r::Logger.new("vagrant::config::vm")
 
         # Internal state
         @__compiled_provider_configs   = {}
@@ -438,8 +439,13 @@ module VagrantPlugins
               config = config.merge(new_config)
             end
           rescue Exception => e
+            @logger.error("Vagrantfile load error: #{e.message}")
+            @logger.error(e.backtrace.join("\n"))
+
             raise Vagrant::Errors::VagrantfileLoadError,
               path: "<provider config: #{name}>",
+              line: e.backtrace[0].split(':')[1],
+              exception_class: e.class,
               message: e.message
           end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1168,7 +1168,8 @@ en:
         a syntax error.
 
         Path: %{path}
-        Message: %{message}
+        Line number: %{line}
+        Message: %{exception_class}: %{message}
       vagrantfile_syntax_error: |-
         There is a syntax error in the following Vagrantfile. The syntax error
         message is reproduced below for convenience:


### PR DESCRIPTION
If the `Vagrantfile` has some kind of error, display not only its path and the exception message, but also the originating line number and exception class.

Also log the full backtrace when the error is in a provider block, just as it is done when it's outside a provider block.