### PR TITLE
Added a --plugin-clean-sources parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # OS-specific
 .DS_Store
 
+# Editor swapfiles
+.*.sw?
+*~
+
 # Vagrant stuff
 acceptance_config.yml
 boxes/*

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -178,11 +178,6 @@ module Vagrant
 
       f = File.open(Tempfile.new("vagrant").path + "2", "w+")
       f.tap do |gemfile|
-        if !sources.include?("http://rubygems.org")
-          gemfile.puts(%Q[source "https://rubygems.org"])
-        end
-
-        gemfile.puts(%Q[source "http://gems.hashicorp.com"])
         sources.each do |source|
           next if source == ""
           gemfile.puts(%Q[source "#{source}"])

--- a/plugins/commands/plugin/command/mixin_install_opts.rb
+++ b/plugins/commands/plugin/command/mixin_install_opts.rb
@@ -3,6 +3,11 @@ module VagrantPlugins
     module Command
       module MixinInstallOpts
         def build_install_opts(o, options)
+          options[:plugin_sources] = [
+            "https://rubygems.org",
+            "http://gems.hashicorp.com",
+          ]
+
           o.on("--entry-point NAME", String,
                "The name of the entry point file for loading the plugin.") do |entry_point|
             options[:entry_point] = entry_point
@@ -17,9 +22,13 @@ module VagrantPlugins
             puts
           end
 
+          o.on("--plugin-clean-sources", String,
+            "Remove all plugin sources defined so far (including defaults)") do
+            options[:plugin_sources] = []
+          end
+
           o.on("--plugin-source PLUGIN_SOURCE", String,
                "Add a RubyGems repository source") do |plugin_source|
-            options[:plugin_sources] ||= []
             options[:plugin_sources] << plugin_source
           end
 


### PR DESCRIPTION
This parameter that will allow for only those sources that are defined by the user to be used. I also added editor swapfiles to the .gitignore.

I work in a corporate environment behind firewalls which prevent access to both rubygems.org and gems.hashicorp.com. We have our own rubygems repository where we host (among other things) Vagrant plugins (both internally-created and external). Without a patch like this, `vagrant plugin install vagrant-triggers` (for instance) will fail because it cannot retrieve the specs from gems.hashicorp.com. Furthermore, we need something like this so that the risk and audit groups don't see the attempts at forbidden traffic.

I'm not thrilled with the parameter behavior I created - it means that parameter parsing is a state machine and that could be surprising. I would have preferred `--plugin-source` to have the behavior of overwriting the defaults. But, that would have been a breaking API change and I didn't want to propose that in the initial request.

Also, this leads to the desire of having a `.vagrantrc` that we can use to set these values by default on a project basis. But, that's another changeset.