### PR TITLE
HyperV provider: VlanID configuration possibility

### DIFF
--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -116,6 +116,7 @@ module VagrantPlugins
               end
 
               b2.use Provision
+              b2.use NetSetVLan
               b2.use StartInstance
               b2.use WaitForIPAddress
               b2.use WaitForCommunicator, [:running]
@@ -216,6 +217,7 @@ module VagrantPlugins
       autoload :StopInstance, action_root.join('stop_instance')
       autoload :SuspendVM, action_root.join("suspend_vm")
       autoload :WaitForIPAddress, action_root.join("wait_for_ip_address")
+      autoload :NetSetVLan, action_root.join("net_set_vlan")
       autoload :MessageWillNotDestroy, action_root.join("message_will_not_destroy")
     end
   end

--- a/plugins/providers/hyperv/action/net_set_vlan.rb
+++ b/plugins/providers/hyperv/action/net_set_vlan.rb
@@ -1,0 +1,19 @@
+module VagrantPlugins
+  module HyperV
+    module Action
+      class NetSetVLan
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          vlan_id = env[:machine].provider_config.vlan_id
+
+          env[:ui].info("[Settings] [Network Adapter] Setting Vlan ID to: #{vlan_id}")
+          env[:machine].provider.driver.net_set_vlan(vlan_id)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/action/net_set_vlan.rb
+++ b/plugins/providers/hyperv/action/net_set_vlan.rb
@@ -8,9 +8,10 @@ module VagrantPlugins
 
         def call(env)
           vlan_id = env[:machine].provider_config.vlan_id
-
-          env[:ui].info("[Settings] [Network Adapter] Setting Vlan ID to: #{vlan_id}")
-          env[:machine].provider.driver.net_set_vlan(vlan_id)
+          if  vlan_id
+            env[:ui].info("[Settings] [Network Adapter] Setting Vlan ID to: #{vlan_id}")
+            env[:machine].provider.driver.net_set_vlan(vlan_id)
+          end  
           @app.call(env)
         end
       end

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -13,12 +13,18 @@ module VagrantPlugins
       attr_accessor :cpus
       attr_accessor :vmname
 
+      # The default VLAN ID for network interface for the virtual machine.
+      #
+      # @return [Integer]
+      attr_accessor :vlan_id
+
       def initialize
         @ip_address_timeout = UNSET_VALUE
         @memory = UNSET_VALUE
         @maxmemory = UNSET_VALUE
         @cpus = UNSET_VALUE
         @vmname = UNSET_VALUE
+        @vlan_id  = UNSET_VALUE
       end
 
       def finalize!
@@ -29,6 +35,7 @@ module VagrantPlugins
         @maxmemory = nil if @maxmemory == UNSET_VALUE
         @cpus = nil if @cpus == UNSET_VALUE 
         @vmname = nil if @vmname == UNSET_VALUE
+        @vlan_id = 0 if @vlan_id == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -3,20 +3,13 @@ require "vagrant"
 module VagrantPlugins
   module HyperV
     class Config < Vagrant.plugin("2", :config)
-      # The timeout to wait for an IP address when booting the machine,
-      # in seconds.
-      #
-      # @return [Integer]
-      attr_accessor :ip_address_timeout
-      attr_accessor :memory
-      attr_accessor :maxmemory
-      attr_accessor :cpus
-      attr_accessor :vmname
-
-      # The default VLAN ID for network interface for the virtual machine.
-      #
-      # @return [Integer]
-      attr_accessor :vlan_id
+      
+      attr_accessor :ip_address_timeout # Time to wait for an IP address when booting, in seconds @return [Integer]
+      attr_accessor :memory #  Memory size in mb @return [Integer]
+      attr_accessor :maxmemory # Maximal memory size in mb enables dynamical memory allocation @return [Integer]
+      attr_accessor :cpus # Number of cpu's @return [Integer]
+      attr_accessor :vmname # Name that will be shoen in Hyperv Manager @return [String]
+      attr_accessor :vlan_id # VLAN ID for network interface for the virtual machine. @return [Integer]
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
@@ -35,7 +28,7 @@ module VagrantPlugins
         @maxmemory = nil if @maxmemory == UNSET_VALUE
         @cpus = nil if @cpus == UNSET_VALUE 
         @vmname = nil if @vmname == UNSET_VALUE
-        @vlan_id = 0 if @vlan_id == UNSET_VALUE
+        @vlan_id = nil if @vlan_id == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -77,6 +77,10 @@ module VagrantPlugins
          execute('import_vm.ps1', options)
        end
 
+       def net_set_vlan(vlan_id)
+          execute("set_network_vlan.ps1", { VmId: vm_id, VlanId: vlan_id })
+       end
+
       protected
 
       def execute_powershell(path, options, &block)

--- a/plugins/providers/hyperv/scripts/set_network_vlan.ps1
+++ b/plugins/providers/hyperv/scripts/set_network_vlan.ps1
@@ -1,0 +1,18 @@
+param (
+    [string]$VmId = $(throw "-VmId is required."),
+    [int]$VlanId = $(throw "-VlanId ")
+ )
+
+# Include the following modules
+$presentDir = Split-Path -parent $PSCommandPath
+$modules = @()
+$modules += $presentDir + "\utils\write_messages.ps1"
+forEach ($module in $modules) { . $module }
+
+try {
+  $vm = Get-VM -Id $VmId -ErrorAction "stop"
+  Set-VMNetworkAdapterVlan $vm -Access -Vlanid $VlanId
+}
+catch {
+  Write-Error-Message "Failed to set VM's Vlan ID $_"
+}

--- a/test/unit/plugins/providers/hyperv/config_test.rb
+++ b/test/unit/plugins/providers/hyperv/config_test.rb
@@ -13,7 +13,7 @@ describe VagrantPlugins::HyperV::Config do
       subject.finalize!
       expect(subject.ip_address_timeout).to eq(120)
     end
-
+  end
   describe "#vlan_id" do
     it "can be set" do
       subject.vlan_id = 100

--- a/test/unit/plugins/providers/hyperv/config_test.rb
+++ b/test/unit/plugins/providers/hyperv/config_test.rb
@@ -20,11 +20,6 @@ describe VagrantPlugins::HyperV::Config do
       subject.finalize!
       expect(subject.vlan_id).to eq(100)
     end
-
-    it "defaults to a number" do
-      subject.finalize!
-      expect(subject.vlan_id).to eq(0)
-    end
   end
   describe "#vmname" do
     it "can be set" do

--- a/test/unit/plugins/providers/hyperv/config_test.rb
+++ b/test/unit/plugins/providers/hyperv/config_test.rb
@@ -13,6 +13,18 @@ describe VagrantPlugins::HyperV::Config do
       subject.finalize!
       expect(subject.ip_address_timeout).to eq(120)
     end
+
+  describe "#vlan_id" do
+    it "can be set" do
+      subject.vlan_id = 100
+      subject.finalize!
+      expect(subject.vlan_id).to eq(100)
+    end
+
+    it "defaults to a number" do
+      subject.finalize!
+      expect(subject.vlan_id).to eq(0)
+    end
   end
   describe "#vmname" do
     it "can be set" do

--- a/website/docs/source/v2/hyperv/configuration.html.md
+++ b/website/docs/source/v2/hyperv/configuration.html.md
@@ -17,6 +17,8 @@ you may set. A complete reference is shown below:
   * `maxmemory` (integer) - Number of MegaBytes maximal allowed to allocate for VM
   	This parameter is switch on Dynamic Allocation of memory.
   	Defaults is taken from box image XML.
+  * `vlan_id` (integer) - Number of Vlan ID for your guest network interface
+    Defaults is not defined, vlan configuration will be untouched if not set.
   * `ip_address_timeout` (integer) - The time in seconds to wait for the
     virtual machine to report an IP address. This defaults to 120 seconds.
     This may have to be increased if your VM takes longer to boot.


### PR DESCRIPTION
This PR mostly based on #5169 it adds possibility to configure vlan_id for hyperv provider
My improvements gives possibility to leave vlan_id untouched in case it does not set
also added description of this option to documentation.

tests present, feature documented
tested on 2012hyperv server
with #5207 will be great improvements for hyperv networking possibilities, and reduce it limitations