### PR TITLE
Make sure debian net post-up never returns an error code.

### DIFF
--- a/templates/guests/debian/network_dhcp.erb
+++ b/templates/guests/debian/network_dhcp.erb
@@ -6,7 +6,7 @@ iface eth<%= options[:interface] %> inet dhcp
     post-up route del default dev $IFACE || true
 <% else %>
     # We need to disable eth0, see GH-2648
-    post-up route del default dev eth0
+    post-up route del default dev eth0 || true
     post-up dhclient $IFACE
     pre-down route add default dev eth0
 <% end %>


### PR DESCRIPTION
Inspired by e7dce43af3905a7a986ef6e3402bf6809ab90f16.

I'm using this configuration in my Vagrantfile:
```ruby
config.vm.network :public_network, use_dhcp_assigned_default_route: true
```

Every once in a while the secondary network interface would not come
up properly and cause the init scripts to wait for ~ 3 minutes before
giving up and continue with booting.

(My guess is that sometimes the VirtualBox dhcp server takes longer to respond than the physical network and that causes the default route deletion to fail).

I haven't seen this issue since I made this change locally on my machine.