### PR TITLE
Make the environment variable documentation more easy to find.

### DIFF
--- a/website/docs/source/v2/cli/index.html.md
+++ b/website/docs/source/v2/cli/index.html.md
@@ -22,3 +22,8 @@ accepts.
 In depth documentation and use cases of various Vagrant commands is
 available by reading the appropriate sub-section available in the left
 navigational area of this site.
+
+You may also wish to consult the
+[documentation](/v2/other/environmental-variables.html) regarding the
+environmental variables that can be used to configure and control
+Vagrant in a global way.


### PR DESCRIPTION
I was looking for the environment variable definition at the place where the cli is documented. Didn't find it. For the next guy who ticks like I do, let's put a link there.