### PR TITLE
providers/virtualbox: read netmask from dhcpservers

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -265,6 +265,8 @@ module VagrantPlugins
                 info[:network_name] = "HostInterfaceNetworking-#{network}"
               elsif ip = line[/^IP:\s+(.+?)$/, 1]
                 info[:ip] = ip
+              elsif netmask = line[/^NetworkMask:\s+(.+?)$/, 1]
+                info[:netmask] = netmask
               elsif lower = line[/^lowerIPAddress:\s+(.+?)$/, 1]
                 info[:lower] = lower
               elsif upper = line[/^upperIPAddress:\s+(.+?)$/, 1]

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -270,6 +270,8 @@ module VagrantPlugins
                 info[:network_name] = "HostInterfaceNetworking-#{network}"
               elsif ip = line[/^IP:\s+(.+?)$/, 1]
                 info[:ip] = ip
+              elsif netmask = line[/^NetworkMask:\s+(.+?)$/, 1]
+                info[:netmask] = netmask
               elsif lower = line[/^lowerIPAddress:\s+(.+?)$/, 1]
                 info[:lower] = lower
               elsif upper = line[/^upperIPAddress:\s+(.+?)$/, 1]

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -293,6 +293,8 @@ module VagrantPlugins
                 info[:network_name] = "HostInterfaceNetworking-#{network}"
               elsif ip = line[/^IP:\s+(.+?)$/, 1]
                 info[:ip] = ip
+              elsif netmask = line[/^NetworkMask:\s+(.+?)$/, 1]
+                info[:netmask] = netmask
               elsif lower = line[/^lowerIPAddress:\s+(.+?)$/, 1]
                 info[:lower] = lower
               elsif upper = line[/^upperIPAddress:\s+(.+?)$/, 1]

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -302,6 +302,8 @@ module VagrantPlugins
                 info[:network_name] = "HostInterfaceNetworking-#{network}"
               elsif ip = line[/^IP:\s+(.+?)$/, 1]
                 info[:ip] = ip
+              elsif netmask = line[/^NetworkMask:\s+(.+?)$/, 1]
+                info[:netmask] = netmask
               elsif lower = line[/^lowerIPAddress:\s+(.+?)$/, 1]
                 info[:lower] = lower
               elsif upper = line[/^upperIPAddress:\s+(.+?)$/, 1]

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_4_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_4_x_examples.rb
@@ -37,6 +37,7 @@ shared_examples "a version 4.x virtualbox driver" do |options|
           network_name: 'HostInterfaceNetworking-vboxnet0',
           network:      'vboxnet0',
           ip:           '172.28.128.2',
+          netmask:      '255.255.255.0',
           lower:        '172.28.128.3',
           upper:        '172.28.128.254',
         }])
@@ -65,8 +66,8 @@ shared_examples "a version 4.x virtualbox driver" do |options|
 
       it "returns a list with one entry for each server" do
         expect(subject.read_dhcp_servers).to eq([
-          {network_name: 'HostInterfaceNetworking-vboxnet0', network: 'vboxnet0', ip: '172.28.128.2', lower: '172.28.128.3', upper: '172.28.128.254'},
-          {network_name: 'HostInterfaceNetworking-vboxnet1', network: 'vboxnet1', ip: '10.0.0.2', lower: '10.0.0.3', upper: '10.0.0.254'},
+          {network_name: 'HostInterfaceNetworking-vboxnet0', network: 'vboxnet0', ip: '172.28.128.2', netmask: '255.255.255.0', lower: '172.28.128.3', upper: '172.28.128.254'},
+          {network_name: 'HostInterfaceNetworking-vboxnet1', network: 'vboxnet1', ip: '10.0.0.2', netmask: '255.255.255.0', lower: '10.0.0.3', upper: '10.0.0.254'},
         ])
       end
     end


### PR DESCRIPTION
This should fix the cleaning up of the default VirtualBox dhcpserver,
which we've been fighting with for ages over in #3083. We were checking
for a structure _including_ a netmask, but the driver was not populating
netmask.