### PR TITLE
Fix Vagrantfile to develop Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,9 @@
 # Ruby, run unit tests, etc.
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "vagrant"
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
   ["vmware_fusion", "vmware_workstation", "virtualbox"].each do |provider|
     config.vm.provider provider do |v, override|
@@ -24,6 +26,7 @@ Vagrant.configure("2") do |config|
 end
 
 $shell = <<-CONTENTS
+export DEBIAN_FRONTEND=noninteractive
 MARKER_FILE="/usr/local/etc/vagrant_provision_marker"
 
 # Only provision once
@@ -37,8 +40,11 @@ apt-get update
 # Install basic dependencies
 apt-get install -y build-essential bsdtar curl
 
+# Import the mpapis public key to verify downloaded releases
+su -l -c 'curl -sSL https://rvm.io/mpapis.asc | gpg -q --import -' vagrant
+
 # Install RVM
-su -l -c 'curl -L https://get.rvm.io | bash -s stable' vagrant
+su -l -c 'curl -sL https://get.rvm.io | bash -s stable' vagrant
 
 # Add the vagrant user to the RVM group
 #usermod -a -G rvm vagrant


### PR DESCRIPTION
This fixes the following issues when using the provided Vagrantfile
that can be used to develop Vagrant.

* use -s for curl

* set a hostname

* set the config.ssh.shell in the development Vagrantfile

==> default: stdin: is not a tty

* export the DEBIAN_FRONTEND variable

==> default: dpkg-preconfigure: unable to re-open stdin: No such file or
directory

* import the mpapis public key to verify downloaded release

==> default: -su: rvm: command not found

* use official Ubuntu Trusty box

New release '14.04.2 LTS' available.