### PR TITLE
core: allow IO redirection of UI for testing

### DIFF
--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -40,22 +40,36 @@ describe Vagrant::UI::Basic do
       subject.output("foo", new_line: false)
     end
 
-    it "outputs to stdout" do
+    it "outputs to the assigned stdout" do
+      stdout = StringIO.new
+      subject.stdout = stdout
+
       expect(subject).to receive(:safe_puts).with { |message, **opts|
-        expect(opts[:io]).to be($stdout)
+        expect(opts[:io]).to be(stdout)
         true
       }
 
       subject.output("foo")
     end
 
-    it "outputs to stderr for errors" do
+    it "outputs to stdout by default" do
+      expect(subject.stdout).to be($stdout)
+    end
+
+    it "outputs to the assigned stderr for errors" do
+      stderr = StringIO.new
+      subject.stderr = stderr
+
       expect(subject).to receive(:safe_puts).with { |message, **opts|
-        expect(opts[:io]).to be($stderr)
+        expect(opts[:io]).to be(stderr)
         true
       }
 
       subject.error("foo")
+    end
+
+    it "outputs to stderr for errors by default" do
+      expect(subject.stderr).to be($stderr)
     end
   end
 


### PR DESCRIPTION
Use of $stdin, $stdout, and $stderr globals makes testing difficult. By
exposing the IO objects as writable attributes, input/output can be more
easily simulated using StringIO or doubles.