### PR TITLE
linux/cap/halt: don't wait for `shutdown -h now` to finish

### DIFF
--- a/plugins/guests/linux/cap/halt.rb
+++ b/plugins/guests/linux/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("shutdown -h now")
+            machine.communicate.sudo("shutdown -h now &")
           rescue IOError
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.


### PR DESCRIPTION
When running a Debian 8 lxc guest (with the vagrant-lxc plugin), which has systemd as init system, `vagrant halt` will hang waiting for `shutdown -h now` to return.

Debug output (`vagrant halt --debug`) looks like this:

```
DEBUG ssh: Exit status: 0
 INFO guest: Detected: debian!
DEBUG guest: Searching for cap: halt
DEBUG guest: Checking in: debian
DEBUG guest: Checking in: linux
DEBUG guest: Found cap: halt in linux
 INFO guest: Execute capability: halt [#<Vagrant::Machine: default (Vagrant::LXC::Provider)>] (debian)
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: shutdown -h now (sudo=true)
DEBUG ssh: stderr: stdin: is not a tty

DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: Sending SSH keep-alive...
DEBUG ssh: Sending SSH keep-alive...
```

And then those `DEBUG ssh: Sending SSH keep-alive...` lines will keep coming until I finish vagrant with ctrl-c.

I have tested with systemd in a virtualbox guest, and with sysvinit (Debian 7) in a vagrant-lxc guest, and with those combinations this is not an issue. I suspect that the  only occurs with systemd under lxc because everything is running under the same kernel and the shutdown provided by systemd is substantially different from the one provided by sysvinit, but I don't know exactly why.

In any way, after sending the halt vagrant will keep checking for the state of the machine, so not waiting for the shutdown command to actually finish does not make much of difference.