### PR TITLE
Force at least one retry in vm_exists? for provider VirtualBox 4.3

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -579,9 +579,14 @@ module VagrantPlugins
             result = raw("showvminfo", uuid)
             return true if result.exit_code == 0
 
-            # GH-2479: Sometimes this happens. In this case, retry. If
-            # we don't see this text, the VM really probably doesn't exist.
-            return false if !result.stderr.include?("CO_E_SERVER_EXEC_FAILURE")
+            # GH-2479: Sometimes this happens. In this case, retry.
+            #
+            # VirtualBox issue https://www.virtualbox.org/ticket/13190
+            # On Windows, `VBoxManage showvminfo` crashes specially after
+            # a suspend. This leads to a new VM being restart each time.
+            # Until fixed in VirtualBox, allow at least one retry even if
+            # stderr does not include CO_E_SERVER_EXEC_FAILURE.
+            return false if i >= 1 && !result.stderr.include?("CO_E_SERVER_EXEC_FAILURE")
 
             # Sleep a bit though to give VirtualBox time to fix itself
             sleep 2


### PR DESCRIPTION
Due to [VirtualBox #13190](https://www.virtualbox.org/ticket/13190), on Windows, `VBoxManager showvminfo` crashes if the VM is suspended (and maybe in other occasions). This leads Vagrant to think the VM does not exist. This has bad consequences for lot of commands since machine uuid is cleared which leads to a new VM being started. Since there is already a retry mechanism in place, simply force at least one retry of the command. The second invocation should work correctly if the machine is present.

Downside of this patch, it takes 2 more seconds for the UI to respond if the vm really does not exist. We could remove this by forcing a retry without a sleep.

Linked to #1454 (Maybe we should start a brand new issue for this however, since we hijacked the initial bug report).

Regards,
Matt