### PR TITLE
Added possibility to configure memory, cpus count, and vmname in vagrant...

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -14,6 +14,15 @@ module VagrantPlugins
         def call(env)
           vm_dir = env[:machine].box.directory.join("Virtual Machines")
           hd_dir = env[:machine].box.directory.join("Virtual Hard Disks")
+          memory = env[:machine].provider_config.memory
+          maxmemory = env[:machine].provider_config.maxmemory
+          cpus = env[:machine].provider_config.cpus
+          vmname = env[:machine].provider_config.vmname
+
+          env[:ui].output("Configured Dynamical memory allocation, maxmemory is #{maxmemory}") if maxmemory
+          env[:ui].output("Configured startup memory is #{memory}") if memory
+          env[:ui].output("Configured cpus number is #{cpus}") if cpus
+          env[:ui].output("Configured vmname is #{vmname}") if vmname
 
           if !vm_dir.directory? || !hd_dir.directory?
             raise Errors::BoxInvalid
@@ -78,6 +87,10 @@ module VagrantPlugins
             image_path:      image_path.to_s.gsub("/", "\\")
           }
           options[:switchname] = switch if switch
+          options[:memory] = memory if memory 
+          options[:maxmemory] = maxmemory if maxmemory
+          options[:cpus] = cpus if cpus
+          options[:vmname] = vmname if vmname 
 
           env[:ui].detail("Creating and registering the VM...")
           server = env[:machine].provider.driver.import(options)

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -8,15 +8,27 @@ module VagrantPlugins
       #
       # @return [Integer]
       attr_accessor :ip_address_timeout
+      attr_accessor :memory
+      attr_accessor :maxmemory
+      attr_accessor :cpus
+      attr_accessor :vmname
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
+        @memory = UNSET_VALUE
+        @maxmemory = UNSET_VALUE
+        @cpus = UNSET_VALUE
+        @vmname = UNSET_VALUE
       end
 
       def finalize!
         if @ip_address_timeout == UNSET_VALUE
           @ip_address_timeout = 120
         end
+        @memory = nil if @memory == UNSET_VALUE
+        @maxmemory = nil if @maxmemory == UNSET_VALUE
+        @cpus = nil if @cpus == UNSET_VALUE 
+        @vmname = nil if @vmname == UNSET_VALUE
       end
 
       def validate(machine)

--- a/test/unit/plugins/providers/hyperv/config_test.rb
+++ b/test/unit/plugins/providers/hyperv/config_test.rb
@@ -9,10 +9,37 @@ describe VagrantPlugins::HyperV::Config do
       subject.finalize!
       expect(subject.ip_address_timeout).to eq(180)
     end
-
     it "defaults to a number" do
       subject.finalize!
       expect(subject.ip_address_timeout).to eq(120)
+    end
+  end
+  describe "#vmname" do
+    it "can be set" do
+      subject.vmname = "test"
+      subject.finalize!
+      expect(subject.vmname).to eq("test")
+    end
+  end
+  describe "#memory" do
+    it "can be set" do
+      subject.memory = 512
+      subject.finalize!
+      expect(subject.memory).to eq(512)
+    end
+  end
+  describe "#maxmemory" do
+    it "can be set" do
+      subject.maxmemory = 1024
+      subject.finalize!
+      expect(subject.maxmemory).to eq(1024)
+    end
+  end
+  describe "#cpus" do
+    it "can be set" do
+      subject.cpus = 2
+      subject.finalize!
+      expect(subject.cpus).to eq(2)
     end
   end
 end

--- a/website/docs/source/v2/hyperv/configuration.html.md
+++ b/website/docs/source/v2/hyperv/configuration.html.md
@@ -8,6 +8,15 @@ sidebar_current: "hyperv-configuration"
 The Hyper-V provider has some provider-specific configuration options
 you may set. A complete reference is shown below:
 
+  * `vmname` (string) - Name of virtual mashine as shown in Hyper-V manager.
+    Defaults is taken from box image XML.
+  * `cpus` (integer) - Number of virtual CPU given to mashine.
+    Defaults is taken from box image XML.
+  * `memory` (integer) - Number of MegaBytes allocated to VM at startup.
+    Defaults is taken from box image XML.
+  * `maxmemory` (integer) - Number of MegaBytes maximal allowed to allocate for VM
+  	This parameter is switch on Dynamic Allocation of memory.
+  	Defaults is taken from box image XML.
   * `ip_address_timeout` (integer) - The time in seconds to wait for the
     virtual machine to report an IP address. This defaults to 120 seconds.
     This may have to be increased if your VM takes longer to boot.


### PR DESCRIPTION
I think it is long-awaited feature for Hyper-V plugin.
This PR gives possibility to manipulate following parameters in Vagrant file for config.vm.provider :hyperv
1. memory: type allocation and size 
2. numbers of CPU
3. Virtual machine name (it is not hostname but visible in hyper-v manager name)
More details in documentation

regards, Volodymyr