### PR TITLE
Update configure_networks.rb for funtoo

### DIFF
--- a/plugins/guests/funtoo/cap/configure_networks.rb
+++ b/plugins/guests/funtoo/cap/configure_networks.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
                 temp.binmode
                 temp.write(entry)
                 temp.close
-                comm.upload(temp.path, "/tmp/vagrant-network-entry-#{ifFile}")
+                comm.upload(temp.path, "/tmp/vagrant-#{ifFile}")
                 comm.sudo("cp /tmp/vagrant-#{ifFile} /etc/conf.d/#{ifFile}")
                 comm.sudo("chmod 0644 /etc/conf.d/#{ifFile}")
                 comm.sudo("ln -fs /etc/init.d/netif.tmpl /etc/init.d/#{ifFile}")


### PR DESCRIPTION
fixed name of temporary network configuration file to work with the further process of copying file to configuration directory in funtoo guests

fix for https://github.com/mitchellh/vagrant/issues/4812