### PR TITLE
Allow vagrant ssh-config with a halted VM

### DIFF
--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -56,9 +56,6 @@ module VagrantPlugins
 
       # Returns the SSH info for accessing the VirtualBox VM.
       def ssh_info
-        # If the VM is not running that we can't possibly SSH into it
-        return nil if state.id != :running
-
         # Return what we know. The host is always "127.0.0.1" because
         # VirtualBox VMs are always local. The port we try to discover
         # by reading the forwarded ports.


### PR DESCRIPTION
Allow vagrant ssh-config on a halted VM on virtualbox : https://github.com/github/hub/issues/910

If the VM is not running, the vagrant ssh command already protects the user from trying to connect, so this won't lead to an unexpected error.