### PR TITLE
Add Scientific Linux to RHEL 7 flavors.

### DIFF
--- a/plugins/guests/redhat/cap/flavor.rb
+++ b/plugins/guests/redhat/cap/flavor.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
           output.chomp!
 
           # Detect various flavors we care about
-          if output =~ /(CentOS|Red Hat Enterprise) Linux( .+)? release 7/i
+          if output =~ /(CentOS|Red Hat Enterprise|Scientific) Linux( .+)? release 7/i
             return :rhel_7
           else
             return :rhel


### PR DESCRIPTION
Extends code committed for #4195 (EL7 Dynamic network cards fix) to include "Scientific Linux release 7.0 (Nitrogen)" in the list of RHEL 7 flavors.