### PR TITLE
Support Regexp usage for bridge configuration

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -157,8 +157,10 @@ module VagrantPlugins
             @logger.debug("Bridge was directly specified in config, searching for: #{config[:bridge]}")
 
             # Search for a matching bridged interface
+            bridge = config[:bridge]
+            bridge = bridge.downcase if bridge.respond_to?(:downcase)
             bridgedifs.each do |interface|
-              if interface[:name].downcase == config[:bridge].downcase
+              if bridge === interface[:name].downcase
                 @logger.debug("Specific bridge found as configured in the Vagrantfile. Using it.")
                 chosen_bridge = interface[:name]
                 break


### PR DESCRIPTION
Most of the time when using a bridged interface we want to connect to the first available interface. Depending on various conditions, hardcoding the exact interface name can be troublesome and difficult to share.

Changing the config a bit permits the usage of a Regexp (or anything that respond to === actually) which helps avoiding to type "1" each time we launch a VM.

I've kept the old "downcase" behaviour so it shouldn't break anything.