### PR TITLE
TinyCore change_host_name capability

### DIFF
--- a/plugins/guests/tinycore/cap/change_host_name.rb
+++ b/plugins/guests/tinycore/cap/change_host_name.rb
@@ -4,7 +4,6 @@ module VagrantPlugins
       class ChangeHostName
         def self.change_host_name(machine, name)
           if !machine.communicate.test("hostname | grep '^#{name}$'")
-            machine.communicate.sudo("sh -c 'echo \"#{name}\" > /etc/hostname'")
             machine.communicate.sudo("/usr/bin/sethostname #{name}")
           end
         end

--- a/plugins/guests/tinycore/plugin.rb
+++ b/plugins/guests/tinycore/plugin.rb
@@ -16,6 +16,11 @@ module VagrantPlugins
         Cap::ConfigureNetworks
       end
 
+      guest_capability("tinycore", "change_host_name") do
+        require_relative "cap/change_host_name"
+        Cap::ChangeHostName
+      end
+
       guest_capability("tinycore", "halt") do
         require_relative "cap/halt"
         Cap::Halt

--- a/test/unit/plugins/guests/tinycore/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/tinycore/cap/change_host_name_test.rb
@@ -1,0 +1,26 @@
+require File.expand_path("../../../../../base", __FILE__)
+
+describe "VagrantPlugins::GuestTinyCore::Cap::ChangeHostName" do
+  let(:described_class) do
+    VagrantPlugins::GuestTinyCore::Plugin.components.guest_capabilities[:tinycore].get(:change_host_name)
+  end
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:old_hostname) { 'boot2docker' }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    communicator.stub_command('hostname -f', stdout: old_hostname)
+  end
+
+  after do
+    communicator.verify_expectations!
+  end
+
+  describe ".change_host_name" do
+    it "refreshes the hostname service with the sethostname command" do
+      communicator.expect_command(%q(/usr/bin/sethostname newhostname.newdomain.tld))
+      described_class.change_host_name(machine, 'newhostname.newdomain.tld')
+    end
+  end
+end


### PR DESCRIPTION
The capability code was already there, but not declared in the plugin file.