### PR TITLE
Allow to use several boxes with the same name

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -166,7 +166,7 @@ module Vagrant
       vf = nil
       vf = @env.vagrantfile_name[0] if @env.vagrantfile_name
       id = Digest::MD5.hexdigest(
-        "#{@env.root_path}#{vf}#{@name}")
+        "#{@env.root_path}#{vf}#{@env.local_data_path}#{@name}")
 
       # We only lock if we're not executing an SSH action. In the future
       # we will want to do more fine-grained unlocking in actions themselves


### PR DESCRIPTION
I have different virtual machines with the same name in Vagrant and using the same Vagrantfile, but different names in virtualbox (and different directories).

This allows me to run action on both VMs at the same time.

Fixes #4822