### PR TITLE
detect fedora 21

### DIFF
--- a/plugins/guests/fedora/guest.rb
+++ b/plugins/guests/fedora/guest.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module GuestFedora
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("grep 'Fedora release [12][67890]' /etc/redhat-release")
+        machine.communicate.test("grep 'Fedora release [12][678901]' /etc/redhat-release")
       end
     end
   end


### PR DESCRIPTION
Last week I noticed that there was some issues regarding the dynamic network cards using Fedora 21 and yesterday I finally tracked down the issue. The grepping didn't support Fedora 21 so I added a trailing 1 to the regexp.