### PR TITLE
Fixed error in ChangeHostName capability for Darwin

### DIFF
--- a/plugins/guests/darwin/cap/change_host_name.rb
+++ b/plugins/guests/darwin/cap/change_host_name.rb
@@ -6,7 +6,9 @@ module VagrantPlugins
           if !machine.communicate.test("hostname -f | grep '^#{name}$' || hostname -s | grep '^#{name}$'")
             machine.communicate.sudo("scutil --set ComputerName #{name}")
             machine.communicate.sudo("scutil --set HostName #{name}")
-            machine.communicate.sudo("scutil --set LocalHostName #{name}")
+            # LocalHostName shouldn't contain dots.
+            # It is used by Bonjour and visible through file sharing services.
+            machine.communicate.sudo("scutil --set LocalHostName #{name.gsub(/\.+/, '')}")
             machine.communicate.sudo("hostname #{name}")
           end
         end


### PR DESCRIPTION
#4535 has broken Darwin guests if `config.vm.hostname` is set to FQDN, with dots:
```
<...>
==> default: Setting hostname...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

scutil --set LocalHostName holly-chef.com

Stdout from the command:



Stderr from the command:

SCPreferencesSetLocalHostName() failed: Invalid argument
```
I've reproduced it on OS X 10.9.5 and 10.10.2 as well.
It is caused by the fact that `LocalHostName` should not contain dots and it could not be equal the FQDN. 
The good practice here is to leave only the first part of hostname, like I've done.