### PR TITLE
doc destroy - notice about space occupied by the box

### DIFF
--- a/website/docs/source/v2/cli/destroy.html.md
+++ b/website/docs/source/v2/cli/destroy.html.md
@@ -18,3 +18,15 @@ confirmation can be skipped by passing in the `-f` or `--force` flag.
 ## Options
 
 * `-f` or `--force` - Don't ask for confirmation before destroying.
+
+<div class="alert alert-info">
+    <p>
+        The <code>vagrant destroy</code> command does not remove a box
+        that may have been installed on your computer during <code>vagrant up</code>.
+        Thus, even if you run <code>vagrant destroy</code>, the box installed in the system
+        will still be present on the hard drive. To return your computer to the
+        state as it was before <code>vagrant up</code> command, you need to use
+        <code>vagrant box remove</code>. For more information, read about the
+        [vagrant box remove](/v2/cli/box.html) command.
+    </p>
+</div>


### PR DESCRIPTION
Hi,
Because `vagrant destroy` doesn't remove the box installed during `vagrant up`, the statement:

    After running this command, your computer should be left at a clean state, 
    as if you never created the guest machine in the first place.

is a bit of an exaggeration, I think. Maybe you will find the notice I have written useful?