### PR TITLE
prefer ipv4 host address over ipv6 for smb synced folders

### DIFF
--- a/plugins/synced_folders/smb/scripts/host_info.ps1
+++ b/plugins/synced_folders/smb/scripts/host_info.ps1
@@ -1,6 +1,9 @@
 $ErrorAction = "Stop"
 
-$net = Get-NetIPAddress | Where-Object {($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")}
+$net = Get-NetIPAddress | Where-Object {
+    ($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")
+} | Sort-Object $_.AddressFamily
+
 $result = @{
 	ip_addresses = $net.IPAddress
 }


### PR DESCRIPTION
fixes #5797 This sorts the ips by `AddressFamily` returning ipv4 first.