### PR TITLE
Update ssh.rb to detect PLink v0.64

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -83,7 +83,7 @@ module Vagrant
         # underneath the covers. In this case, we tell the user.
         if Platform.windows?
           r = Subprocess.execute(ssh_path)
-          if r.stdout.include?("PuTTY Link")
+          if r.stdout.include?("PuTTY Link") || r.stdout.include?("Plink: command-line connection utility")
             raise Errors::SSHIsPuttyLink,
               host: ssh_info[:host],
               port: ssh_info[:port],


### PR DESCRIPTION
PLink 0.64 (released 28-2-2015) changes the command-line description, so the previous text-match no longer works.

This fixes one of the issues that frequently occurs on Windows systems.