### PR TITLE
Fix catching "Start-VM" exceptions on Hyper-V during starting up VM

### DIFF
--- a/plugins/providers/hyperv/scripts/start_vm.ps1
+++ b/plugins/providers/hyperv/scripts/start_vm.ps1
@@ -10,7 +10,7 @@ forEach ($module in $modules) { . $module }
 
 try {
   $vm = Get-VM -Id $VmId -ErrorAction "stop"
-  Start-VM $vm
+  Start-VM $vm -ErrorAction "stop"
   $state = $vm.state
   $status = $vm.status
   $name = $vm.name


### PR DESCRIPTION
Fix for "Start-VM exceptions are not caught' #5101