### PR TITLE
[DOCS] Clarifies the entry for config.ssh.insert_key

### DIFF
--- a/website/docs/source/v2/vagrantfile/ssh_settings.html.md
+++ b/website/docs/source/v2/vagrantfile/ssh_settings.html.md
@@ -68,8 +68,13 @@ is enabled. Defaults to false.
 <hr>
 
 `config.ssh.insert_key` - If `true`, Vagrant will automatically insert
-an insecure keypair to use for SSH. By default, this is true. This only
-has an effect if you don't already use private keys for authentication.
+an keypair to use for SSH, replacing the default Vagrant's insecure key
+inside the machine if detected. By default, this is true.
+
+This only has an effect if you don't already use private keys for
+authentication or if you are relying on the default insecure key.
+If you don't have to take care about security in your project and want to
+keep using the default insecure key, set this to `false`.
 
 <hr>
 


### PR DESCRIPTION
Related to the issue #5059, because of the changes introduced by pull request #4707. It's a nice feature, but a lot of people are having a hard time to find this configuration because the documentation is not clear.