### PR TITLE
provisioners/chef: use synced folder cache instead of counter

### DIFF
--- a/plugins/provisioners/chef/config/base.rb
+++ b/plugins/provisioners/chef/config/base.rb
@@ -1,11 +1,7 @@
-require "vagrant/util/counter"
-
 module VagrantPlugins
   module Chef
     module Config
       class Base < Vagrant.plugin("2", :config)
-        extend Vagrant::Util::Counter
-
         # The path to Chef's bin/ directory.
         # @return [String]
         attr_accessor :binary_path
@@ -48,11 +44,11 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :version
 
-        # The path where the Chef installer will be downloaded to. Only valid if 
+        # The path where the Chef installer will be downloaded to. Only valid if
         # install is true or "force". It defaults to nil, which means that the
-        # omnibus installer will choose the destination and you have no control 
-        # over it. 
-        # 
+        # omnibus installer will choose the destination and you have no control
+        # over it.
+        #
         # @return [String]
         attr_accessor :installer_download_path
 

--- a/plugins/provisioners/chef/config/base_runner.rb
+++ b/plugins/provisioners/chef/config/base_runner.rb
@@ -81,19 +81,13 @@ module VagrantPlugins
           @https_proxy_pass   = nil if @https_proxy_pass == UNSET_VALUE
           @no_proxy           = nil if @no_proxy == UNSET_VALUE
           @node_name          = nil if @node_name == UNSET_VALUE
-          @provisioning_path  = nil if @provisioning_path == UNSET_VALUE
+          @provisioning_path = "/tmp/vagrant-chef" if @provisioning_path == UNSET_VALUE
           @file_backup_path   = "/var/chef/backup" if @file_backup_path == UNSET_VALUE
           @file_cache_path    = "/var/chef/cache"  if @file_cache_path == UNSET_VALUE
           @verbose_logging    = false if @verbose_logging == UNSET_VALUE
 
           if @encrypted_data_bag_secret_key_path == UNSET_VALUE
             @encrypted_data_bag_secret_key_path = nil
-          end
-
-          # Set the default provisioning path to be a unique path in /tmp
-          if !@provisioning_path
-            counter = self.class.get_and_update_counter(:chef_config)
-            @provisioning_path = "/tmp/vagrant-chef-#{counter}"
           end
         end
 

--- a/plugins/provisioners/chef/config/chef_apply.rb
+++ b/plugins/provisioners/chef/config/chef_apply.rb
@@ -24,11 +24,7 @@ module VagrantPlugins
           super
 
           @recipe = nil if @recipe == UNSET_VALUE
-
-          if @upload_path == UNSET_VALUE
-            counter = self.class.get_and_update_counter(:chef_apply)
-            @upload_path = "/tmp/vagrant-chef-apply-#{counter}"
-          end
+          @upload_path = "/tmp/vagrant-chef-apply" if @upload_path == UNSET_VALUE
         end
 
         def validate(machine)

--- a/plugins/provisioners/chef/provisioner/chef_apply.rb
+++ b/plugins/provisioners/chef/provisioner/chef_apply.rb
@@ -42,7 +42,8 @@ module VagrantPlugins
 
         # The destination (on the guest) where the recipe will live
         # @return [String]
-        def target_recipe_path(key)
+        def target_recipe_path
+          key = Digest::MD5.hexdigest(config.recipe)
           File.join(config.upload_path, "recipe-#{key}.rb")
         end
 
@@ -55,9 +56,7 @@ module VagrantPlugins
           file.rewind
 
           # Upload the tempfile to the guest
-          @machine.communicate.upload(
-            file.path,
-            target_recipe_path(Digest::MD5.hexdigest(config.recipe)))
+          @machine.communicate.upload(file.path, target_recipe_path)
         ensure
           # Delete our template
           file.close

--- a/plugins/provisioners/chef/provisioner/chef_apply.rb
+++ b/plugins/provisioners/chef/provisioner/chef_apply.rb
@@ -1,3 +1,4 @@
+require "digest/md5"
 require "tempfile"
 
 require_relative "base"
@@ -41,8 +42,8 @@ module VagrantPlugins
 
         # The destination (on the guest) where the recipe will live
         # @return [String]
-        def target_recipe_path
-          File.join(config.upload_path, "recipe.rb")
+        def target_recipe_path(key)
+          File.join(config.upload_path, "recipe-#{key}.rb")
         end
 
         # Write the raw recipe contents to a tempfile and upload that to the
@@ -54,7 +55,9 @@ module VagrantPlugins
           file.rewind
 
           # Upload the tempfile to the guest
-          @machine.communicate.upload(file.path, target_recipe_path)
+          @machine.communicate.upload(
+            file.path,
+            target_recipe_path(Digest::MD5.hexdigest(config.recipe)))
         ensure
           # Delete our template
           file.close

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -1,3 +1,7 @@
+require "digest/md5"
+require "securerandom"
+require "set"
+
 require "log4r"
 
 require "vagrant/util/counter"
@@ -11,6 +15,8 @@ module VagrantPlugins
       class ChefSolo < Base
         extend Vagrant::Util::Counter
         include Vagrant::Util::Counter
+        include Vagrant::Action::Builtin::MixinSyncedFolders
+
         attr_reader :environments_folders
         attr_reader :cookbook_folders
         attr_reader :role_folders
@@ -28,10 +34,11 @@ module VagrantPlugins
           @data_bags_folders = expanded_folders(@config.data_bags_path, "data_bags")
           @environments_folders = expanded_folders(@config.environments_path, "environments")
 
-          share_folders(root_config, "csc", @cookbook_folders)
-          share_folders(root_config, "csr", @role_folders)
-          share_folders(root_config, "csdb", @data_bags_folders)
-          share_folders(root_config, "cse", @environments_folders)
+          existing = synced_folders(@machine, cached: true)
+          share_folders(root_config, "csc", @cookbook_folders, existing)
+          share_folders(root_config, "csr", @role_folders, existing)
+          share_folders(root_config, "csdb", @data_bags_folders, existing)
+          share_folders(root_config, "cse", @environments_folders, existing)
         end
 
         def provision(mode = :solo)
@@ -72,8 +79,10 @@ module VagrantPlugins
               local_path = File.expand_path(path, @machine.env.root_path)
 
               if File.exist?(local_path)
-                # Path exists on the host, setup the remote path
-                remote_path = "#{@config.provisioning_path}/chef-solo-#{get_and_update_counter(:cookbooks_path)}"
+                # Path exists on the host, setup the remote path. We use
+                # the MD5 of the local path so that it is predictable.
+                key         = Digest::MD5.hexdigest(local_path)
+                remote_path = "#{@config.provisioning_path}/#{key}"
               else
                 @machine.ui.warn(I18n.t("vagrant.provisioners.chef.cookbook_folder_not_found_warning",
                                        path: local_path.to_s))
@@ -103,16 +112,31 @@ module VagrantPlugins
 
         # Shares the given folders with the given prefix. The folders should
         # be of the structure resulting from the `expanded_folders` function.
-        def share_folders(root_config, prefix, folders)
-          folders.each do |type, local_path, remote_path|
-            if type == :host
-              opts = {}
-              opts[:id] = "v-#{prefix}-#{self.class.get_and_update_counter(:shared_folder)}"
-              opts[:type] = @config.synced_folder_type if @config.synced_folder_type
-
-              root_config.vm.synced_folder(local_path, remote_path, opts)
+        def share_folders(root_config, prefix, folders, existing=nil)
+          existing_set = Set.new
+          (existing || []).each do |_, fs|
+            fs.each do |id, data|
+              existing_set.add(data[:guestpath])
             end
           end
+
+          folders.each do |type, local_path, remote_path|
+            next if type != :host
+
+            # If this folder already exists, then we don't share it, it means
+            # it was already put down on disk.
+            if existing_set.include?(remote_path)
+              @logger.debug("Not sharing #{local_path}, exists as #{remote_path}")
+              next
+            end
+
+            opts = {}
+            opts[:id] = "v-#{prefix}-#{self.class.get_and_update_counter(:shared_folder)}"
+            opts[:type] = @config.synced_folder_type if @config.synced_folder_type
+
+            root_config.vm.synced_folder(local_path, remote_path, opts)
+          end
+
           @shared_folders += folders
         end
 

--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -1,11 +1,7 @@
-require "vagrant/util/counter"
-
 module VagrantPlugins
   module Puppet
     module Config
       class Puppet < Vagrant.plugin("2", :config)
-        extend Vagrant::Util::Counter
-
         attr_accessor :facter
         attr_accessor :hiera_config_path
         attr_accessor :manifest_file
@@ -65,15 +61,8 @@ module VagrantPlugins
           @manifest_file  = "default.pp" if @manifest_file == UNSET_VALUE
           @module_path    = nil if @module_path == UNSET_VALUE
           @synced_folder_type = nil if @synced_folder_type == UNSET_VALUE
-          @temp_dir       = nil if @temp_dir == UNSET_VALUE
+          @temp_dir       = "/tmp/vagrant-puppet" if @temp_dir == UNSET_VALUE
           @working_directory = nil if @working_directory == UNSET_VALUE
-
-          # Set a default temp dir that has an increasing counter so
-          # that multiple Puppet definitions won't overwrite each other
-          if !@temp_dir
-            counter   = self.class.get_and_update_counter(:puppet_config)
-            @temp_dir = "/tmp/vagrant-puppet-#{counter}"
-          end
         end
 
         # Returns the module paths as an array of paths expanded relative to the

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -1,3 +1,5 @@
+require "digest/md5"
+
 require "log4r"
 
 module VagrantPlugins
@@ -22,8 +24,9 @@ module VagrantPlugins
 
           # Setup the module paths
           @module_paths = []
-          @expanded_module_paths.each_with_index do |path, i|
-            @module_paths << [path, File.join(config.temp_dir, "modules-#{i}")]
+          @expanded_module_paths.each_with_index do |path, _|
+            key = Digest::MD5.hexdigest(path)
+            @module_paths << [path, File.join(config.temp_dir, "modules-#{key}")]
           end
 
           folder_opts = {}
@@ -85,7 +88,8 @@ module VagrantPlugins
         def manifests_guest_path
           if config.manifests_path[0] == :host
             # The path is on the host, so point to where it is shared
-            File.join(config.temp_dir, "manifests")
+            key = Digest::MD5.hexdigest(config.manifests_path[1])
+            File.join(config.temp_dir, "manifests-#{key}")
           else
             # The path is on the VM, so just point directly to it
             config.manifests_path[1]

--- a/test/unit/plugins/provisioners/chef/config/base_runner_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/base_runner_test.rb
@@ -123,7 +123,7 @@ describe VagrantPlugins::Chef::Config::BaseRunner do
   describe "#provisioning_path" do
     it "defaults to a tmp_path" do
       subject.finalize!
-      expect(subject.provisioning_path).to match(%r{/tmp/vagrant-chef-\d+})
+      expect(subject.provisioning_path).to eq("/tmp/vagrant-chef")
     end
   end
 

--- a/test/unit/plugins/provisioners/chef/config/chef_apply_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/chef_apply_test.rb
@@ -23,7 +23,7 @@ describe VagrantPlugins::Chef::Config::ChefApply do
   describe "#upload_path" do
     it "defaults to /tmp/vagrant-chef-apply.rb" do
       subject.finalize!
-      expect(subject.upload_path).to match(%r{/tmp/vagrant-chef-apply-\d+})
+      expect(subject.upload_path).to eq("/tmp/vagrant-chef-apply")
     end
   end
 


### PR DESCRIPTION
Fixes #4988 

This changes the Chef provisioner from using counters to using predictable names based on the MD5 of the local path. These are then verified using the synced folder cache. This removes the need for two things causing problems.

1. Counter usage for synced folder paths in the provisioner itself. This was originally necessary to avoid conflicts. We no longer worry about this anymore since use the MD5 of the local path as the name, this avoids conflicts, and if they do conflict, its the same folder so it doesn't matter.

2. Counter usage for the provisioning path. We needed this in case multiple `config.vm.provision` was there since the counters from 1 above were scoped to each provisioner. We no longer need this because 1 is gone and the same logic applies for conflicting folders (it doesn't matter since they're the same).

Once this is in, I'll fix Puppet as well, which is the only other provisioner with this problem I believe.