### PR TITLE
fix ftp push check bug

### DIFF
--- a/plugins/pushes/ftp/adapter.rb
+++ b/plugins/pushes/ftp/adapter.rb
@@ -74,13 +74,22 @@ module VagrantPlugins
 
         # Create the parent directories if they does not exist (naive mkdir -p)
         fullpath.descend do |path|
-          if @server.list(path.to_s).empty?
+          unless check_dir_exists? path.to_s
             @server.mkdir(path.to_s)
           end
         end
 
         # Upload the file
         @server.putbinaryfile(local, remote)
+      end
+
+      def check_dir_exists?(path)
+        begin
+          @server.chdir(path)
+          return true
+        rescue Net::FTPPermError
+          return false
+        end
       end
 
       private


### PR DESCRIPTION
list method is not safe to check if a dir exist or not on remote.

To re-produce the error, you could do  'git clone git@github.com:sinatra/sinatra.git' in directory which Vagrantfile stay in, and run $vagrant push.