### PR TITLE
Recognize new Fedora releases

### DIFF
--- a/plugins/guests/fedora/guest.rb
+++ b/plugins/guests/fedora/guest.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module GuestFedora
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("grep 'Fedora release [12][678901]' /etc/redhat-release")
+        machine.communicate.test("grep 'Fedora release 1[6789]\\|Fedora release 2[0-9]' /etc/redhat-release")
       end
     end
   end


### PR DESCRIPTION
With Fedora 22 to be released and Fedora 23 in development, let's fix the Fedora recognition pattern for Fedora future releases.