### PR TITLE
Added ignore_errors to pupper_server provisioner

### DIFF
--- a/plugins/provisioners/puppet/config/puppet_server.rb
+++ b/plugins/provisioners/puppet/config/puppet_server.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
         attr_accessor :options
         attr_accessor :puppet_server
         attr_accessor :puppet_node
+        attr_accessor :ignore_errors
 
         def initialize
           super
@@ -18,6 +19,7 @@ module VagrantPlugins
           @options                 = []
           @puppet_node             = UNSET_VALUE
           @puppet_server           = UNSET_VALUE
+          @ignore_errors           = UNSET_VALUE
         end
 
         def merge(other)

--- a/plugins/provisioners/puppet/provisioner/puppet_server.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet_server.rb
@@ -84,8 +84,14 @@ module VagrantPlugins
           end
 
           options = options.join(" ")
+          if config.ignore_errors
+              return_decision = 'true'
+
+          else
+              return_decision = '[ $? -eq 2 ]'
+          end
           command = "#{facter}puppet agent --onetime --no-daemonize #{options} " +
-            "--server #{config.puppet_server} --detailed-exitcodes || [ $? -eq 2 ]"
+            "--server #{config.puppet_server} --detailed-exitcodes || #{return_decision}"
 
           @machine.ui.info I18n.t("vagrant.provisioners.puppet_server.running_puppetd")
           @machine.communicate.sudo(command) do |type, data|


### PR DESCRIPTION
 - this will continue with provisioning, even if some stuff in puppet
   failed
 - it will just return true, regardless of the actual return value of
   puppet agent

We have some very long puppet runs here where some stuff may fail, but we then want to fix this within the vagrant created box.
We have more provisioners after puppet and want to be sure they are run as well.

Thus, we need to be able to ignore the result of the puppet_provision.

Since this is completely optional, it should not harm.

Thanks,
Sven

PS: With my combination of rbenv, bundler and such, I wasn't able to get vagrant to run properly, sorry. I'd loved to properly test and such. Maybe one of you can let me know in a understandable way how I can get vagrant to run under rbenv/bundler/gem, you name it.