### PR TITLE
Fixed ssh.private_key_path issue

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -443,8 +443,9 @@ module Vagrant
         end
       end
 
-      # If we have a private key in our data dir, then use that
-      if @data_dir
+      # If we have a private key in our data dir & private key is not set
+      # in Vagrantfile, then use that
+      if @data_dir && !@config.ssh.private_key_path
         data_private_key = @data_dir.join("private_key")
         if data_private_key.file?
           info[:private_key_path] = [data_private_key.to_s]


### PR DESCRIPTION
When attempting to run vagrant ssh, the ssh private key path is overwritten by the default value.

This commit adds a check and skips the overwrite if ssh.private_key_path is specified in the Vagrantfile.

https://github.com/mitchellh/vagrant/issues/5374