### PR TITLE
Switch to docker.com

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -14,8 +14,8 @@ module VagrantPlugins
               end
               comm.sudo("apt-get update -y")
               comm.sudo("apt-get install -y --force-yes -q curl")
-              comm.sudo("curl -sSL https://get.docker.io/gpg | apt-key add -")
-              comm.sudo("echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list")
+              comm.sudo("curl -sSL https://get.docker.com/gpg | apt-key add -")
+              comm.sudo("echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list")
               comm.sudo("apt-get update")
               comm.sudo("echo lxc lxc/directory string /var/lib/lxc | debconf-set-selections")
               comm.sudo("apt-get install -y --force-yes -q xz-utils #{package} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'")


### PR DESCRIPTION
docker.io seems to be deprecated & handled differently from docker.com; see https://twitter.com/clint_newsom/status/557290529810313217

Anecdotally, the docker.com URLs worked while the docker.io URLs were failing, so I have more long-term confidence in them