### PR TITLE
Allow specifying post_up_message block

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -341,6 +341,12 @@ module VagrantPlugins
         @__defined_vms[name].config_procs << [options[:config_version], block] if block
       end
 
+      # Returns configured post_up_message. If value is callable, returns the
+      # value of invoking it.
+      def post_up_message
+        @post_up_message.respond_to?(:call) ? @post_up_message.call : @post_up_message
+      end
+
       #-------------------------------------------------------------------
       # Internal methods, don't call these.
       #-------------------------------------------------------------------

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -260,6 +260,12 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       subject.finalize!
       expect(subject.post_up_message).to eq("foo")
     end
+
+    it "can be a proc" do
+      subject.post_up_message = -> { "bar" }
+      subject.finalize!
+      expect(subject.post_up_message).to eq("bar")
+    end
   end
 
   describe "#provider and #__providers" do


### PR DESCRIPTION
This PR allows users to configure a callable `post_up_message` to print values at a later time:

```ruby
Vagrant.configure("2") do |config|
  config.vm.post_up_message = -> {
    ip = `vagrant ssh -- "ifconfig eth1 | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n1"`.chomp
    """
    Your instance is configured.

    https://#{ip}
    Username: foo
    Password: bar
    """
  }
end
```

I also thought about changing the method signature to be more DSL-like, but decided against it for minimal changes. Open to updating the PR to this if it feels more natural.

```ruby
Vagrant.configure("2") do |config|
  config.vm.post_up_message do
    "deferred message here"
  end
end
```

Thoughts?