### PR TITLE
Update dependency to allow most recent bundler version

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", ">= 1.5.2", "< 1.8.0"
+  s.add_dependency "bundler", ">= 1.5.2", "<= 1.9.9"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"


### PR DESCRIPTION
Making changes to vagrant.gemspec to allow successful execution of 'bundler install' with the latest version of bundler (version 1.9.9)

Changed from "< 1.8.0" to "<= 1.9.9"