### PR TITLE
Copy linux support for insert_public_key and remove_public_key to solari...

### DIFF
--- a/plugins/guests/solaris11/cap/insert_public_key.rb
+++ b/plugins/guests/solaris11/cap/insert_public_key.rb
@@ -1,0 +1,21 @@
+require "vagrant/util/shell_quote"
+
+module VagrantPlugins
+  module GuestSolaris11
+    module Cap
+      class InsertPublicKey
+        def self.insert_public_key(machine, contents)
+          contents = contents.chomp
+          contents = Vagrant::Util::ShellQuote.escape(contents, "'")
+
+          machine.communicate.tap do |comm|
+            comm.execute("mkdir -p ~/.ssh")
+            comm.execute("chmod 0700 ~/.ssh")
+            comm.execute("printf '#{contents}\\n' >> ~/.ssh/authorized_keys")
+            comm.execute("chmod 0600 ~/.ssh/authorized_keys")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/solaris11/cap/remove_public_key.rb
+++ b/plugins/guests/solaris11/cap/remove_public_key.rb
@@ -1,0 +1,21 @@
+require "vagrant/util/shell_quote"
+
+module VagrantPlugins
+  module GuestSolaris11
+    module Cap
+      class RemovePublicKey
+        def self.remove_public_key(machine, contents)
+          contents = contents.chomp
+          contents = Vagrant::Util::ShellQuote.escape(contents, "'")
+
+          machine.communicate.tap do |comm|
+            if comm.test("test -f ~/.ssh/authorized_keys")
+              comm.execute(
+                "sed -i '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/solaris11/plugin.rb
+++ b/plugins/guests/solaris11/plugin.rb
@@ -49,6 +49,16 @@ module VagrantPlugins
         require_relative "cap/rsync"
         Cap::RSync
       end
+
+      guest_capability("solaris11", "insert_public_key") do
+        require_relative "cap/insert_public_key"
+        Cap::InsertPublicKey
+      end
+
+      guest_capability("solaris11", "remove_public_key") do
+        require_relative "cap/remove_public_key"
+        Cap::RemovePublicKey
+      end
     end
   end
 end


### PR DESCRIPTION
This addresses issue #4969, for Solaris 11 requiring 'config.ssh.insert_key = false'.  It just copies the appropriate code over from the linux plugin.  I don't have a Solaris 10 image to test against, so I did not make the change there.  It passes the unit tests and the provider/virtualbox/basic acceptance test.