### PR TITLE
Support insert_public_key and remove_public_key on darwin guest

### DIFF
--- a/plugins/guests/darwin/cap/insert_public_key.rb
+++ b/plugins/guests/darwin/cap/insert_public_key.rb
@@ -1,0 +1,21 @@
+require "vagrant/util/shell_quote"
+
+module VagrantPlugins
+  module GuestDarwin
+    module Cap
+      class InsertPublicKey
+        def self.insert_public_key(machine, contents)
+          contents = contents.chomp
+          contents = Vagrant::Util::ShellQuote.escape(contents, "'")
+
+          machine.communicate.tap do |comm|
+            comm.execute("mkdir -p ~/.ssh")
+            comm.execute("chmod 0700 ~/.ssh")
+            comm.execute("printf '#{contents}\\n' >> ~/.ssh/authorized_keys")
+            comm.execute("chmod 0600 ~/.ssh/authorized_keys")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/darwin/cap/remove_public_key.rb
+++ b/plugins/guests/darwin/cap/remove_public_key.rb
@@ -1,0 +1,21 @@
+require "vagrant/util/shell_quote"
+
+module VagrantPlugins
+  module GuestDarwin
+    module Cap
+      class RemovePublicKey
+        def self.remove_public_key(machine, contents)
+          contents = contents.chomp
+          contents = Vagrant::Util::ShellQuote.escape(contents, "'")
+
+          machine.communicate.tap do |comm|
+            if comm.test("test -f ~/.ssh/authorized_keys")
+              comm.execute(
+                "sed -i '' '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/darwin/plugin.rb
+++ b/plugins/guests/darwin/plugin.rb
@@ -26,6 +26,11 @@ module VagrantPlugins
         Cap::Halt
       end
 
+      guest_capability("darwin", "insert_public_key") do
+        require_relative "cap/insert_public_key"
+        Cap::InsertPublicKey
+      end
+
       guest_capability("darwin", "mount_nfs_folder") do
         require_relative "cap/mount_nfs_folder"
         Cap::MountNFSFolder
@@ -34,6 +39,11 @@ module VagrantPlugins
       guest_capability("darwin", "mount_vmware_shared_folder") do
         require_relative "cap/mount_vmware_shared_folder"
         Cap::MountVmwareSharedFolder
+      end
+
+      guest_capability("darwin", "remove_public_key") do
+        require_relative "cap/remove_public_key"
+        Cap::RemovePublicKey
       end
 
       guest_capability("darwin", "rsync_installed") do


### PR DESCRIPTION
Here's an implementation of the private key caps for darwin. It's copied from the Linux guest caps, with a minor tweak to the variant of sed that ships on OS X. This fixes #5204.