### PR TITLE
NFS filesync: Prevent sed from creating tmp files

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -1,4 +1,5 @@
 require "log4r"
+require "open3"
 
 require "vagrant/util"
 require "vagrant/util/shell_quote"
@@ -177,13 +178,16 @@ module VagrantPlugins
             "sed", "-E", "-e",
             "/^# VAGRANT-BEGIN:( #{user})? #{id}/," +
             "/^# VAGRANT-END:( #{user})? #{id}/ d",
-            "-ibak",
             "/etc/exports"
           ]
 
           # Use sed to just strip out the block of code which was inserted
           # by Vagrant, and restart NFS.
-          system(*command)
+          stdin, stdout, stderr = Open3.popen3(*command)
+
+          f = File.new("/etc/exports", "w")
+          f.write(stdout.gets)
+          f.close
         end
 
         def self.nfs_checkexports!


### PR DESCRIPTION
Even if one tries hard to prevent vagrant from asking for password while using the NFS file sync and does following:

```
sudo chown root:admin /etc/exports
sudo chmod g+w /etc/exports

echo "%admin ALL=(root) NOPASSWD: /sbin/nfsd" >> /etc/sudoers
```

then there is still this `sed` which tries to create temp files in `/etc` and as that requires su perms and no sudo is provided, it ends up in following errors:

```
sed: couldn't open temporary file /etc/sedKEZcGM: Permission denied
```

and from security point of view I don't see a reason to allow write for all admins on that system just because `sed` wants to put temp files there.

If you think that using `open3` or generally the approach taken is not the best solution here, I'm really open for suggestions and happy to modify the PR.