### PR TITLE
Check plugin name with version spec in has_plugin

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -156,7 +156,7 @@ module Vagrant
     Plugin::Manager.instance.installed_specs.any? do |s|
       match = s.name == name
       next match if !version
-      next version.satisfied_by?(s.version)
+      next match && version.satisfied_by?(s.version)
     end
   end
 

--- a/test/unit/vagrant_test.rb
+++ b/test/unit/vagrant_test.rb
@@ -75,7 +75,7 @@ describe Vagrant do
       expect(described_class.has_plugin?("bar")).to be_false
     end
 
-    it "finds plugins by gem version" do
+    it "finds plugins by gem name and version" do
       specs = [Gem::Specification.new]
       specs[0].name = "foo"
       specs[0].version = "1.2.3"
@@ -83,6 +83,7 @@ describe Vagrant do
 
       expect(described_class.has_plugin?("foo", "~> 1.2.0")).to be_true
       expect(described_class.has_plugin?("foo", "~> 1.0.0")).to be_false
+      expect(described_class.has_plugin?("bar", "~> 1.2.0")).to be_false
     end
   end
 


### PR DESCRIPTION
If one passes a version spec to `Vagrant.has_plugin?`, the actual plugin name is ignored and any installed plugin which matches the version spec makes the check pass. Fix this by also checking for plugin name match in addition to the requested version spec.