### PR TITLE
vagrant duplicates >= eth2 when defining two private network ips

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
             # First, remove any previous network modifications
             # from the interface file.
             comm.sudo("sed -e '/^#VAGRANT-BEGIN/,$ d' /etc/network/interfaces > /tmp/vagrant-network-interfaces.pre")
-            comm.sudo("sed -ne '/^#VAGRANT-END/,$ p' /etc/network/interfaces | tail -n +2 > /tmp/vagrant-network-interfaces.post")
+            comm.sudo("sed -ne '/^#VAGRANT-END/,$ p' /etc/network/interfaces | tac | sed -e '/^#VAGRANT-END/,$ d' | tac > /tmp/vagrant-network-interfaces.post")
 
             # Accumulate the configurations to add to the interfaces file as
             # well as what interfaces we're actually configuring since we use that


### PR DESCRIPTION
When a vagrant box has two private network ips /etc/network/interfaces
will duplicate eth2 and bigger. sed matches greedy, so the first
 #VAGRANT-END matches. This will result in:

/etc/network/interfaces:29: interface eth2 declared allow-auto twice
/sbin/ifup: couldn't read interfaces file "/etc/network/interfaces"

Tac print files in reverse and will match the first vagrant-end and only print what is under the last vagrant-end. Tac is in coreutils and is installed with a debootstrap wheezy, so i am assuming that nobody will have an issue on Debian.