### PR TITLE
communicators/winrm: don't stop task on idle end

### DIFF
--- a/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
+++ b/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
@@ -27,7 +27,7 @@ $task_xml = @'
     <StartWhenAvailable>false</StartWhenAvailable>
     <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
     <IdleSettings>
-      <StopOnIdleEnd>true</StopOnIdleEnd>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
       <RestartOnIdle>false</RestartOnIdle>
     </IdleSettings>
     <AllowStartOnDemand>true</AllowStartOnDemand>


### PR DESCRIPTION
StopOnIdleEnd was set in the task definition for elevated/privileged
windows guest scripts. This setting:

> specifies that the task stops when the idle condition ceases to be true [1]

The "idle condition" is something that Windows periodically checks for,
and it's defined by a bunch of criteria like user presence/absence, CPU
/ IO idle time, etc. [2]

Telling our provisioner to stop the task if the "idle condition" ceases
to be true is a recipe for some sporadically stopped tasks, which seems
like precisely the behavior being reported in #5362.

I'm pretty sure this fixes #5362

[1] https://msdn.microsoft.com/en-us/library/cc248332.aspx
[2] https://msdn.microsoft.com/en-us/library/windows/desktop/aa383561%28v=vs.85%29.aspx