### PR TITLE
Fixed inaccurate downloading status message

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -420,8 +420,15 @@ module Vagrant
             show_url = opts[:show_url]
             show_url ||= url
 
+            textLoading = "vagrant.box_downloading"
+
+            # Adjust status message when 'downloading' a local box.
+            if(show_url.start_with?('file://'))
+              textLoading = "vagrant.box_unpacking"
+            end
+
             env[:ui].detail(I18n.t(
-              "vagrant.box_downloading",
+              textLoading,
               url: show_url))
             if File.file?(d.destination)
               env[:ui].info(I18n.t("vagrant.actions.box.download.resuming"))

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -24,6 +24,8 @@ en:
       Downloading: %{url}
     box_download_error: |-
       Error downloading: %{message}
+    box_unpacking: |-
+      Unpacking necessary files from: %{url}
     box_expanding_url: |-
       URL: %{url}
     box_loading_metadata: |-


### PR DESCRIPTION
Importing a base box from the local file system currently outputs `Downloading: file://...`.
This PR changes this to  `Unpacking necessary files from: file://...` which is more accurate.
Fixes #5386.