### PR TITLE
core: log action name to info

### DIFF
--- a/lib/vagrant/action/runner.rb
+++ b/lib/vagrant/action/runner.rb
@@ -62,7 +62,7 @@ module Vagrant
         end
 
         # We place a process lock around every action that is called
-        @logger.info("Running action: #{callable_id}")
+        @logger.info("Running action: #{environment[:action_name]} #{callable_id}")
         Util::Busy.busy(int_callback) { callable.call(environment) }
 
         # Return the environment in case there are things in there that


### PR DESCRIPTION
I found this output to be very helpful in debugging an action hook
problem in a plugin.  problem. I'm not sure why the callable_id is
useful (seem to always show up as an instance of `Builder` or `Warden`
for me), but I left it in there just in case it's useful to someone.