### PR TITLE
fix checksum verification for downloaded boxes (fixes #4665)

### DIFF
--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -64,6 +64,8 @@ module Vagrant
           box_download_ca_path = machine.config.vm.box_download_ca_path
           box_download_client_cert = machine.config.vm.box_download_client_cert
           box_download_insecure = machine.config.vm.box_download_insecure
+          box_download_checksum_type = machine.config.vm.box_download_checksum_type
+          box_download_checksum = machine.config.vm.box_download_checksum
           box_formats = machine.provider_options[:box_format] ||
             machine.provider_name
 
@@ -86,6 +88,8 @@ module Vagrant
               box_download_ca_cert: box_download_ca_cert,
               box_download_ca_path: box_download_ca_path,
               box_download_insecure: box_download_insecure,
+              box_checksum_type: box_download_checksum_type,
+              box_checksum: box_download_checksum,
             }))
           rescue Errors::BoxAlreadyExists
             # Just ignore this, since it means the next part will succeed!

--- a/test/unit/vagrant/action/builtin/handle_box_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_box_test.rb
@@ -106,4 +106,31 @@ describe Vagrant::Action::Builtin::HandleBox do
       subject.call(env)
     end
   end
+
+  context "with a box with a checksum set" do
+    before do
+      machine.stub(box: nil)
+
+      machine.config.vm.box = "foo"
+      machine.config.vm.box_url = "bar"
+      machine.config.vm.box_download_checksum_type = "sha256"
+      machine.config.vm.box_download_checksum = "1f42ac2decf0169c4af02b2d8c77143ce35f7ba87d5d844e19bf7cbb34fbe74e"
+    end
+
+    it "adds a box that doesn't exist and maps checksum options correctly" do
+      expect(action_runner).to receive(:run).with { |action, opts|
+        expect(opts[:box_name]).to eq(machine.config.vm.box)
+        expect(opts[:box_url]).to eq(machine.config.vm.box_url)
+        expect(opts[:box_provider]).to eq(:dummy)
+        expect(opts[:box_version]).to eq(machine.config.vm.box_version)
+        expect(opts[:box_checksum_type]).to eq(machine.config.vm.box_download_checksum_type)
+        expect(opts[:box_checksum]).to eq(machine.config.vm.box_download_checksum)
+        true
+      }
+
+      expect(app).to receive(:call).with(env)
+
+      subject.call(env)
+    end
+  end
 end


### PR DESCRIPTION
This fixes https://github.com/mitchellh/vagrant/issues/4665 which I ran into today.
I had added the wrong shasum to my Vagrantfile but the box still got downloaded and imported, so I decided to take a stab at fixing it.

Manually adding the box from the command line with
```
vagrant box add --name randombox --checksum-type sha256 --checksum <sha256_of_box>
```
validates the checksum just fine so I used plugins/commands/box/command/add.rb as model.

It turned out that lib/vagrant/action/builtin/handle_box.rb wasn't passing either of box_checksum and box_checksum_type to Vagrant::Action.action_box_add.