### PR TITLE
only set EFI secure boot for gen 2 machines in hyperv provider

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -136,11 +136,14 @@ $vm | Set-VM @more_vm_params -Passthru
 # Add drives to the virtual machine
 $controllers = Select-Xml -xml $vmconfig -xpath "//*[starts-with(name(.),'controller')]"
 
-# Set EFI secure boot 
-if ($secure_boot_enabled -eq "True") {
-    Set-VMFirmware -VM $vm -EnableSecureBoot On
-}  else {
-    Set-VMFirmware -VM $vm -EnableSecureBoot Off
+# Only set EFI secure boot for Gen 2 machines, not gen 1
+if ($generation -ne 1) {
+	# Set EFI secure boot 
+	if ($secure_boot_enabled -eq "True") {
+		Set-VMFirmware -VM $vm -EnableSecureBoot On
+	}  else {
+		Set-VMFirmware -VM $vm -EnableSecureBoot Off
+	}
 }
 
 # A regular expression pattern to pull the number from controllers


### PR DESCRIPTION
Stopping the EFI secure boot Set-VMFirmware commands from running on generation 1 machines.  If the Set-VMFirmware commands are run, generation 1 machines won't load.