### PR TITLE
Don't use cache for synced folders in ChefSolo

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
           @data_bags_folders = expanded_folders(@config.data_bags_path, "data_bags")
           @environments_folders = expanded_folders(@config.environments_path, "environments")
 
-          existing = synced_folders(@machine, cached: true)
+          existing = synced_folders(@machine, cached: false)
           share_folders(root_config, "csc", @cookbook_folders, existing)
           share_folders(root_config, "csr", @role_folders, existing)
           share_folders(root_config, "csdb", @data_bags_folders, existing)

--- a/test/unit/plugins/provisioners/chef/provisioner/chef_solo_test.rb
+++ b/test/unit/plugins/provisioners/chef/provisioner/chef_solo_test.rb
@@ -1,0 +1,79 @@
+require_relative "../../../../base"
+
+require Vagrant.source_root.join("lib/vagrant/action/builtin/mixin_synced_folders")
+require Vagrant.source_root.join("plugins/provisioners/chef/provisioner/chef_solo")
+
+describe VagrantPlugins::Chef::Provisioner::ChefSolo do
+  include_context "unit"
+
+  let(:machine) { double("machine") }
+  let(:config)  { double("config") }
+  let(:vm)      { double("vm") }
+
+  subject { described_class.new(machine, config) }
+
+  before(:each) do
+    allow(config).to receive(:vm).and_return(vm)
+
+    allow(subject.class).to receive(:get_and_update_counter).and_return(1, 2, 3, 4)
+
+    allow(subject).to receive(:expanded_folders).and_return(
+                          [[:host, '/tmp/chef/cookbooks', '/tmp/vagrant-chef-1/cookbooks']],
+                          [[:host, '/tmp/chef/roles', '/tmp/vagrant-chef-1/roles']],
+                          [[:host, '/tmp/chef/data_bags', '/tmp/vagrant-chef-1/data_bags']],
+                          [[:host, '/tmp/chef/environments', '/tmp/vagrant-chef-1/environments']]
+                        )
+
+    allow(config).to receive(:cookbooks_path).and_return('/tmp/chef/cookbooks')
+    allow(config).to receive(:roles_path).and_return('/tmp/chef/roles')
+    allow(config).to receive(:data_bags_path).and_return('/tmp/chef/data_bags')
+    allow(config).to receive(:environments_path).and_return('/tmp/chef/environments')
+    allow(config).to receive(:synced_folder_type).and_return('nfs')
+  end
+
+  describe "#share_folders" do
+    it "adds shared_folders" do
+      expect(subject).to receive(:synced_folders).and_return([])
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/cookbooks', '/tmp/vagrant-chef-1/cookbooks', {id: 'v-csc-1', type: 'nfs'})
+                      .and_return(true)
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/roles', '/tmp/vagrant-chef-1/roles', {id: 'v-csr-2', type: 'nfs'})
+                      .and_return(true)
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/data_bags', '/tmp/vagrant-chef-1/data_bags', {id: 'v-csdb-3', type: 'nfs'})
+                      .and_return(true)
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/environments', '/tmp/vagrant-chef-1/environments', {id: 'v-cse-4', type: 'nfs'})
+                      .and_return(true)
+
+      subject.configure(config)
+    end
+
+    it "doesn't add duplicate shared_folders" do
+      expect(subject).to receive(:synced_folders)
+                          .and_return({"nfs" =>  { "/tmp/chef/cookbooks" => {guestpath: '/tmp/vagrant-chef-1/cookbooks'}}})
+
+      expect(vm).to_not receive(:synced_folder)
+                      .with('/tmp/chef/cookbooks', '/tmp/vagrant-chef-1/cookbooks', {id: 'v-csc-1', type: 'nfs'})
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/roles', '/tmp/vagrant-chef-1/roles', {id: 'v-csr-1', type: 'nfs'})
+                      .and_return(true)
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/data_bags', '/tmp/vagrant-chef-1/data_bags', {id: 'v-csdb-2', type: 'nfs'})
+                      .and_return(true)
+
+      expect(vm).to receive(:synced_folder)
+                      .with('/tmp/chef/environments', '/tmp/vagrant-chef-1/environments', {id: 'v-cse-3', type: 'nfs'})
+                      .and_return(true)
+
+      subject.configure(config)
+    end
+  end
+end


### PR DESCRIPTION
This disables using the synced_folders cache for ChefSolo. I've also added tests for the ChefSolo provisioner in regards to the conflicts and confirming the counter updates correctly.

This should close #5199, #5200, and #5140.

@mitchellh @sethvargo 