### PR TITLE
Fix capitalization of Vagrant in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Ruby 2.0 is needed.
 
 ### Dependencies and Unit Tests
 
-To hack on vagrant, you'll need [bundler](http://github.com/carlhuda/bundler) which can
+To hack on Vagrant, you'll need [bundler](http://github.com/carlhuda/bundler) which can
 be installed with a simple `gem install bundler`. Afterwards, do the following:
 
     bundle install


### PR DESCRIPTION
Fixes capitalization of 'Vagrant' in `README.md`, so it matches the rest of the file. Hope you're having a great week! :)