### PR TITLE
Kindly document how to disable checkpoint remote call.

### DIFF
--- a/website/docs/source/v2/other/environmental-variables.html.md
+++ b/website/docs/source/v2/other/environmental-variables.html.md
@@ -9,6 +9,14 @@ Vagrant has a set of environmental variables that can be used to
 configure and control it in a global way. This page lists those environmental
 variables.
 
+## VAGRANT\_CHECKPOINT\_DISABLE 
+
+Vagrant does occasional network calls to check whether the version of Vagrant
+that is running locally is up to date. We understand that software making remote
+calls over the internet for any reason can be undesirable. To surpress these
+calls, set the environment variable `VAGRANT_CHECKPOINT_DISABLE` to any
+non-empty value.
+
 ## VAGRANT\_CWD
 
 `VAGRANT_CWD` can be set to change the working directory of Vagrant. By


### PR DESCRIPTION
The hashicorp checkpoint gem's [current documentation](http://www.rubydoc.info/gems/hashicorp-checkpoint/0.1.4) has this to say:

> We understand that software making remote calls over the internet for any reason can be undesirable. Because of this, Checkpoint can be disabled in all of our software that includes it. You can view the source of this client to see that we're not sending any private information.

Instructions how to do the disabling have been omitted from the Vagrant documentation. This pull request contains a (very minimal) fix for that omission.

Thank you for providing fine software!