### PR TITLE
Fix issue #4152: Salt minion bootstrapping

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -15,7 +15,7 @@ if (Test-Path C:\tmp\minion.pem) {
 
 # Detect architecture
 if ([IntPtr]::Size -eq 4) {
-  $arch = "win32"
+  $arch = "x86"
 } else {
   $arch = "AMD64"
 }

--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -1,5 +1,5 @@
 # Salt version to install
-$version = '2014.1.10'
+$version = '2014.7.1'
 
 # Create C:\tmp\ - if Vagrant doesn't upload keys and/or config it might not exist
 New-Item C:\tmp\ -ItemType directory | out-null
@@ -11,11 +11,6 @@ New-Item C:\salt\conf\pki\minion\ -ItemType directory | out-null
 if (Test-Path C:\tmp\minion.pem) {
   cp C:\tmp\minion.pem C:\salt\conf\pki\minion\
   cp C:\tmp\minion.pub C:\salt\conf\pki\minion\
-}
-
-# Check if minion config has been uploaded
-if (Test-Path C:\tmp\minion) {
-  cp C:\tmp\minion C:\salt\conf\
 }
 
 # Detect architecture
@@ -34,7 +29,13 @@ $webclient.DownloadFile($url, $file)
 
 # Install minion silently
 Write-Host "Installing Salt minion..."
-C:\tmp\salt.exe /S
+#Wait for process to exit before continuing...
+C:\tmp\salt.exe /S | Out-Null
+
+# Check if minion config has been uploaded
+if (Test-Path C:\tmp\minion) {
+  cp C:\tmp\minion C:\salt\conf\
+}
 
 # Wait for salt-minion service to be registered before trying to start it
 $service = Get-Service salt-minion -ErrorAction SilentlyContinue


### PR DESCRIPTION
Copy the config after we know the installer exits. Also rev the
installed version to 2014.7.1 (latest stable as of 3/4/2015)

It seems to work with a Windows 8.1 box that I have tested. Works on initial bootstrapping and succeeds on re-provisioning.