### PR TITLE
Allow filtering/reprioritization of synced folder preferences

### DIFF
--- a/lib/vagrant/action/builtin/mixin_synced_folders.rb
+++ b/lib/vagrant/action/builtin/mixin_synced_folders.rb
@@ -27,9 +27,11 @@ module Vagrant
 
           allowed_types = machine.config.vm.allowed_synced_folder_types
           if allowed_types
-            ordered = ordered.select do |_, key, impl|
-              allowed_types.include? key
-            end
+            ordered = allowed_types.map do |type|
+              ordered.find do |_, key, impl|
+                key == type
+              end
+            end.compact
           end
 
           # Find the proper implementation

--- a/lib/vagrant/action/builtin/mixin_synced_folders.rb
+++ b/lib/vagrant/action/builtin/mixin_synced_folders.rb
@@ -25,6 +25,13 @@ module Vagrant
           # Order the plugins by priority. Higher is tried before lower.
           ordered = ordered.sort { |a, b| b[0] <=> a[0] }
 
+          allowed_types = machine.config.vm.allowed_synced_folder_types
+          if allowed_types
+            ordered = ordered.select do |_, key, impl|
+              allowed_types.include? key
+            end
+          end
+
           # Find the proper implementation
           ordered.each do |_, key, impl|
             return key if impl.new.usable?(machine)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -373,6 +373,10 @@ module VagrantPlugins
           @usable_port_range = (2200..2250)
         end
 
+        if @allowed_synced_folder_types
+          @allowed_synced_folder_types = Array(@allowed_synced_folder_types).map(&:to_sym)
+        end
+
         # Make sure that the download checksum is a string and that
         # the type is a symbol
         @box_download_checksum = "" if !@box_download_checksum

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
     class VMConfig < Vagrant.plugin("2", :config)
       DEFAULT_VM_NAME = :default
 
+      attr_accessor :allowed_synced_folder_types
       attr_accessor :base_mac
       attr_accessor :boot_timeout
       attr_accessor :box
@@ -36,6 +37,7 @@ module VagrantPlugins
       attr_reader :provisioners
 
       def initialize
+        @allowed_synced_folder_types  = UNSET_VALUE
         @base_mac                     = UNSET_VALUE
         @boot_timeout                 = UNSET_VALUE
         @box                          = UNSET_VALUE
@@ -347,6 +349,7 @@ module VagrantPlugins
 
       def finalize!
         # Defaults
+        @allowed_synced_folder_types = nil if @allowed_synced_folder_types == UNSET_VALUE
         @base_mac = nil if @base_mac == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
         @box = nil if @box == UNSET_VALUE

--- a/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
@@ -53,6 +53,22 @@ describe Vagrant::Action::Builtin::MixinSyncedFolders do
       result = subject.default_synced_folder_type(machine, plugins)
       expect(result).to eq("good")
     end
+
+    it "reprioritizes based on allowed_synced_folder_types" do
+      plugins = {
+        "bad" => [impl(false, "bad"), 0],
+        "good" => [impl(true, "good"), 1],
+        "same" => [impl(true, "same"), 1],
+      }
+
+      expect(vm_config).to receive(:allowed_synced_folder_types).and_return(["good", "same"])
+      result = subject.default_synced_folder_type(machine, plugins)
+      expect(result).to eq("good")
+
+      expect(vm_config).to receive(:allowed_synced_folder_types).and_return(["same", "good"])
+      result = subject.default_synced_folder_type(machine, plugins)
+      expect(result).to eq("same")
+    end
   end
 
   describe "impl_opts" do

--- a/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
@@ -28,14 +28,26 @@ describe Vagrant::Action::Builtin::MixinSyncedFolders do
     end
   end
 
-  let(:vm_config) { double("machine_vm_config") }
+  let(:vm_config) { double("machine_vm_config", :allowed_synced_folder_types => nil) }
 
   describe "default_synced_folder_type" do
     it "returns the usable implementation" do
       plugins = {
         "bad" => [impl(false, "bad"), 0],
-        "nope" => [impl(true, "nope"), 1],
-        "good" => [impl(true, "good"), 5],
+        "good" => [impl(true, "good"), 1],
+        "best" => [impl(true, "best"), 5],
+      }
+
+      result = subject.default_synced_folder_type(machine, plugins)
+      expect(result).to eq("best")
+    end
+
+    it "filters based on allowed_synced_folder_types" do
+      expect(vm_config).to receive(:allowed_synced_folder_types).and_return(["bad", "good"])
+      plugins = {
+        "bad" => [impl(false, "bad"), 0],
+        "good" => [impl(true, "good"), 1],
+        "best" => [impl(true, "best"), 5],
       }
 
       result = subject.default_synced_folder_type(machine, plugins)


### PR DESCRIPTION
Currently Vagrant selects the default synced folder type based on hardcoded priorities. It will select the highest-priority "usable" plugin. Usable doesn't necessary mean working, it usually just checks that pre-requisite software is either installed or can be installed automatically. It might still be unusable in practice because of security policies or the need for additional configuration.

I've also found that the order is not always deterministic. Currently rsync and nfs have equal priority. I've seen some users report that NFS is selected, and others report that rsync is selected, when both are "usable" on their system. The `config.nfs.functional = false` property can let you disable nfs to ensure rsync is selected, but there currently isn't a way to disable rsync and force NFS to be selected (other than customizing the settings of *each* shared folder, which requires knowing the synced folders setup by provisioners and other plugins).

This PR adds a property that both filters and reprioritizes the available synced folder types before selecting a default type. This way you can force a specific selection:
```ruby
  config.vm.allowed_synced_folder_types = :rsync
```

Allow Vagrant to choose from a subset of available types:
```ruby
  # Will use rsync if it's usable, nfs if it isn't
  config.vm.allowed_synced_folder_types = [:rsync, :nfs]
```

And swap the preferences:
```ruby
  # Will use nfs if it's usable, rsync if it isn't
  config.vm.allowed_synced_folder_types = [:nfs, :rsync]
```

In addition to giving the user more control of the priorities so they can easily choose nfs vs rsync, this is currently the only way to select a very low-priority synced folder type like [WinRM](https://github.com/mitchellh/vagrant/pull/4983) over higher-priority and nearly always "usable" types like rsync.