### PR TITLE
Fix #5673 - Use hostnamectl to set the hostname on Ubuntu Vivid 15.

### DIFF
--- a/plugins/guests/ubuntu/cap/change_host_name.rb
+++ b/plugins/guests/ubuntu/cap/change_host_name.rb
@@ -6,21 +6,38 @@ module VagrantPlugins
           super
         end
 
+        def update_etc_hostname
+          super unless vivid?
+          sudo("hostnamectl set-hostname '#{short_hostname}'")
+        end
+
         def refresh_hostname_service
           if hardy?
             # hostname.sh returns 1, so use `true` to get a 0 exitcode
             sudo("/etc/init.d/hostname.sh start; true")
+          elsif vivid?
+            # Service runs via hostnamectl
           else
             sudo("service hostname start")
           end
         end
 
         def hardy?
-          machine.communicate.test("[ `lsb_release -c -s` = hardy ]")
+          os_version("hardy")
+        end
+
+        def vivid?
+          os_version("vivid")
         end
 
         def renew_dhcp
           sudo("ifdown -a; ifup -a; ifup -a --allow=hotplug")
+        end
+
+      private
+
+        def os_version(name)
+          machine.communicate.test("[ `lsb_release -c -s` = #{name} ]")
         end
       end
     end


### PR DESCRIPTION
Resolves #5673.