### PR TITLE
Hyper V fuller network support 

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -435,12 +435,12 @@ module Vagrant
       # Set the private key path. If a specific private key is given in
       # the Vagrantfile we set that. Otherwise, we use the default (insecure)
       # private key, but only if the provider didn't give us one.
+      if @config.ssh.private_key_path && !info[:password]
+        info[:private_key_path] = @config.ssh.private_key_path
+      end
+
       if !info[:private_key_path] && !info[:password]
-        if @config.ssh.private_key_path
-          info[:private_key_path] = @config.ssh.private_key_path
-        else
-          info[:private_key_path] = @env.default_private_key_path
-        end
+        info[:private_key_path] = @env.default_private_key_path
       end
 
       # If we have a private key in our data dir, then use that

--- a/lib/vagrant/util/powershell.rb
+++ b/lib/vagrant/util/powershell.rb
@@ -21,7 +21,7 @@ module Vagrant
           "powershell",
           "-NoProfile",
           "-ExecutionPolicy", "Bypass",
-          "&('#{path}')",
+          "-File", path,
           args
         ].flatten
 

--- a/plugins/guests/linux/cap/choose_addressable_ip_addr.rb
+++ b/plugins/guests/linux/cap/choose_addressable_ip_addr.rb
@@ -3,8 +3,15 @@ module VagrantPlugins
     module Cap
       module ChooseAddressableIPAddr
         def self.choose_addressable_ip_addr(machine, possible)
+          possible_ips = possible
+
+          info = machine.ssh_info
+          host_ip = IPAddr.new(info[:host])
+          possible_ips = possible.map{ |ip| IPAddr.new(ip)}
+          possible_ips = possible_ips.sort_by{|ip| (host_ip.to_i - ip.to_i).abs}
+
           machine.communicate.tap do |comm|
-            possible.each do |ip|
+            possible_ips.each do |ip|
               command = "ping -c1 -w1 -W1 #{ip}"
               if comm.test(command)
                 return ip

--- a/plugins/guests/windows/cap/choose_addressable_ip_addr.rb
+++ b/plugins/guests/windows/cap/choose_addressable_ip_addr.rb
@@ -3,8 +3,15 @@ module VagrantPlugins
     module Cap
       module ChooseAddressableIPAddr
         def self.choose_addressable_ip_addr(machine, possible)
+          possible_ips = possible
+
+          info = machine.ssh_info
+          host_ip = IPAddr.new(info[:host])
+          possible_ips = possible.map{ |ip| IPAddr.new(ip)}
+          possible_ips = possible_ips.sort_by{|ip| (host_ip.to_i - ip.to_i).abs}
+
           machine.communicate.tap do |comm|
-            possible.each do |ip|
+            possible_ips.each do |ip|
               command = "ping -n 1 -w 1 #{ip}"
               if comm.test(command)
                 return ip

--- a/plugins/kernel_v1/config/synced_folder.rb
+++ b/plugins/kernel_v1/config/synced_folder.rb
@@ -1,0 +1,23 @@
+ui.askrequire "vagrant"
+
+module VagrantPlugins
+  module Kernel_V1
+    class SyncedFolderConfig < Vagrant.plugin("1", :config)
+      attr_accessor :username
+      attr_accessor :password
+
+      def initialize
+        @username = UNSET_VALUE
+        @password = UNSET_VALUE
+      end
+
+      def upgrade(new)
+        synced_folder = new.synced_folder
+        synced_folder.username = @username if @username != UNSET_VALUE
+        synced_folder.password = @password if @password != UNSET_VALUE
+
+        synced_folder
+      end
+    end
+  end
+end

--- a/plugins/kernel_v1/config/synced_folder.rb
+++ b/plugins/kernel_v1/config/synced_folder.rb
@@ -1,5 +1,3 @@
-ui.askrequire "vagrant"
-
 module VagrantPlugins
   module Kernel_V1
     class SyncedFolderConfig < Vagrant.plugin("1", :config)

--- a/plugins/kernel_v1/plugin.rb
+++ b/plugins/kernel_v1/plugin.rb
@@ -30,6 +30,11 @@ module VagrantPlugins
         PackageConfig
       end
 
+      config("synced_folder", true) do
+        require File.expand_path("../config/synced_folder", __FILE__)
+        SyncedFolderConfig
+      end
+
       config("vagrant", true) do
         require File.expand_path("../config/vagrant", __FILE__)
         VagrantConfig

--- a/plugins/kernel_v2/config/synced_folder.rb
+++ b/plugins/kernel_v2/config/synced_folder.rb
@@ -1,0 +1,24 @@
+require "vagrant"
+
+module VagrantPlugins
+  module Kernel_V2
+    class SyncedFolderConfig < Vagrant.plugin("2", :config)
+      attr_accessor :username
+      attr_accessor :password
+
+      def initialize
+        @username = UNSET_VALUE
+        @password = UNSET_VALUE
+      end
+
+      def finalize!
+        @username = nil if @username == UNSET_VALUE
+        @password = nil if @password == UNSET_VALUE
+      end
+
+      def to_s
+        "SyncedFolder"
+      end
+    end
+  end
+end

--- a/plugins/kernel_v2/plugin.rb
+++ b/plugins/kernel_v2/plugin.rb
@@ -30,6 +30,11 @@ module VagrantPlugins
         PushConfig
       end
 
+      config("synced_folder") do
+        require File.expand_path("../config/synced_folder", __FILE__)
+        SyncedFolderConfig
+      end
+
       config("vagrant") do
         require File.expand_path("../config/vagrant", __FILE__)
         VagrantConfig

--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -116,6 +116,7 @@ module VagrantPlugins
               end
 
               b2.use Provision
+              b2.use Network
               b2.use StartInstance
               b2.use WaitForIPAddress
               b2.use WaitForCommunicator, [:running]
@@ -209,6 +210,7 @@ module VagrantPlugins
       autoload :CheckEnabled, action_root.join("check_enabled")
       autoload :DeleteVM, action_root.join("delete_vm")
       autoload :Import, action_root.join("import")
+      autoload :Network, action_root.join("network")
       autoload :IsWindows, action_root.join("is_windows")
       autoload :ReadState, action_root.join("read_state")
       autoload :ResumeVM, action_root.join("resume_vm")

--- a/plugins/providers/hyperv/action/network.rb
+++ b/plugins/providers/hyperv/action/network.rb
@@ -1,0 +1,362 @@
+require "set"
+
+require "log4r"
+
+require "vagrant/util/network_ip"
+require "vagrant/util/scoped_hash_override"
+
+module VagrantPlugins
+  module HyperV
+    module Action
+      # This middleware class sets up all networking for the VirtualBox
+      # instance. This includes host only networks, bridged networking,
+      # forwarded ports, etc.
+      #
+      # This handles all the `config.vm.network` configurations.
+      class Network
+        include Vagrant::Util::NetworkIP
+        include Vagrant::Util::ScopedHashOverride
+
+        def initialize(app, env)
+          @logger = Log4r::Logger.new("vagrant::plugins::hyperv::network")
+          @app    = app
+        end
+
+        def call(env)
+          # TODO: Validate network configuration prior to anything below
+          @env = env
+
+          # Get the list of network adapters from the configuration
+          network_adapters_config = env[:machine].provider_config.network_adapters.dup
+
+          # Assign the adapter slot for each high-level network
+          available_slots = Set.new(1..8)
+          network_adapters_config.each do |slot, _data|
+            available_slots.delete(slot)
+          end
+
+          @logger.debug("Available slots for high-level adapters: #{available_slots.inspect}")
+          @logger.info("Determining network adapters required for high-level configuration...")
+          available_slots = available_slots.to_a.sort
+          env[:machine].config.vm.networks.each do |type, options|
+            # We only handle private and public networks
+            options = scoped_hash_override(options, :hyperv)
+
+            # Figure out the slot that this adapter will go into
+            slot = options[:adapter]
+            if !slot
+              if available_slots.empty?
+                raise Vagrant::Errors::VirtualBoxNoRoomForHighLevelNetwork
+              end
+
+              slot = available_slots.shift
+            end
+
+            # Configure it
+            data = nil
+            if type == :private_network
+              # private_network = hostonly
+              data = [:private, options]
+            elsif type == :public_network
+              # public_network = bridged
+              data = [:external, options]
+            elsif type == :forwarded_port
+              # public_network = bridged
+              data = [:external, options]
+            end
+
+            # Store it!
+            @logger.info(" -- Slot #{slot}: #{data[0]}")
+            network_adapters_config[slot] = data
+          end
+
+          @logger.info("Determining adapters and compiling network configuration...")
+          adapters = []
+          networks = []
+          network_adapters_config.each do |slot, data|
+            type    = data[0]
+            options = data[1]
+
+            @logger.info("Network slot #{slot}. Type: #{type}.")
+
+            # Get the normalized configuration for this type
+            config = send("#{type}_config", options)
+            config[:adapter] = slot
+            @logger.debug("Normalized configuration: #{config.inspect}")
+
+            # Get the HyperV adapter configuration
+            adapter = send("#{type}_adapter", config)
+            adapters << adapter
+            @logger.debug("Adapter configuration: #{adapter.inspect}")
+
+            # Get the network configuration
+            network = send("#{type}_network_config", config)
+            network[:auto_config] = config[:auto_config]
+            networks << network
+          end
+
+          if !adapters.empty?
+            switches = env[:machine].provider.driver.execute("get_switches.ps1", {})
+            raise Errors::NoSwitches if switches.empty?
+
+            adapters.each do |adapter|
+              switchToFind = adapter[:intnet].downcase
+
+              if switchToFind
+                @logger.info("Looking for switch with name: #{switchToFind}")
+                switch = switches.find { |s| s["Name"].downcase == switchToFind.downcase }["Name"]
+                if switch
+                  @logger.info("Found switch: #{switch}")
+                else
+                  @logger.info("Unable to find switch: #{switch}")
+                  raise Errors::SwitchDoesNotExist,
+                    switch: switchToFind
+                end
+              end
+            end
+
+            # Enable the adapters
+            @logger.info("Enabling adapters...")
+            env[:ui].output(I18n.t("vagrant.actions.vm.network.preparing"))
+            adapters.each do |adapter|
+              env[:ui].detail(I18n.t(
+                "vagrant.virtualbox.network_adapter",
+                adapter: adapter[:adapter].to_s,
+                type: adapter[:type].to_s,
+                extra: "",
+              ))
+            end
+
+            env[:machine].provider.driver.enable_adapters(adapters)
+          end
+
+          # Continue the middleware chain.
+          
+          @app.call(env)
+
+          # If we have networks to configure, then we configure it now, since
+          # that requires the machine to be up and running.
+          if !adapters.empty? && !networks.empty?
+
+            assign_interface_numbers(networks, adapters)
+
+            # Only configure the networks the user requested us to configure
+            networks_to_configure = networks.select { |n| n[:auto_config] }
+            if !networks_to_configure.empty?
+              
+              env[:ui].info I18n.t("vagrant.actions.vm.network.configuring")
+              env[:machine].guest.capability(:configure_networks, networks_to_configure)
+            end
+          end
+        end
+
+        def external_config(options)
+          return {
+            :auto_config                     => false,
+            :bridge                          => nil,
+            :mac                             => nil,
+            :nic_type                        => nil,
+            :use_dhcp_assigned_default_route => false
+          }.merge(options || {})
+        end
+
+        def external_adapter(config)
+          intnet_name = config[:network_name]
+          intnet_name = "external" if intnet_name == true
+
+          # Given the choice we can now define the adapter we're using
+          return {
+            :adapter     => config[:adapter],
+            :type        => :bridged,
+            :mac_address => config[:mac],
+            :nic_type    => config[:nic_type],
+            :intnet => intnet_name,
+          }
+        end
+
+        def external_network_config(config)
+          if config[:ip] && (!config[:type] || config[:type] != :dhcp)
+            options = {
+                :auto_config => false,
+                :mac         => config[:mac],
+                :netmask     => "255.255.255.0",
+                :type        => :static
+            }.merge(config)
+            options[:type] = options[:type].to_sym
+            return options
+          end
+
+          return {
+            :type => :dhcp,
+            :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route]
+          }
+        end
+
+        def internal_config(options)
+          return {
+            :auto_config                     => true,
+            :bridge                          => nil,
+            :mac                             => nil,
+            :nic_type                        => nil,
+            :use_dhcp_assigned_default_route => false
+          }.merge(options || {})
+        end
+
+        def internal_adapter(config)
+          intnet_name = config[:network_name]
+          intnet_name = "internal" if intnet_name == true
+
+          # Given the choice we can now define the adapter we're using
+          return {
+            :adapter     => config[:adapter],
+            :type        => :static,
+            :mac_address => config[:mac],
+            :nic_type    => config[:nic_type],
+            :intnet => intnet_name,
+          }
+        end
+
+        def internal_network_config(config)
+          if config[:ip] && (!config[:type] || config[:type] != :dhcp)
+            options = {
+                :auto_config => true,
+                :mac         => config[:mac],
+                :netmask     => "255.255.255.0",
+                :type        => :static
+            }.merge(config)            
+            return options
+          end
+
+          return {
+            :type => :dhcp,
+            :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route]
+          }
+        end
+
+        def private_config(options)
+          return {
+            :type => "static",
+            :ip => nil,
+            :netmask => "255.255.255.0",
+            :adapter => nil,
+            :mac => nil,
+            :intnet => nil,
+            :auto_config => true
+          }.merge(options || {})
+        end
+
+        def private_adapter(config)
+          intnet_name = config[:network_name]
+          intnet_name = "private" if intnet_name == true
+
+          return {
+            :adapter => config[:adapter],
+            :type => config[:type].to_sym,
+            :mac_address => config[:mac],
+            :nic_type => config[:nic_type],
+            :intnet => intnet_name,
+          }
+        end
+
+        def private_network_config(config)
+          if config[:ip] && (!config[:type] || config[:type] != :dhcp)
+            options = {
+                :ip          => config[:ip],
+                :netmask     => config[:netmask],
+                :mac         => config[:mac],
+                :type        => :static
+            }.merge(config)
+            return options
+          end
+
+          return {
+            :type => :dhcp,
+            :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route]
+          }
+        end
+
+        def nat_config(options)
+          return {
+            :auto_config => false
+          }
+        end
+
+        def nat_adapter(config)
+          intnet_name = config[:network_name]
+          intnet_name = "nat" if intnet_name == true
+
+          return {
+            :adapter => config[:adapter],
+            :mac_address => config[:mac],
+            :type    => :nat,
+            :intnet => intnet_name,
+          }
+        end
+
+        def nat_network_config(config)
+          return {}
+        end
+
+        #-----------------------------------------------------------------
+        # Misc. helpers
+        #-----------------------------------------------------------------
+        # Assigns the actual interface number of a network based on the
+        # enabled NICs on the virtual machine.
+        #
+        # This interface number is used by the guest to configure the
+        # NIC on the guest VM.
+        #
+        # The networks are modified in place by adding an ":interface"
+        # field to each.
+        def assign_interface_numbers(networks, adapters)
+          current = 0
+          adapter_to_interface = {}
+
+          # Make a first pass to assign interface numbers by adapter location
+          vm_adapters = @env[:machine].provider.driver.read_network_interfaces
+          vm_adapters.sort.each do |number, adapter|
+            if adapter[:type] != :none
+              # Not used, so assign the interface number and increment
+              adapter_to_interface[number] = current
+              current += 1
+            end
+          end
+
+          # Make a pass through the adapters to assign the :interface
+          # key to each network configuration.
+          adapters.each_index do |i|
+            adapter = adapters[i]
+            network = networks[i]
+
+            # Figure out the interface number by simple lookup
+            network[:interface] = adapter_to_interface[adapter[:adapter]]
+          end
+        end
+
+        #-----------------------------------------------------------------
+        # Hostonly Helper Functions
+        #-----------------------------------------------------------------
+        # This creates a host only network for the given configuration.
+        def hostonly_create_network(config)
+          @env[:machine].provider.driver.create_host_only_network(
+            :adapter_ip => config[:adapter_ip],
+            :netmask    => config[:netmask]
+          )
+        end
+
+        # This finds a matching host only network for the given configuration.
+        def hostonly_find_matching_network(config)
+          this_netaddr = network_address(config[:ip], config[:netmask])
+
+          @env[:machine].provider.driver.read_host_only_interfaces.each do |interface|
+            return interface if config[:name] && config[:name] == interface[:name]
+            return interface if this_netaddr == \
+              network_address(interface[:ip], interface[:netmask])
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/action/read_guest_ip.rb
+++ b/plugins/providers/hyperv/action/read_guest_ip.rb
@@ -26,8 +26,7 @@ module VagrantPlugins
           begin
             Timeout.timeout(120) do
             begin
-              network_info  = env[:machine].provider.driver.read_guest_ip
-              host_ip = network_info["ip"]
+              host_ip = env[:machine].provider.driver.read_guest_ip[0]
               sleep 10 if host_ip.empty?
               end while host_ip.empty?
             end

--- a/plugins/providers/hyperv/action/wait_for_ip_address.rb
+++ b/plugins/providers/hyperv/action/wait_for_ip_address.rb
@@ -23,8 +23,7 @@ module VagrantPlugins
               return if env[:interrupted]
 
               # Try to get the IP
-              network_info = env[:machine].provider.driver.read_guest_ip
-              guest_ip = network_info["ip"]
+              guest_ip = env[:machine].provider.driver.read_guest_ip[0]
 
               if guest_ip
                 begin

--- a/plugins/providers/hyperv/cap/nic_mac_addresses.rb
+++ b/plugins/providers/hyperv/cap/nic_mac_addresses.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module HyperV
+    module Cap
+      module NicMacAddresses
+        def self.nic_mac_addresses(machine)
+          machine.provider.driver.read_mac_addresses
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -8,6 +8,12 @@ module VagrantPlugins
       #
       # @return [Integer]
       attr_accessor :ip_address_timeout
+      # The defined network adapters.
+      #
+      # @return [Hash]
+      attr_reader :network_adapters
+
+      attr_accessor :generation
       attr_accessor :memory
       attr_accessor :maxmemory
       attr_accessor :cpus
@@ -15,11 +21,25 @@ module VagrantPlugins
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
+        @network_adapters = {}
+        @generation = "1"
         @memory = UNSET_VALUE
         @maxmemory = UNSET_VALUE
         @cpus = UNSET_VALUE
         @vmname = UNSET_VALUE
+
+        # We require that network adapter 1 is a NAT device.
+        network_adapter(1, :nat)
       end
+
+       # This defines a network adapter that will be added to the VirtualBox
+      # virtual machine in the given slot.
+      #
+      # @param [Integer] slot The slot for this network adapter.
+      # @param [Symbol] type The type of adapter.
+      def network_adapter(slot, type, **opts)
+        @network_adapters[slot] = [type, opts]
+       end
 
       def finalize!
         if @ip_address_timeout == UNSET_VALUE

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -49,33 +49,73 @@ module VagrantPlugins
         execute('get_vm_status.ps1', { VmId: vm_id })
       end
 
-       def delete_vm
-         execute('delete_vm.ps1', { VmId: vm_id })
-       end
+      def delete_vm
+        execute('delete_vm.ps1', { VmId: vm_id })
+      end
 
-       def read_guest_ip
-         execute('get_network_config.ps1', { VmId: vm_id })
-       end
+      def read_guest_ip
+        execute('get_network_config.ps1', { VmId: vm_id })
+      end
 
-       def resume
-         execute('resume_vm.ps1', { VmId: vm_id })
-       end
+      def resume
+        execute('resume_vm.ps1', { VmId: vm_id })
+      end
 
-       def start
-         execute('start_vm.ps1', { VmId: vm_id })
-       end
+      def start
+        execute('start_vm.ps1', { VmId: vm_id })
+      end
 
-       def stop
-         execute('stop_vm.ps1', { VmId: vm_id })
-       end
+      def stop
+        execute('stop_vm.ps1', { VmId: vm_id })
+      end
 
-       def suspend
-         execute("suspend_vm.ps1", { VmId: vm_id })
-       end
+      def suspend
+        execute("suspend_vm.ps1", { VmId: vm_id })
+      end
 
-       def import(options)
-         execute('import_vm.ps1', options)
-       end
+      def import(options)
+        execute('import_vm.ps1', options)
+      end
+
+      def enable_adapters(adapters)
+        nics = {}
+        nics[:VmId] = vm_id
+        nics[:Adapters] = adapters.to_json.gsub('"', '\"')
+
+        execute("enable_adapters.ps1", nics)
+      end
+
+      def read_network_interfaces
+        nics = {}
+        info = execute('get_network_interfaces.ps1', { VmId: vm_id })
+        info.each_with_index do |nic, index|
+            adapter = index + 1
+
+            nics[adapter] ||= {}
+            nics[adapter][:network_name] = nic["SwitchName"]
+            nics[adapter][:mac_address] = nic["MacAddress"]
+            nics[adapter][:id] = nic["Id"]
+        end
+
+        nics
+      end
+
+      # Share a set of folders on this VM.
+      #
+      # @param [Array<Hash>] folders
+      def share_folders(folders)
+      end
+
+      def read_mac_addresses
+        nics = {}
+        info = execute('get_network_interfaces.ps1', { VmId: vm_id })
+        info.each_with_index do |nic, index|
+            adapter = index + 1
+
+            nics[adapter] = nic["MacAddress"].gsub(":", "")
+        end
+        nics
+      end
 
       protected
 
@@ -86,7 +126,7 @@ module VagrantPlugins
         ps_options = []
         options.each do |key, value|
           ps_options << "-#{key}"
-          ps_options << "'#{value}'"
+          ps_options << "#{value}"
         end
 
         # Always have a stop error action for failures

--- a/plugins/providers/hyperv/errors.rb
+++ b/plugins/providers/hyperv/errors.rb
@@ -22,6 +22,10 @@ module VagrantPlugins
         error_key(:no_switches)
       end
 
+      class SwitchDoesNotExist < HyperVError
+        error_key(:switch_does_not_exist)
+      end
+
       class PowerShellFeaturesDisabled < HyperVError
         error_key(:powershell_features_disabled)
       end

--- a/plugins/providers/hyperv/plugin.rb
+++ b/plugins/providers/hyperv/plugin.rb
@@ -27,6 +27,11 @@ module VagrantPlugins
         Cap::PublicAddress
       end
 
+      provider_capability("hyperv", "nic_mac_addresses") do
+        require_relative "cap/nic_mac_addresses"
+        Cap::NicMacAddresses
+      end
+
       protected
 
       def self.init!

--- a/plugins/providers/hyperv/provider.rb
+++ b/plugins/providers/hyperv/provider.rb
@@ -86,12 +86,12 @@ module VagrantPlugins
         return nil if state.id != :running
 
         # Read the IP of the machine using Hyper-V APIs
-        network = @driver.read_guest_ip
-        return nil if !network["ip"]
+        ip = @driver.read_guest_ip[0]
 
+        return nil if !ip
         {
-          host: network["ip"],
-          port: 22,
+          host: ip,
+          port: @machine.config.ssh.guest_port
         }
       end
     end

--- a/plugins/providers/hyperv/scripts/enable_adapters.ps1
+++ b/plugins/providers/hyperv/scripts/enable_adapters.ps1
@@ -1,0 +1,66 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$VmId = $(throw "-VmId is required."),
+    [Parameter(Mandatory=$true)]
+    $adapters
+ )
+
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+if(!$adapters) {
+    Write-Error-Message "No adapters specified"
+} else {
+    $adapters = $adapters | ConvertFrom-Json
+}
+
+if ($adapters.length -gt 0){
+    $vm = Get-VM -Id $VmId -ErrorAction "Stop"
+    Stop-VM $vm -Force
+
+    $installedAdapters = Get-VMNetworkAdapter -VM $vm
+
+    $adapterInstance = 0
+    $installedAdapters | %{
+        $adapterInstance = $adapterInstance + 1
+        $installedAdapter = $_
+        if ($adapterInstance -gt $adapters.length){
+            #Write-Output-Message "Removing adapter $adapterInstance - $($installedAdapter.MacAddress)"
+            Remove-VMNetworkAdapter $vm -VMNetworkAdapterName $_.Name
+        } 
+    } 
+
+    $adapterInstance = 0
+    $adapters | Sort-Object adapter | %{
+        $adapterInstance = $adapterInstance + 1
+        $installedAdapter = $installedAdapters[$adapterInstance-1]
+        $macAddress = $_.mac_address
+        $switchname = $_.intnet
+
+        if ($installedAdapter){
+            if ($macAddress){
+                #Write-Output-Message "Configuring adapter - $($installedAdapter.MacAddress) for switch $switchname"
+                Set-VMNetworkAdapter -VMNetworkAdapter $installedAdapter -StaticMacAddress $macAddress
+                Connect-VMNetworkAdapter -VMNetworkAdapter $installedAdapter -SwitchName $switchname
+            } else {
+                #Write-Output-Message "Configuring adapter - dynamic mac address for switch $switchname"
+                Set-VMNetworkAdapter -VMNetworkAdapter $installedAdapter -DynamicMacAddress
+                Connect-VMNetworkAdapter -VMNetworkAdapter $installedAdapter -SwitchName $switchname
+            }
+        } else {
+            if ($macAddress){
+                #Write-Output-Message "Adding adapter - $macAddress"
+                Add-VMNetworkAdapter $vm -SwitchName $switchname -StaticMacAddress $macAddress
+            } else {
+                #Write-Output-Message "Adding adapter - dynamic mac address"
+                Add-VMNetworkAdapter $vm -SwitchName $switchname -DynamicMacAddress
+            }
+        }
+    }
+}
+$resultHash = @{
+  message = "OK"
+}
+$result = ConvertTo-Json $resultHash
+Write-Output-Message $result

--- a/plugins/providers/hyperv/scripts/get_network_interfaces.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_interfaces.ps1
@@ -8,15 +8,7 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
 $vm = Get-VM -Id $VmId -ErrorAction "Stop"
-$networks = Get-VMNetworkAdapter -VM $vm
+$network = Get-VMNetworkAdapter -VM $vm
 
-$results = @()
-
-$networks | %{
-    $_.IpAddresses | %{
-        $results += $_
-    }
-}
-
-$result = ConvertTo-Json $results
+$result = ConvertTo-Json $network
 Write-Output-Message $result

--- a/plugins/synced_folders/smb/scripts/host_info.ps1
+++ b/plugins/synced_folders/smb/scripts/host_info.ps1
@@ -1,8 +1,9 @@
 $ErrorAction = "Stop"
 
-$net = Get-NetIPAddress | Where-Object {($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")}
+$ipAddresses = Get-NetIPAddress | Where-Object {($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1") -and (!$_.IPAddress.StartsWith("169.254."))} | Sort-Object -Property AddressFamily, InterfaceIndex | %{ ($_.IpAddress -split '%')[0]}
+
 $result = @{
-	ip_addresses = $net.IPAddress
+	ip_addresses = $ipAddresses
 }
 
 Write-Output $(ConvertTo-Json $result)

--- a/plugins/synced_folders/smb/scripts/remove_share.ps1
+++ b/plugins/synced_folders/smb/scripts/remove_share.ps1
@@ -1,0 +1,18 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$share_name
+)
+
+Write-Host "Delete share $share_name"
+
+$ErrorAction = "Stop"
+
+$result = net share "$share_name"
+if ($LastExitCode -eq 0) {
+    $result = net share "$share_name" /delete /y
+
+    if ($LastExitCode -ne 0) {
+        $host.ui.WriteErrorLine("Error: $result")
+        exit 1
+    }
+}

--- a/plugins/synced_folders/smb/scripts/set_share.ps1
+++ b/plugins/synced_folders/smb/scripts/set_share.ps1
@@ -8,8 +8,13 @@ Param(
 
 $ErrorAction = "Stop"
 
-if (net share | Select-String $share_name) {
-  net share $share_name /delete /y
+$result = net share "$share_name"
+if ($LastExitCode -eq 0) {
+    $result = net share "$share_name" /delete /y
+
+    if ($LastExitCode -ne 0) {
+        exit $LastExitCode
+    }
 }
 
 # The names of the user are language dependent!
@@ -35,7 +40,7 @@ if (![string]::IsNullOrEmpty($host_share_username)) {
     #>
 }
 
-$result = net share $share_name=$path /unlimited /GRANT:$grant
+$result = net share "$share_name=$path" /unlimited "/GRANT:$grant"
 if ($LastExitCode -eq 0) {
     exit 0
 }

--- a/templates/locales/providers_hyperv.yml
+++ b/templates/locales/providers_hyperv.yml
@@ -51,6 +51,15 @@ en:
 
         For more help, please see the documentation on the Vagrant website
         for Hyper-V.
+      switch_does_not_exist: |-
+        There are no virtual switch named ('%{switch}') for Hyper-V! Please 
+        open the Hyper-V Manager, go to the "Virtual Switch Manager", and 
+        create it.
+
+        A virtual switch is required for each adapter.
+
+        For more help, please see the documentation on the Vagrant website
+        for Hyper-V.
       powershell_features_disabled: |-
         The Hyper-V cmdlets for PowerShell are not available! Vagrant
         requires these to control Hyper-V. Please enable them in the


### PR DESCRIPTION
Support for configuring network adapters for Hyper v by specifying the switch to use
Reconfigure network adapters based on configuration (not only at import time)
Better naming convention for duplicate machine names for Hyper v
Add support for different versions of Hyper V generation
Make detection of addressable ip addresses a little smarter
Can specify username and password for shared folder support
Add support for detecting nic mac addresses
Do not return 169.254.0.0 addresses for addressable addresses
Return ipv6 without scope id (ruby does not like it)
Remove shares when they are not used anymore