### PR TITLE
Windows rsync needs to create folders before syncing

### DIFF
--- a/plugins/guests/windows/cap/rsync.rb
+++ b/plugins/guests/windows/cap/rsync.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module GuestWindows
+    module Cap
+      class RSync
+        def self.rsync_pre(machine, opts)
+          machine.communicate.tap do |comm|
+            comm.execute("mkdir '#{opts[:guestpath]}'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/windows/plugin.rb
+++ b/plugins/guests/windows/plugin.rb
@@ -64,6 +64,11 @@ module VagrantPlugins
         Cap::MountSharedFolder
       end
 
+      guest_capability(:windows, :rsync_pre) do
+        require_relative "cap/rsync"
+        Cap::RSync
+      end
+
       protected
 
       def self.init!

--- a/test/unit/plugins/guests/windows/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/windows/cap/rsync_test.rb
@@ -1,0 +1,26 @@
+require File.expand_path("../../../../../base", __FILE__)
+
+require Vagrant.source_root.join("plugins/guests/windows/cap/rsync")
+
+describe "VagrantPlugins::GuestWindows::Cap::RSync" do
+  let(:described_class) do
+    VagrantPlugins::GuestWindows::Plugin.components.guest_capabilities[:windows].get(:rsync_pre)
+  end
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  after do
+    communicator.verify_expectations!
+  end
+
+  describe ".rsync_pre" do
+    it 'makes the guestpath directory with mkdir' do
+      communicator.expect_command("mkdir '/sync_dir'")
+      described_class.rsync_pre(machine, guestpath: '/sync_dir')
+    end
+  end
+end


### PR DESCRIPTION
Some of the other guests have a folder structure pre-creation on an rsync command, so I thought Windows could benefit from one as well, especially those of us using Windows guests on AWS. This will fix #5255 (without the need for the work-around).