### PR TITLE
guests/freebsd: fix call of set -i : missing extension

### DIFF
--- a/plugins/guests/freebsd/cap/remove_public_key.rb
+++ b/plugins/guests/freebsd/cap/remove_public_key.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
           machine.communicate.tap do |comm|
             if comm.test("test -f ~/.ssh/authorized_keys")
               comm.execute(
-                "sed -i '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys")
+                "sed -i .bak '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys")
             end
           end
         end


### PR DESCRIPTION
Sed on freebsd seems to be mores strict than on other
platforms about use of -i: the extension is not optional.

Signed-off-by: Michael Adam <obnox@samba.org>