### PR TITLE
Relax i18n gem spec to support 0.7.0

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bundler", ">= 1.5.2", "< 1.8.0"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
-  s.add_dependency "i18n", "~> 0.6.0"
+  s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"
   s.add_dependency "listen", "~> 2.8.0"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.1"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"


### PR DESCRIPTION
API changes seem pretty minor:  https://github.com/svenfuchs/i18n/blob/master/CHANGELOG.md

Useful for folks that package instead of omnibus.