### PR TITLE
Add SCP to vagrant CLI

### DIFF
--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -26,6 +26,7 @@ module Vagrant
       autoload :Provision, "vagrant/action/builtin/provision"
       autoload :ProvisionerCleanup, "vagrant/action/builtin/provisioner_cleanup"
       autoload :SetHostname, "vagrant/action/builtin/set_hostname"
+      autoload :SCPExec, "vagrant/action/builtin/scp_exec"
       autoload :SSHExec, "vagrant/action/builtin/ssh_exec"
       autoload :SSHRun,  "vagrant/action/builtin/ssh_run"
       autoload :SyncedFolders, "vagrant/action/builtin/synced_folders"

--- a/lib/vagrant/action/builtin/scp_exec.rb
+++ b/lib/vagrant/action/builtin/scp_exec.rb
@@ -1,0 +1,38 @@
+require "pathname"
+
+require "vagrant/util/scp"
+
+module Vagrant
+  module Action
+    module Builtin
+      # This class will run a single file upload/download to/from the remote
+      # machine.
+      #
+      # The exit code will be made available in the env variable with the key:
+      # `:scp_run_exit_status`
+      class SCPExec
+        def initialize(app, env)
+          @app    = app
+        end
+
+        def call(env)
+          # Grab the SSH info from the machine
+          info = env[:machine].ssh_info
+
+          # If the result is nil, then the machine is telling us that it is
+          # not yet ready for SSH, so we raise this exception.
+          raise Errors::SSHNotReady if info.nil?
+
+          info[:private_key_path] ||= []
+
+          if info[:private_key_path].empty? && info[:password]
+            env[:ui].warn(I18n.t("vagrant.ssh_exec_password"))
+          end
+
+          # Exec!
+          Vagrant::Util::SCP.exec(info, env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -584,11 +584,19 @@ module Vagrant
       error_key(:rsync_not_installed_in_guest)
     end
 
+    class SCPEmptySourceOrDestination < VagrantError
+      error_key(:scp_empty_source_or_destination)
+    end
+
     class SCPPermissionDenied < VagrantError
       error_key(:scp_permission_denied)
     end
 
     class SCPUnavailable < VagrantError
+      error_key(:scp_unavailable)
+    end
+
+    class SCPUnavailableWindows < VagrantError
       error_key(:scp_unavailable)
     end
 

--- a/lib/vagrant/util/scp.rb
+++ b/lib/vagrant/util/scp.rb
@@ -1,0 +1,104 @@
+require "vagrant/util/safe_puts"
+require "vagrant/util/ssh"
+
+module Vagrant
+  module Util
+    # This is a class that has helpers on it for dealing with SCP These
+    # helpers don't depend on any part of Vagrant except what is given
+    # via the parameters.
+    class SCP
+      # Halts the running of this process and replaces it with SCP instance
+      # that copies files to/from the remote machine.
+      #
+      # Note: This method NEVER returns. The process ends after this.
+      #
+      # @param [Hash] ssh_info This is the SSH information. For the keys
+      #   required please see the documentation of {Machine#ssh_info}.
+      # @param [Hash] opts These are additional options that are supported
+      #   by exec.
+      def self.exec(ssh_info, opts={})
+        # Ensure the platform supports scp. On Windows there are several programs which
+        # include scp, notably git, mingw and cygwin, but make sure scp is in the path!
+        scp_path = Which.which("scp")
+        if !scp_path
+          if Platform.windows?
+            raise Errors::SCPUnavailableWindows,
+              host: ssh_info[:host],
+              port: ssh_info[:port],
+              username: ssh_info[:username],
+              key_path: ssh_info[:private_key_path].join(", ")
+          end
+
+          raise Errors::SCPUnavailable
+        end
+
+        # If plain mode is enabled then we don't do any authentication (we don't
+        # set a user or an identity file)
+        plain_mode = opts[:plain_mode]
+
+        options = {}
+        options[:host] = ssh_info[:host]
+        options[:port] = ssh_info[:port]
+        options[:username] = ssh_info[:username]
+        options[:private_key_path] = ssh_info[:private_key_path]
+
+        log_level = ssh_info[:log_level] || "FATAL"
+
+        # Command line options
+        command_options = [
+          "-P", options[:port].to_s,
+          "-o", "Compression=yes",
+          "-o", "DSAAuthentication=yes",
+          "-o", "LogLevel=#{log_level}",
+          "-o", "StrictHostKeyChecking=no",
+          "-o", "UserKnownHostsFile=/dev/null"
+        ]
+
+        # Solaris/OpenSolaris/Illumos uses SunSSH which doesn't support the
+        # IdentitiesOnly option. Also, we don't enable it in plain mode so
+        # that SSH properly searches our identities and tries to do it itself.
+        if !Platform.solaris? && !plain_mode
+          command_options += ["-o", "IdentitiesOnly=yes"]
+        end
+
+        # If we're not in plain mode, attach the private key path.
+        if !plain_mode
+          options[:private_key_path].each do |path|
+            command_options += ["-i", path.to_s]
+          end
+        end
+
+        if ssh_info[:proxy_command]
+          command_options += ["-o", "ProxyCommand=#{ssh_info[:proxy_command]}"]
+        end
+
+        # Build up the host string for connecting
+        host_string = options[:host]
+        host_string = "#{options[:username]}@#{host_string}" if !plain_mode
+
+        src = opts[:source]
+        dst = opts[:destination]
+
+        raise Vagrant::Errors::SCPEmptySourceOrDestination if src.nil? || dst.nil?
+
+        src = src.sub('vagrant', host_string) if src.start_with? 'vagrant:'
+        dst = dst.sub('vagrant', host_string) if dst.start_with? 'vagrant:'
+
+        command_options += [src, dst]
+
+        # On Cygwin we want to get rid of any DOS file warnings because
+        # we really don't care since both work.
+        ENV["nodosfilewarning"] = "1" if Platform.cygwin?
+
+        # If we're still here, it means we're supposed to subprocess
+        # out to scp rather than exec it.
+        process = ChildProcess.build("scp", *command_options)
+        process.io.inherit!
+        process.start
+        process.wait
+        return process.exit_code
+      end
+    end
+  end
+end
+

--- a/plugins/commands/scp/command.rb
+++ b/plugins/commands/scp/command.rb
@@ -1,0 +1,38 @@
+require 'optparse'
+
+module VagrantPlugins
+  module CommandSCP
+    class Command < Vagrant.plugin("2", :command)
+      def self.synopsis
+        "copies files from/to machine via SCP"
+      end
+
+      def execute
+        options = {}
+
+        opts = OptionParser.new do |o|
+          o.banner = <<-BANNER
+          Usage: vagrant scp vagrant:[PATH] [DEST-PATH] (vm to host)
+                 vagrant scp [PATH] vagrant:[DEST-PATH] (host to vm)
+          BANNER
+        end
+
+        # Parse destination and source
+        argv = parse_options(opts)
+        dirs = parse_dirs(argv)
+
+        with_target_vms([], single_target: true) do |vm|
+          vm.action(:scp_exec, dirs)
+        end
+
+        # Success, exit status 0
+        0
+      end
+
+      def parse_dirs(argv)
+        { source: argv.first, destination: argv.at(1) }
+      end
+    end
+  end
+end
+

--- a/plugins/commands/scp/plugin.rb
+++ b/plugins/commands/scp/plugin.rb
@@ -1,0 +1,18 @@
+require "vagrant"
+
+module VagrantPlugins
+  module CommandSCP
+    class Plugin < Vagrant.plugin("2")
+      name "scp command"
+      description <<-DESC
+      The `scp` command allows you to copy files from/to your running virtual machine.
+      DESC
+
+      command("scp") do
+        require File.expand_path("../command", __FILE__)
+        Command
+      end
+    end
+  end
+end
+

--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -219,6 +219,17 @@ module VagrantPlugins
       end
 
       # This is the action that will exec into an SSH shell.
+      def self.action_scp_exec
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use CheckVirtualbox
+          b.use CheckCreated
+          b.use CheckAccessible
+          b.use CheckRunning
+          b.use Vagrant::Action::Builtin::SCPExec
+        end
+      end
+
+      # This is the action that will exec into an SSH shell.
       def self.action_ssh
         Vagrant::Action::Builder.new.tap do |b|
           b.use CheckVirtualbox

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1018,9 +1018,34 @@ en:
 
         Source: %{from}
         Dest: %{to}
+      scp_empty_source_or_destination: |-
+        Please specify both a source file and a destination to copy the file to. (ie: vagrant:~/test.txt ~/test2.txt)
       scp_unavailable: |-
         SSH server on the guest doesn't support SCP. Please install the necessary
         software to enable SCP on your guest operating system.
+      scp_unavailable_windows: |-
+        `scp` executable not found in any directories in the %PATH% variable. Is an
+        SCP client installed? Try installing Cygwin, MinGW or Git, all of which
+        contain an SCP client. Or use your favorite SCP client with the following
+        authentication information shown below:
+
+        Host: %{host}
+        Port: %{port}
+        Username: %{username}
+        Private key: %{key_path}
+      shared_folder_create_failed: |-
+        Failed to create the following shared folder on the host system. This is
+        usually because Vagrant does not have sufficient permissions to create
+        the folder.
+
+        %{path}
+
+        Please create the folder manually or specify another path to share.
+      shell_expand_failed: |-
+        Vagrant failed to determine the shell expansion of a guest path
+        (probably for one of your shared folders). This is an extremely rare
+        error case and most likely indicates an unusual configuration of the
+        guest system. Please report a bug with your Vagrantfile and debug log.
       shared_folder_create_failed: |-
         Failed to create the following shared folder on the host system. This is
         usually because Vagrant does not have sufficient permissions to create

--- a/test/unit/vagrant/action/builtin/scp_exec_test.rb
+++ b/test/unit/vagrant/action/builtin/scp_exec_test.rb
@@ -1,0 +1,29 @@
+require File.expand_path("../../../../base", __FILE__)
+
+describe Vagrant::Action::Builtin::SCPExec do
+  let(:app) { lambda { |env| } }
+  let(:env) { { machine: machine } }
+  let(:machine) do
+    result = double("machine")
+    allow(result).to receive(:ssh_info).and_return(machine_ssh_info)
+    result
+  end
+  let(:machine_ssh_info) { {} }
+  let(:scp_klass) { Vagrant::Util::SCP }
+
+  it "raises an exception if SSH is not ready" do
+    not_ready_machine = double("machine")
+    allow(not_ready_machine).to receive(:ssh_info).and_return(nil)
+
+    env[:machine] = not_ready_machine
+    expect { described_class.new(app, env).call(env) }.
+      to raise_error(Vagrant::Errors::SSHNotReady)
+  end
+
+  it "raises an exception if a destination or a source are not given" do
+    ssh_info     = { foo: :bar }
+    expect { described_class.new(app, env).call(env) }.
+      to raise_error(Vagrant::Errors::SCPEmptySourceOrDestination)
+  end
+end
+


### PR DESCRIPTION
This PR adds an scp option to the vagrant CLI.

It lets one copy files from/to the remote vagrant machine using:

```bash
vagrant scp ~/foo.txt vagrant:~/bar.txt # local to vagrant machine
vagrant scp vagrant:~/bar.txt . # vagrant to local machine
```

I do most of my development work in vagrant machines so that I don't end up polluting my machine with dependencies for each project I work on. I therefore need to copy files back and forward and this command simplifies it.

I know I could use shared directories, but it makes me actually move stuff twice. Once from host to the shared dir and a second from the shared dir to the directory I want it in in the vagrant machine.

There are some rough edges in the code, and some duplication that could be removed, but I could use some feedback since it's the first code that I've written for Vagrant. Still trying to grasp the architecture :)