### PR TITLE
fix master_config documentation

### DIFF
--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -85,7 +85,7 @@ public key
 ## Master Options
 These only make sense when `install_master` is `true`.
 
-* `master_config` (string, default: "salt/minion")
+* `master_config` (string, default: "salt/master")
   Path to a custom salt master config file
 
 * `master_key` (salt/key/master.pem) - Path to your master key


### PR DESCRIPTION
Based on this vagrant code:

```
          @machine.env.ui.info "Copying salt master config to vm."
          @machine.communicate.upload(expanded_path(@config.master_config).to_s, temp_config_dir + "/master")
        end
```

It seems that the current documentation:
 * master_config (string, default: "salt/minion") Path to a custom salt master config file

is probably incorrect and the master_conifg probably defaults to salt/master, not salt/minion.

Unless I'm reading the code wrong.
