### PR TITLE
added gpg signature for rvm and bundle gem install to the docs Vagrantfile

### DIFF
--- a/website/docs/Vagrantfile
+++ b/website/docs/Vagrantfile
@@ -4,11 +4,13 @@
 $script = <<SCRIPT
 sudo apt-get -y update
 sudo apt-get -y install curl
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable
 . ~/.bashrc
 . ~/.bash_profile
 rvm install 2.0.0
 rvm --default use 2.0.0
+gem install bundle
 cd /vagrant
 bundle
 SCRIPT


### PR DESCRIPTION
When attempting to run vagrant up on the Vagrantfile provided in the documentation directory, I get an error related to rvm's gpg signature and the bundle gem not being installed. 

This commit adds a line to retrieve the key and another to install the bundle gem to the Vagrantfile's provisioning script. 

Gist of the error:
https://gist.github.com/brooksbrown/e0d53d995d8dfcc9204d