### PR TITLE
Fix issue #5657: Take only files while box repackage

### DIFF
--- a/lib/vagrant/box.rb
+++ b/lib/vagrant/box.rb
@@ -173,7 +173,7 @@ module Vagrant
 
       Util::SafeChdir.safe_chdir(@directory) do
         # Find all the files in our current directory and tar it up!
-        files = Dir.glob(File.join(".", "**", "*"))
+        files = Dir.glob(File.join(".", "**", "*")).select { |f| File.file?(f) }
 
         # Package!
         Util::Subprocess.execute("bsdtar", "-czf", path.to_s, *files)


### PR DESCRIPTION
Fixes GH-5657

While doing a box repackage, we have to select only files to avoid duplicates in the resulted tar.