### PR TITLE
Being able to edit a file does not mean you can write in its parent directory

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -102,7 +102,7 @@ module VagrantPlugins
 
           # Use sed to just strip out the block of code which was inserted
           # by Vagrant
-          system("#{sudo_command}sed -r -e '\\\x01^# VAGRANT-BEGIN:( #{user})? #{id}\x01,\\\x01^# VAGRANT-END:( #{user})? #{id}\x01 d' -ibak /etc/exports")
+          system("cp /etc/exports /tmp && #{sudo_command}sed -r -e '\\\x01^# VAGRANT-BEGIN:( #{user})? #{id}\x01,\\\x01^# VAGRANT-END:( #{user})? #{id}\x01 d' -ibak /tmp/exports ; cp /tmp/exports /etc/exports")
         end
 
         def self.nfs_opts_setup(folders)


### PR DESCRIPTION
Interactive `sed` needs write permission on the file itself. However, it may create a backup file, which leads to the fact that the directory where the file is located must be writable as well. That is a side effect because this directory does not need to be writable.

This patch fixes this side effect by editing the file in `/tmp`, and replaces it right after.