### PR TITLE
Remove docker0 from guest network interface enumeration

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
           end
 
           if virtual
-            machine.communicate.sudo("ls /sys/class/net | grep -v lo") do |_, result|
+            machine.communicate.sudo("ls /sys/class/net | egrep -v lo\\|docker") do |_, result|
               interface_names = result.split("\n")
             end
 


### PR DESCRIPTION
Using vagrant-libvirt, setting a fixed interface IP address fails if the guest VM runs RHEL7 or Fedora and has a docker0 interface.

The symptom is that **eth0** is brought up successfully for management, Vagrant connects in via ssh, then **eth1** fixed IP configuration is erroneously written to /etc/sysconfig/network-scripts/ifcfg-**eth0**. Then eth0 is bounced (incorrectly) and the "up" process hangs.

The fault occurs because 'docker0' is not removed from this network interface enumeration, causing a subsequent off-by-one error. The fault was probably introduced (inadvertently) in commit 55a90445cdfc290d4a1f68c66835c0249ca59cdd.