### PR TITLE
Update host_info.ps1

### DIFF
--- a/plugins/synced_folders/smb/scripts/host_info.ps1
+++ b/plugins/synced_folders/smb/scripts/host_info.ps1
@@ -1,6 +1,6 @@
 $ErrorAction = "Stop"
 
-$net = Get-NetIPAddress
+$net = Get-NetIPAddress | Where-Object {($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")}
 $result = @{
 	ip_addresses = $net.IPAddress
 }

--- a/plugins/synced_folders/smb/scripts/host_info.ps1
+++ b/plugins/synced_folders/smb/scripts/host_info.ps1
@@ -1,8 +1,8 @@
 $ErrorAction = "Stop"
 
-$net = Get-WmiObject -class win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"'
+$net = Get-NetIPAddress
 $result = @{
-    ip_addresses = $net.ipaddress
+	ip_addresses = $net.IPAddress
 }
 
 Write-Output $(ConvertTo-Json $result)


### PR DESCRIPTION
Changed method for getting IP addresses.  Windows built-in VPN IP addresses do not appear in list using Get-WMIObject, causing shared folders to fail.