### PR TITLE
Fixed VirtualBox's error message on 'private_network'

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -285,7 +285,7 @@ en:
         id_in_pre_import: |-
           The ':id' parameter is not available in "pre-import" customizations.
         intnet_on_bad_type: |-
-          VirtualBox internal networks can only be enabled on "private_networks"
+          VirtualBox internal networks can only be enabled on "private_network"
         invalid_event: |-
           %{event} is not a valid event for customization. Valid events
           are: %{valid_events}


### PR DESCRIPTION
Currently, a VirtualBox error message suggests
`VirtualBox internal networks can only be enabled on "private_networks"`
which is incorrect. This PR changes the error message to
`VirtualBox internal networks can only be enabled on "private_network"`.

Fixes #5418.