### PR TITLE
Use service command to restart docker, not upstart.

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_configure_auto_start.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_configure_auto_start.rb
@@ -7,8 +7,7 @@ module VagrantPlugins
             machine.communicate.tap do |comm|
               if !comm.test('grep -q \'\-r=true\' /etc/default/docker')
                 comm.sudo("echo 'DOCKER_OPTS=\"-r=true ${DOCKER_OPTS}\"' >> /etc/default/docker")
-                comm.sudo("stop docker")
-                comm.sudo("start docker")
+                comm.sudo("service docker restart")
 
                 # Wait some amount time for the pid to become available
                 # so that we don't start executing Docker commands until


### PR DESCRIPTION
Very simple tweak I'm using personally for Debian-based boxes. upstart ships by default on Ubuntu, but not on Debian, and `service` works in both. Fixes #5245.