### PR TITLE
Allow colon in NFS ID regex

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -137,7 +137,7 @@ module VagrantPlugins
           user = Process.uid
 
           File.read("/etc/exports").lines.each do |line|
-            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9\-_]+?)$/, 2]
+            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9\-_:]+?)$/, 2]
               if valid_ids.include?(id)
                 logger.debug("Valid ID: #{id}")
               else

--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -71,7 +71,7 @@ module VagrantPlugins
           user = Process.uid
 
           File.read("/etc/exports").lines.each do |line|
-            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9\-_]+?)$/, 2]
+            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9\-_:]+?)$/, 2]
               if valid_ids.include?(id)
                 logger.debug("Valid ID: #{id}")
               else


### PR DESCRIPTION
In developing a Vagrant plugin for XenServer[1], the unique identifier that the API uses for VMs contains a colon. They are of the form:

    OpaqueRef:1530c1b3-2cd8-9561-5dc8-7aaa160fb641

It seems the other plugins use their platform's unique identifier for the machine ID and so do we.

The issue is that this machine ID is used by the SyncedFolders built-in plugin to create an entry in `/etc/exports`. This functions correctly, however the SyncedFoldersCleanup plugin doesn't clean them up because the regex in `prune_nfs` doesn't allow for colons in the line.

An alternative would be to allow any string after the "VAGRANT-BEGIN <uid>" since there are no limitations on what can be put into the machine's ID.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>