### PR TITLE
Disable insert_key for boot2docker host

### DIFF
--- a/plugins/providers/docker/hostmachine/Vagrantfile
+++ b/plugins/providers/docker/hostmachine/Vagrantfile
@@ -18,4 +18,9 @@ Vagrant.configure("2") do |config|
 
   # b2d doesn't support NFS
   config.nfs.functional = false
+
+  # b2d doesn't persist filesystem between reboots
+  if config.ssh.respond_to?(:insert_key)
+    config.ssh.insert_key = false
+  end
 end


### PR DESCRIPTION
Vagrant >1.7 is unable to login to the default boot2docker host if it has
been halted and brought back up again.

This is because the insecure SSH keypair is replaced but boot2docker doesn't
persist filesystem changes between reboots. So when next brought up Vagrant
tries to use the new keypair which is no longer valid and subsequently isn't
able to login.

Prevent this from happening by disabling the `ssh.insert_key` option on
versions where it is available.

---

I'm not sure how this will affect users that upgrade from an earlier version to 1.7, because this `Vagrantfile` will have already been copied out to `~/.vagrant.d/data/docker-host` and they won't receive this change. Any ideas?