### PR TITLE
Escape/unescape cURL URLs/auth

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -27,10 +27,10 @@ module Vagrant
         @destination = destination.to_s
 
         begin
-          url = URI.parse(@source)
+          url = URI.parse(URI.escape(@source))
           if url.scheme && url.scheme.start_with?("http") && url.user
-            auth = "#{url.user}"
-            auth += ":#{url.password}" if url.password
+            auth = "#{URI.unescape(url.user)}"
+            auth += ":#{URI.unescape(url.password)}" if url.password
             url.user = nil
             url.password = nil
             options[:auth] ||= auth


### PR DESCRIPTION
Goal is to enable passwords with special characters to be used.

Escape special characters in URL provided before parsing with `URI.parse`, then unescape them again in the authentication details.