### PR TITLE
Add missing word to output of "vagrant up"

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1699,7 +1699,7 @@ en:
             Machine not provisioning because `--no-provision` is specified.
           disabled_by_sentinel: |-
             Machine already provisioned. Run `vagrant provision` or use the `--provision`
-            to force provisioning. Provisioners marked to run always will still run.
+            flag to force provisioning. Provisioners marked to run always will still run.
         resume:
           resuming: Resuming suspended VM...
           unpausing: |-


### PR DESCRIPTION
Add the word `flag` to the phrase `or use the '--provision' flag`, which is displayed when `vagrant up` is run for a VM that's already been provisioned.