### PR TITLE
Create machine data directory only after the machine will be checked

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -604,10 +604,8 @@ module Vagrant
       @logger.info("Uncached load of machine.")
 
       # Determine the machine data directory and pass it to the machine.
-      # XXX: Permissions error here.
       machine_data_path = @local_data_path.join(
         "machines/#{name}/#{provider}")
-      FileUtils.mkdir_p(machine_data_path)
 
       # Create the machine and cache it for future calls. This will also
       # return the machine from this method.

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -70,6 +70,10 @@ module Vagrant
       # Get the provider configuration from the final loaded configuration
       provider_config = config.vm.get_provider_config(provider)
 
+      # Create machine data directory if it doesn't exist
+      # XXX: Permissions error here.
+      FileUtils.mkdir_p(data_path)
+
       # Create the machine and cache it for future calls. This will also
       # return the machine from this method.
       return Machine.new(name, provider, provider_cls, provider_config,


### PR DESCRIPTION
It fixes GH-5189
Actually, machine data directory should be created after machine configuration, e.q. when checks will be passed : [lib/vagrant/vagrantfile.rb#L108-L141](https://github.com/mitchellh/vagrant/blob/59dbe51ef2f0ba021b5e9c213710303d45c3b2d2/lib/vagrant/vagrantfile.rb#L108-L141)

### Why it is important
Currently we have this issue on OS X hosts: GH-5189, and it affects all providers: https://forum.parallels.com/threads/vagrant-builds-vms-but-cannot-locate-them.327487/
It is caused by two facts: 
- Machine data directory is created before check that the specified provider exists. Vagrant doesn't delete this dir even if provider check has been failed.
- The filesystem on OS X host is case insensitive by default. Thats why this "hidden error" still exists and make all subsequent "vagrant" commands not working.

How to reproduce: https://github.com/mitchellh/vagrant/issues/5189#issuecomment-74072717