### PR TITLE
fedora: don't try to use biosdevname if it's not installed

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           virtual = false
           interface_names = Array.new
           machine.communicate.sudo("/usr/sbin/biosdevname; echo $?") do |_, result|
-            virtual = true if result.chomp == '4'
+            virtual = true if ['4', '127'].include? result.chomp
           end
 
           if virtual


### PR DESCRIPTION
If biosdevname isn't installed it doesn't make sense to try using it
for persistent device names.  Just treat lack of biosdevname as
virtual networking.