### PR TITLE
Added bootstrap_options param to the salt provisioner docs

### DIFF
--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -112,6 +112,13 @@ These may be used to control the output of state execution:
   Can be one of "all", "garbage", "trace", "debug", "info", or
   "warning".
 
+## Miscellaneous
+
+You can pass any additional command line options to the salt bootstrap script
+with the following:
+
+* `bootstrap_options` (string) - Command line options.
+
 ## Pillar Data
 
 You can export pillar data for use during provisioning by using the ``pillar``


### PR DESCRIPTION
I discovered this option by digging in the source for a way to pass extra params to `bootstrap_salt.sh`.