### PR TITLE
contrib/bash: Auto-complete VMs for up command

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -70,8 +70,13 @@ _vagrant() {
               return 0
             ;;
             "up")
+              vagrant_state_file=$(__vagrantinvestigate) || return 1
+              if [[ -d $vagrant_state_file ]]
+              then
+                local vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+              fi
               local up_commands="--no-provision"
-              COMPREPLY=($(compgen -W "${up_commands}" -- ${cur}))
+              COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
               return 0
             ;;
             "ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config")
@@ -107,18 +112,32 @@ _vagrant() {
     if [ $COMP_CWORD == 3 ]
     then
       action="${COMP_WORDS[COMP_CWORD-2]}"
-      if [ $action == 'box' ]
-      then
-        case "$prev" in
+      case "$action" in
+        "up")
+          if [ "$prev" == "--no-provision" ]
+          then
+            if [[ -d $vagrant_state_file ]]
+            then
+              local vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+            fi
+            COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
+            return 0
+          fi
+          ;;
+        "box")
+          case "$prev" in
             "remove"|"repackage")
               local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
               ;;
             *)
-            ;;
-        esac
-      fi
+              ;;
+          esac
+          ;;
+        *)
+          ;;
+      esac
     fi
 
 }


### PR DESCRIPTION
An update to the bash auto-completion script to complete VM names for the `vagrant up` command.

I made a similar commit at https://github.com/kura/vagrant-bash-completion/commit/e720d90ae9a6589eb13c578b40a503e902d4897c earlier but what I really intended was to put it here since this is the "official" location.