### PR TITLE
Proposed fix for #4815 - Windows UNC path to allow > 256 characters

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -148,7 +148,7 @@ module Vagrant
         # @param [String] path Path to convert to UNC for Windows
         # @return [String]
         def windows_unc_path(path)
-          "//?/" + path.gsub("/", "\\")
+          "\\\\?\\" + path.gsub("/", "\\")
         end
 
         # Returns a boolean noting whether the terminal supports color.

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -144,6 +144,13 @@ module Vagrant
           path
         end
 
+        # Converts a given path to UNC format by adding a prefix and converting slashes.
+        # @param [String] path Path to convert to UNC for Windows
+        # @return [String]
+        def windows_unc_path(path)
+          "//?/" + path.gsub("/", "\\")
+        end
+
         # Returns a boolean noting whether the terminal supports color.
         # output.
         def terminal_supports_colors?

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -496,10 +496,14 @@ module VagrantPlugins
 
         def share_folders(folders)
           folders.each do |folder|
+            hostpath = folder[:hostpath]
+            if Vagrant::Util::Platform.windows?
+              hostpath = Vagrant::Util::Platform.windows_unc_path(hostpath)
+            end
             args = ["--name",
               folder[:name],
               "--hostpath",
-              Vagrant::Util::Platform.windows? ? ("//?/" + File.expand_path(folder[:hostpath])).gsub("/","\\") : folder[:hostpath]]
+              hostpath]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
             # Enable symlinks on the shared folder

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -499,7 +499,7 @@ module VagrantPlugins
             args = ["--name",
               folder[:name],
               "--hostpath",
-              folder[:hostpath]]
+              Vagrant::Util::Platform.windows? ? ("//?/" + File.expand_path(folder[:hostpath])).gsub("/","\\") : folder[:hostpath]]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
             # Enable symlinks on the shared folder

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -13,7 +13,7 @@ describe Vagrant::Util::Platform do
 
   describe "#windows_unc_path" do
     it "correctly converts a path" do
-      expect(described_class.windows_unc_path("c:/foo").to_s).to eql("//?/c:\\foo")
+      expect(described_class.windows_unc_path("c:/foo").to_s).to eql("\\\\?\\c:\\foo")
     end
   end
 end

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -10,4 +10,10 @@ describe Vagrant::Util::Platform do
       expect(described_class.fs_real_path("c:/foo").to_s).to eql("C:/foo")
     end
   end
+
+  describe "#windows_unc_path" do
+    it "correctly converts a path" do
+      expect(described_class.windows_unc_path("c:/foo").to_s).to eql("//?/c:\\foo")
+    end
+  end
 end


### PR DESCRIPTION
Proposed fix for #4815 (and #1953) based on many comments, notably @Ingramz and @celtric. 

This changes the VirtualBox share on Windows to use UNC paths, for which Windows allows > 256 characters.

Long paths become an issue when using npm for example, which can result in multiple sub directories. Once the path reaches 256 characters, the guest OS usually throws a Permission Denied or Protocol Error.

All rake tests passing, but couldn't get acceptance tests for virtualbox running so acceptance tests are not run. Tested in Windows 7 with VirtualBox 4.3.20 and Vagrant 1.7.2.