### PR TITLE
aufs is optional, if docker can't get it press on

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
             machine.communicate.tap do |comm|
               # TODO: Perform check on the host machine if aufs is installed and using LXC
               if machine.provider_name != :lxc
-                comm.sudo("lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r`")
+                comm.sudo("lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r` || true")
               end
               comm.sudo("apt-get update -y")
               comm.sudo("apt-get install -y --force-yes -q curl")


### PR DESCRIPTION
Per https://github.com/mitchellh/vagrant/issues/5697#issuecomment-100581277, addresses https://github.com/mitchellh/vagrant/issues/5697 by not requiring success from `apt-get install linux-image-extra-*`.

This issue was also brought up on the Linode provider https://github.com/displague/vagrant-linode/issues/27