### PR TITLE
Add password to rdp_info hash

### DIFF
--- a/plugins/commands/rdp/command.rb
+++ b/plugins/commands/rdp/command.rb
@@ -69,7 +69,15 @@ module VagrantPlugins
           end
           rdp_info[:username] = username
         end
-
+        
+        if !rdp_info[:password]
+          username = ssh_info[:password]
+          if machine.config.vm.communicator == :winrm
+            username = machine.config.winrm.password
+          end
+          rdp_info[:password] = username
+        end
+        
         rdp_info[:host] ||= ssh_info[:host]
         rdp_info[:port] ||= machine.config.rdp.port
 

--- a/plugins/commands/rdp/command.rb
+++ b/plugins/commands/rdp/command.rb
@@ -71,11 +71,11 @@ module VagrantPlugins
         end
         
         if !rdp_info[:password]
-          username = ssh_info[:password]
+          password = ssh_info[:password]
           if machine.config.vm.communicator == :winrm
-            username = machine.config.winrm.password
+            password = machine.config.winrm.password
           end
-          rdp_info[:password] = username
+          rdp_info[:password] = password
         end
         
         rdp_info[:host] ||= ssh_info[:host]


### PR DESCRIPTION
Any specific reason the password was omitted from the rdp_info hash?

Without the password in the rdp_info hash I see no way of figuring out the password in the rdp_client capability.