### PR TITLE
enable symlinks before adding shared folder

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -452,11 +452,11 @@ module VagrantPlugins
               folder[:hostpath]]
             args << "--transient" if folder.has_key?(:transient) && folder[:transient]
 
-            # Add the shared folder
-            execute("sharedfolder", "add", @uuid, *args)
-
             # Enable symlinks on the shared folder
             execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+
+            # Add the shared folder
+            execute("sharedfolder", "add", @uuid, *args)
           end
         end
 

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -483,11 +483,11 @@ module VagrantPlugins
               folder[:hostpath]]
             args << "--transient" if folder.has_key?(:transient) && folder[:transient]
 
-            # Add the shared folder
-            execute("sharedfolder", "add", @uuid, *args)
-
             # Enable symlinks on the shared folder
             execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+
+            # Add the shared folder
+            execute("sharedfolder", "add", @uuid, *args)
           end
         end
 

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -500,11 +500,11 @@ module VagrantPlugins
               folder[:hostpath]]
             args << "--transient" if folder.has_key?(:transient) && folder[:transient]
 
-            # Add the shared folder
-            execute("sharedfolder", "add", @uuid, *args)
-
             # Enable symlinks on the shared folder
             execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+
+            # Add the shared folder
+            execute("sharedfolder", "add", @uuid, *args)
           end
         end
 


### PR DESCRIPTION
Fix for issue #5093 to allow symlinks to work in Docker shared folders with using VirtualBox as the host. 