### PR TITLE
For SMB on Linux guests, specify the user's domain as a separate parameter

### DIFF
--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -27,10 +27,14 @@ module VagrantPlugins
 
           smb_password = Shellwords.shellescape(options[:smb_password])
 
+          # If a domain is provided in the username, separate it
+          username, domain = (options[:smb_username] || '').split('@', 2)
+
           options[:mount_options] ||= []
           options[:mount_options] << "sec=ntlm"
-          options[:mount_options] << "username=#{options[:smb_username]}"
+          options[:mount_options] << "username=#{username}"
           options[:mount_options] << "pass=#{smb_password}"
+          options[:mount_options] << "domain=#{domain}" if domain
 
           # First mount command uses getent to get the group
           mount_options = "-o uid=#{mount_uid},gid=#{mount_gid}"

--- a/test/unit/plugins/guests/linux/cap/mount_shared_folder_test.rb
+++ b/test/unit/plugins/guests/linux/cap/mount_shared_folder_test.rb
@@ -1,0 +1,44 @@
+require File.expand_path("../../../../../base", __FILE__)
+
+describe "VagrantPlugins::GuestLinux::Cap::MountSharedFolder" do
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:guest) { double("guest") }
+
+  before do
+    allow(machine).to receive(:guest).and_return(guest)
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(guest).to receive(:capability).and_return(nil)
+  end
+
+  describe "smb" do
+    let(:described_class) do
+      VagrantPlugins::GuestLinux::Plugin.components.guest_capabilities[:linux].get(:mount_smb_shared_folder)
+    end
+
+    describe ".mount_shared_folder" do
+      describe "with a domain" do
+        let(:mount_command) { "mount -t cifs -o uid=`id -u `,gid=`getent group  | cut -d: -f3`,sec=ntlm,username=user,pass=pass,domain=domain //host/name " }
+        before do
+          communicator.expect_command mount_command
+          communicator.stub_command mount_command, exit_code: 0
+        end
+        after { communicator.verify_expectations! }
+        it "should call mount with correct args" do
+          described_class.mount_smb_shared_folder(machine, 'name', 'guestpath', {:smb_username => "user@domain", :smb_password => "pass", :smb_host => "host"})
+        end
+      end
+      describe "without a domain" do
+        let(:mount_command) { "mount -t cifs -o uid=`id -u `,gid=`getent group  | cut -d: -f3`,sec=ntlm,username=user,pass=pass //host/name " }
+        before do
+          communicator.expect_command mount_command
+          communicator.stub_command mount_command, exit_code: 0
+        end
+        after { communicator.verify_expectations! }
+        it "should call mount with correct args" do
+          described_class.mount_smb_shared_folder(machine, 'name', 'guestpath', {:smb_username => "user", :smb_password => "pass", :smb_host => "host"})
+        end
+      end
+    end
+  end
+end

--- a/website/docs/source/v2/synced-folders/smb.html.md
+++ b/website/docs/source/v2/synced-folders/smb.html.md
@@ -49,8 +49,8 @@ The SMB synced folder type has a variety of options it accepts:
 * `smb_username` (string) - The username used for authentication to mount
   the SMB mount. This is the username to access the mount, _not_ the username
   of the account where the folder is being mounted to. This is usually your
-  Windows username. If this isn't specified, Vagrant will prompt you for
-  it.
+  Windows username. If you sign into a domain, specify it as `user@domain`.
+  If this option isn't specified, Vagrant will prompt you for it.
 
 ## Example
 


### PR DESCRIPTION
For SMB on Linux guests, specify the user's domain as a separate parameter to the mount command. This is more reliable than passing user@domain as the username. This is not needed for SMB on Windows guests as they expect the user@domain form.

This does not change how it is configured in the Vagrantfile.

Fixes #3620