### PR TITLE
Use latest winrm-fs release

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rest-client", ">= 1.6.0", "< 2.0"
   s.add_dependency "wdm", "~> 0.1.0"
   s.add_dependency "winrm", "~> 1.3"
-  s.add_dependency "winrm-fs", "~> 0.1.0"
+  s.add_dependency "winrm-fs", "~> 0.2.0"
 
   # We lock this down to avoid compilation issues.
   s.add_dependency "nokogiri", "= 1.6.3.1"


### PR DESCRIPTION
[winrm-fs 0.2.0](https://github.com/WinRb/winrm-fs/blob/master/changelog.md#020) is a bit more polished, Vagrant should use it.