### PR TITLE
Fix bug of path conversion on windows with cygwin.

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -111,6 +111,10 @@ module Vagrant
         # This expands the path and ensures proper casing of each part
         # of the path.
         def fs_real_path(path, **opts)
+          # This line fixes bug on windows, when using MobaXterm/cygwin.
+          # path uses short filename but Dir.entries(path) uses long filename.
+          return path if cygwin?
+
           path = Pathname.new(File.expand_path(path))
 
           if path.exist? && !fs_case_sensitive?


### PR DESCRIPTION
On Windows, using MobaXterm, vagrant cannot create share folder correctly. The host folder is always %USERPROFILE% instead of current folder.

The `path` param passed to `fs_real_path` looks like `C:/Users/me/DOCUME~1/MOBAXT~1/home/my-project`. Dir.entries(path) will list folders with long filename like `Documents and Settings`, which does not match `DOCUME~1`.