### PR TITLE
Check Upstart is running before emitting upstart events.

### DIFF
--- a/plugins/guests/linux/cap/mount_nfs.rb
+++ b/plugins/guests/linux/cap/mount_nfs.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
             end
 
             # Emit an upstart event if we can
-            if machine.communicate.test("test -x /sbin/initctl")
+            if machine.communicate.test("test -x /sbin/initctl && test 'upstart' = $(basename $(sudo readlink /proc/1/exe))")
               machine.communicate.sudo(
                 "/sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{expanded_guest_path}")
             end

--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -82,7 +82,7 @@ module VagrantPlugins
           end
 
           # Emit an upstart event if we can
-          if machine.communicate.test("test -x /sbin/initctl")
+          if machine.communicate.test("test -x /sbin/initctl && test 'upstart' = $(basename $(sudo readlink /proc/1/exe))")
             machine.communicate.sudo(
               "/sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{expanded_guest_path}")
           end

--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -80,7 +80,7 @@ module VagrantPlugins
           end
 
           # Emit an upstart event if we can
-          if machine.communicate.test("test -x /sbin/initctl")
+          if machine.communicate.test("test -x /sbin/initctl && test 'upstart' = $(basename $(sudo readlink /proc/1/exe))")
             machine.communicate.sudo(
               "/sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{expanded_guest_path}")
           end


### PR DESCRIPTION
Fixes issue #5377.
Check that Upstart is not just installed but currently actively running
before attempting to emit an event after mounting shared folders.
Only requires the binary be named upstart, not that it lives in /sbin.