### PR TITLE
Capability to mount smb shares in darwin guests

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -316,6 +316,10 @@ module Vagrant
       error_key(:corrupt_machine_index)
     end
 
+    class DarwinMountFailed < VagrantError
+      error_key(:darwin_mount_failed)
+    end
+
     class DarwinNFSMountFailed < VagrantError
       error_key(:darwin_nfs_mount_failed)
     end

--- a/plugins/guests/darwin/cap/choose_addressable_ip_addr.rb
+++ b/plugins/guests/darwin/cap/choose_addressable_ip_addr.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module GuestDarwin
+    module Cap
+      module ChooseAddressableIPAddr
+        def self.choose_addressable_ip_addr(machine, possible)
+          machine.communicate.tap do |comm|
+            possible.each do |ip|
+              command = "ping -c1 -t1 #{ip}"
+              if comm.test(command)
+                return ip
+              end
+            end
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
@@ -8,16 +8,24 @@ module VagrantPlugins
         extend Vagrant::Util::Retryable
         def self.mount_smb_shared_folder(machine, name, guestpath, options)
           expanded_guest_path = machine.guest.capability(:shell_expand_guest_path, guestpath)
-          machine.communicate.execute("mkdir -p #{expanded_guest_path}")
+
+          mount_point_owner = options[:owner];
+          if mount_point_owner
+            machine.communicate.sudo("mkdir -p #{expanded_guest_path}")
+            machine.communicate.sudo("chown #{mount_point_owner} #{expanded_guest_path}")
+          else
+            # fallback to assumption that user has permission
+            # to create the specified mountpoint
+            machine.communicate.execute("mkdir -p #{expanded_guest_path}")
+          end
 
           smb_password = Shellwords.shellescape(options[:smb_password])
           mount_options = options[:mount_options];
-
           mount_command = "mount -t smbfs " +
             (mount_options ? "-o '#{mount_options.join(",")}' " : "") +
             "'//#{options[:smb_username]}:#{smb_password}@#{options[:smb_host]}/#{name}' " +
             "#{expanded_guest_path}"
-          retryable(on: Vagrant::Errors::DarwinMountFailed, tries: 10, sleep: 5) do 
+          retryable(on: Vagrant::Errors::DarwinMountFailed, tries: 10, sleep: 2) do
             machine.communicate.execute(
               mount_command,
               error_class: Vagrant::Errors::DarwinMountFailed)

--- a/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
             "'//#{options[:smb_username]}:#{smb_password}@#{options[:smb_host]}/#{name}' " +
             "#{expanded_guest_path}"
           retryable(on: Vagrant::Errors::DarwinMountFailed, tries: 10, sleep: 5) do 
-            machine.communicate.sudo(
+            machine.communicate.execute(
               mount_command,
               error_class: Vagrant::Errors::DarwinMountFailed)
           end

--- a/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
@@ -1,0 +1,29 @@
+require "vagrant/util/retryable"
+require "shellwords"
+
+module VagrantPlugins
+  module GuestDarwin
+    module Cap
+      class MountSMBSharedFolder
+        extend Vagrant::Util::Retryable
+        def self.mount_smb_shared_folder(machine, name, guestpath, options)
+          expanded_guest_path = machine.guest.capability(:shell_expand_guest_path, guestpath)
+          machine.communicate.execute("mkdir -p #{expanded_guest_path}")
+
+          smb_password = Shellwords.shellescape(options[:smb_password])
+          mount_options = options[:mount_options];
+
+          mount_command = "mount -t smbfs " +
+            (mount_options ? "-o '#{mount_options.join(",")}' " : "") +
+            "'//#{options[:smb_username]}:#{smb_password}@#{options[:smb_host]}/#{name}' " +
+            "#{expanded_guest_path}"
+          retryable(on: Vagrant::Errors::DarwinMountFailed, tries: 10, sleep: 5) do 
+            machine.communicate.sudo(
+              mount_command,
+              error_class: Vagrant::Errors::DarwinMountFailed)
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/darwin/plugin.rb
+++ b/plugins/guests/darwin/plugin.rb
@@ -16,6 +16,11 @@ module VagrantPlugins
         Cap::ChangeHostName
       end
 
+      guest_capability("darwin", "choose_addressable_ip_addr") do
+        require_relative "cap/choose_addressable_ip_addr"
+        Cap::ChooseAddressableIPAddr
+      end
+
       guest_capability("darwin", "configure_networks") do
         require_relative "cap/configure_networks"
         Cap::ConfigureNetworks
@@ -34,6 +39,11 @@ module VagrantPlugins
       guest_capability("darwin", "mount_nfs_folder") do
         require_relative "cap/mount_nfs_folder"
         Cap::MountNFSFolder
+      end
+
+      guest_capability("darwin", "mount_smb_shared_folder") do
+        require_relative "cap/mount_smb_shared_folder"
+        Cap::MountSMBSharedFolder
       end
 
       guest_capability("darwin", "mount_vmware_shared_folder") do


### PR DESCRIPTION
This integrates a simple [plugin](https://github.com/alh84001/vagrant-darwin-smb) I wrote that enables mounting SMB shares in OSX boxes.

In addition to `mount_smb_shared_folder` capability, `choose_addressable_ip_addr` capability is also added.

Related issue I opened some time ago:
https://github.com/mitchellh/vagrant/issues/5392