### PR TITLE
Add :name attribute to shell provisioner.

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
       attr_accessor :privileged
       attr_accessor :binary
       attr_accessor :keep_color
+      attr_accessor :name
       attr_accessor :powershell_args
 
       def initialize
@@ -20,6 +21,7 @@ module VagrantPlugins
         @privileged  = UNSET_VALUE
         @binary      = UNSET_VALUE
         @keep_color  = UNSET_VALUE
+        @name        = UNSET_VALUE
         @powershell_args  = UNSET_VALUE
       end
 
@@ -31,10 +33,14 @@ module VagrantPlugins
         @privileged  = true if @privileged == UNSET_VALUE
         @binary      = false if @binary == UNSET_VALUE
         @keep_color  = false if @keep_color == UNSET_VALUE
+        @name        = nil if @name == UNSET_VALUE
         @powershell_args  = "-ExecutionPolicy Bypass" if @powershell_args == UNSET_VALUE
 
         if @args && args_valid?
           @args = @args.is_a?(Array) ? @args.map { |a| a.to_s } : @args.to_s
+        end
+        if not(@name.nil?) and not(@name.is_a?(String))
+          @name = nil
         end
       end
 

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -65,7 +65,10 @@ module VagrantPlugins
 
             comm.upload(path.to_s, config.upload_path)
 
-            if config.path
+            if not(config.name.nil?)
+              @machine.ui.detail(I18n.t("vagrant.provisioners.shell.running",
+                                      script: "Name: #{config.name}"))
+            elsif config.path
               @machine.ui.detail(I18n.t("vagrant.provisioners.shell.running",
                                       script: path.to_s))
             else
@@ -122,7 +125,10 @@ module VagrantPlugins
             command = "powershell #{shell_args.to_s} -file #{command}" if
               File.extname(exec_path).downcase == '.ps1'
 
-            if config.path
+            if not(config.name.nil?)
+              @machine.ui.detail(I18n.t("vagrant.provisioners.shell.running",
+                                      script: "Name: #{config.name}"))
+            elsif config.path
               @machine.ui.detail(I18n.t("vagrant.provisioners.shell.runningas",
                                       local: config.path.to_s, remote: exec_path))
             else

--- a/website/docs/source/v2/provisioning/shell.html.md
+++ b/website/docs/source/v2/provisioning/shell.html.md
@@ -59,6 +59,9 @@ The remainder of the available options are optional:
   true, Vagrant will not do this, allowing the native colors from the script
   to be outputted.
 
+* `name` (string) - This value will be displayed in the output so that
+  identification by the user is easier when many shell provisioners are present.
+
 * `powershell_args` (string) - Extra arguments to pass to `PowerShell`
   if you're provisioning with PowerShell on Windows.
 


### PR DESCRIPTION
This allows the display of friendly output to the user when we think an
important action should be labeled a certain way. This makes vagrant
output a lot more useful when many inline shell provisioners are
present.

This patch includes documentation updates too! w00t :)