### PR TITLE
Fix RHEL name and description

### DIFF
--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -3,8 +3,8 @@ require "vagrant"
 module VagrantPlugins
   module GuestRedHat
     class Plugin < Vagrant.plugin("2")
-      name "RedHat guest"
-      description "RedHat guest support."
+      name "Red Hat Enterprise Linux guest"
+      description "Red Hat Enterprise Linux guest support."
 
       guest("redhat", "linux") do
         require File.expand_path("../guest", __FILE__)

--- a/plugins/hosts/redhat/plugin.rb
+++ b/plugins/hosts/redhat/plugin.rb
@@ -3,8 +3,8 @@ require "vagrant"
 module VagrantPlugins
   module HostRedHat
     class Plugin < Vagrant.plugin("2")
-      name "Red Hat host"
-      description "Red Hat host support."
+      name "Red Hat Enterprise Linux host"
+      description "Red Hat Enterprise Linux host support."
 
       host("redhat", "linux") do
         require File.expand_path("../host", __FILE__)


### PR DESCRIPTION
Red Hat Linux no longer exists, so let's make it RHEL.