### PR TITLE
Ignore Windows NICs with nil :net_connection_id

### DIFF
--- a/plugins/guests/windows/cap/configure_networks.rb
+++ b/plugins/guests/windows/cap/configure_networks.rb
@@ -64,7 +64,9 @@ module VagrantPlugins
           guest_network.network_adapters.each do |nic|
             @@logger.debug("nic: #{nic.inspect}")
             naked_mac = nic[:mac_address].gsub(':','')
-            if driver_mac_address[naked_mac]
+            # If the :net_connection_id entry is nil then it is probably a virtual connection
+            # and should be ignored.
+            if driver_mac_address[naked_mac] && !nic[:net_connection_id].nil?
               vm_interface_map[driver_mac_address[naked_mac]] = {
                 net_connection_id: nic[:net_connection_id],
                 mac_address: naked_mac,


### PR DESCRIPTION
When upping a Win XP box, vagrant found a lot of "virtual" network
connections that did not have DHCP enabled, and tried to configure them
for DHCP. This did not work because their :net_connection_id is nil.
Ignoring these network connections enabled the XP box to be upped.

I realize that Windows XP is not officially supported, but I hope that you'll accept contributions that enable it to function. I also tested this change against a Windows 7 box to confirm that this change does not affect a newer Windows version.