### PR TITLE
select a Hyper-V switch based on a network_name

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -55,23 +55,39 @@ module VagrantPlugins
           switches = env[:machine].provider.driver.execute("get_switches.ps1", {})
           raise Errors::NoSwitches if switches.empty?
 
-          switch = switches[0]["Name"]
-          if switches.length > 1
-            env[:ui].detail(I18n.t("vagrant_hyperv.choose_switch") + "\n ")
-            switches.each_index do |i|
-              switch = switches[i]
-              env[:ui].detail("#{i+1}) #{switch["Name"]}")
-            end
-            env[:ui].detail(" ")
+          switch = nil
+          env[:machine].config.vm.networks.each do |type, opts|
+            next if type != :public_network && type != :private_network
 
-            switch = nil
-            while !switch
-              switch = env[:ui].ask("What switch would you like to use? ")
-              next if !switch
-              switch = switch.to_i - 1
-              switch = nil if switch < 0 || switch >= switches.length
+            switchToFind = opts[:network_name]
+
+            if switchToFind
+              puts "Looking for switch with name: #{switchToFind}"
+              switch = switches.find { |s| s["Name"].downcase == switchToFind.downcase }["Name"]
+              puts "Found switch: #{switch}"
             end
-            switch = switches[switch]["Name"]
+          end
+
+          if switch.nil?
+            if switches.length > 1
+              env[:ui].detail(I18n.t("vagrant_hyperv.choose_switch") + "\n ")
+              switches.each_index do |i|
+                switch = switches[i]
+                env[:ui].detail("#{i+1}) #{switch["Name"]}")
+              end
+              env[:ui].detail(" ")
+
+              switch = nil
+              while !switch
+                switch = env[:ui].ask("What switch would you like to use? ")
+                next if !switch
+                switch = switch.to_i - 1
+                switch = nil if switch < 0 || switch >= switches.length
+              end
+              switch = switches[switch]["Name"]
+            else
+              switch = switches[0]["Name"]
+            end
           end
 
           env[:ui].detail("Cloning virtual hard drive...")

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
           env[:machine].config.vm.networks.each do |type, opts|
             next if type != :public_network && type != :private_network
 
-            switchToFind = opts[:network_name]
+            switchToFind = opts[:bridge]
 
             if switchToFind
               puts "Looking for switch with name: #{switchToFind}"


### PR DESCRIPTION
Currently if one has more than one Hyper-V switch, vagrant will require user intervention to select the switch to use when importing a machine. This is always slightly annoying and problematic when using applications such as Test-Kitchen that do not allow interactive setup of a vagrant box.

This PR allows a Vagrantfile to include a public or private network with a network name. If a switch exists with the same name, it is the one that will be chosen:

```
config.vm.network "public_network", bridge: 'External Virtual Switch'
```

Considering one has multiple switches and one is named after the `bridge`, that switch will be chosen. If no network name is specified, the the current behavior takes over and prompts the user.

This is a modified steal from @Taliesin's PR #3480 that was previously closed (due to too broad of scope from what I can tell).