### PR TITLE
Fix ansible with vagrant-libvirt and machines without ip

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -116,7 +116,11 @@ module VagrantPlugins
           @machine.env.active_machines.each do |am|
             begin
               m = @machine.env.machine(*am)
-              m_ssh_info = m.ssh_info
+              begin
+                m_ssh_info = m.ssh_info
+              rescue => e
+                @logger.error(e)
+              end
               if !m_ssh_info.nil?
                 file.write("#{m.name} ansible_ssh_host=#{m_ssh_info[:host]} ansible_ssh_port=#{m_ssh_info[:port]}\n")
                 inventory_machines[m.name] = m


### PR DESCRIPTION
The vagrant-libvirt raises an exception when trying to get an ssh_info for a
machine without an ip address. We just want to skip the machine that produces 
error on getting the ssh_info.