### PR TITLE
Reorder forward port args in Getting Started

### DIFF
--- a/website/docs/source/v2/getting-started/networking.html.md
+++ b/website/docs/source/v2/getting-started/networking.html.md
@@ -26,7 +26,7 @@ is a simple edit to the Vagrantfile, which now looks like this:
 Vagrant.configure("2") do |config|
   config.vm.box = "hashicorp/precise32"
   config.vm.provision :shell, path: "bootstrap.sh"
-  config.vm.network :forwarded_port, host: 4567, guest: 80
+  config.vm.network :forwarded_port, guest: 80, host: 4567
 end
 ```
 


### PR DESCRIPTION
Just a quick update to Networking under Getting Started. In the main Networking section, there's a line that states, 

"In the case of forwarded ports, two numeric arguments are expected: the port on the guest followed by the port on the host that the guest port can be accessed by."

However, in the Networking section under Getting Started, it has them flipped around. So, this flips them so it's consistent with the main Networking section in the docs where the examples show `guest` followed by `host`.