### PR TITLE
Fix #5143 VBoxManage error on 'vagrant destroy'

### DIFF
--- a/lib/vagrant/action/builtin/synced_folders.rb
+++ b/lib/vagrant/action/builtin/synced_folders.rb
@@ -74,15 +74,20 @@ module Vagrant
             [instance, impl_name, fs]
           end
 
-          # Go through each folder and prepare the folders
-          folders.each do |impl, impl_name, fs|
-            @logger.info("Invoking synced folder prepare for: #{impl_name}")
-            impl.prepare(env[:machine], fs, impl_opts(impl_name, env))
-          end
+          @logger.debug("Checking if we have to prepare synced folders...")
+          if !env[:synced_folders_disable]
+            @logger.debug("Preparation is required, preparing")
+           # Go through each folder and prepare the folders
+            folders.each do |impl, impl_name, fs|
+              @logger.info("Invoking synced folder prepare for: #{impl_name}")
+              impl.prepare(env[:machine], fs, impl_opts(impl_name, env))
+            end
 
-          # Continue, we need the VM to be booted.
-          @app.call(env)
-
+            # Continue, we need the VM to be booted.
+            @app.call(env)
+         end
+         
+         @logger.debug("Checking if we have synced folders to enable")
           # Once booted, setup the folder contents
           folders.each do |impl, impl_name, fs|
             if !env[:synced_folders_disable]
@@ -92,9 +97,11 @@ module Vagrant
             end
 
             # We're disabling synced folders
+             @logger.debug("Checking if we have synced folders to disable")
             to_disable = {}
             fs.each do |id, data|
               next if !env[:synced_folders_disable].include?(id)
+              @logger.debug("Will disable #{id}")
               to_disable[id] = data
             end
 

--- a/plugins/providers/docker/action/host_machine_sync_folders_disable.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders_disable.rb
@@ -19,13 +19,11 @@ module VagrantPlugins
 
           # Read our random ID for this instance
           id_path   = env[:machine].data_dir.join("host_machine_sfid")
+          @logger.debug("Docker host id_path: #{id_path}")
           return @app.call(env) if !id_path.file?
           host_sfid = id_path.read.chomp
 
           host_machine = env[:machine].provider.host_vm
-
-          @app.call(env)
-
           begin
             env[:machine].provider.host_vm_lock do
               setup_synced_folders(host_machine, host_sfid, env)
@@ -40,7 +38,6 @@ module VagrantPlugins
 
         def setup_synced_folders(host_machine, host_sfid, env)
           to_disable = []
-
           # Read the existing folders that are setup
           existing_folders = synced_folders(host_machine, cached: true)
           if existing_folders
@@ -48,6 +45,7 @@ module VagrantPlugins
               fs.each do |id, data|
                 if data[:docker_host_sfid] == host_sfid
                   to_disable << id
+                  @logger.debug("Folder #{id} will be disabled")
                 end
               end
             end

--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -1,9 +1,6 @@
 require "forwardable"
-
 require "log4r"
-
 require "vagrant/util/retryable"
-
 require File.expand_path("../base", __FILE__)
 
 module VagrantPlugins
@@ -37,9 +34,9 @@ module VagrantPlugins
           begin
             @version = read_version || ""
           rescue Vagrant::Errors::CommandUnavailable,
-            Vagrant::Errors::CommandUnavailableWindows
-            # This means that VirtualBox was not found, so we raise this
-            # error here.
+          Vagrant::Errors::CommandUnavailableWindows
+          # This means that VirtualBox was not found, so we raise this
+          # error here.
             raise Vagrant::Errors::VirtualBoxNotDetected
           end
 
@@ -80,6 +77,10 @@ module VagrantPlugins
             # about it (mark the UUID as nil)
             raise VMNotFound if !@driver.vm_exists?(@uuid)
           end
+        end
+
+        def getDriver
+          return @driver
         end
 
         def_delegators :@driver, :clear_forwarded_ports,
@@ -141,7 +142,7 @@ module VagrantPlugins
           retryable(on: Vagrant::Errors::VirtualBoxVersionEmpty, tries: 3, sleep: 1) do
             output = execute("--version")
             if output =~ /vboxdrv kernel module is not loaded/ ||
-              output =~ /VirtualBox kernel modules are not loaded/i
+            output =~ /VirtualBox kernel modules are not loaded/i
               raise Vagrant::Errors::VirtualBoxKernelModuleNotLoaded
             elsif output =~ /Please install/
               # Check for installation incomplete warnings, for example:

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -553,6 +553,7 @@ module VagrantPlugins
         def unshare_folders(names)
           names.each do |name|
             begin
+              @logger.debug("Unsharing folder #{name}")
               execute(
                 "sharedfolder", "remove", @uuid,
                 "--name", name,

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -81,7 +81,7 @@ module VagrantPlugins
 
       # This is here so that we can stub it for tests
       def driver(machine)
-        machine.provider.driver
+        machine.provider.driver.getDriver
       end
 
       def os_friendly_id(id)

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -70,11 +70,11 @@ module VagrantPlugins
 
         # Remove the shared folders from the VM metadata
         names = folders.map { |id, _data| os_friendly_id(id) }
-        driver(machine).unshare_folders(names)
+		driver(machine).unshare_folders(names)
       end
 
       def cleanup(machine, opts)
-        driver(machine).clear_shared_folders if machine.id && machine.id != ""
+    		driver(machine).clear_shared_folders if machine.id && machine.id != ""
       end
 
       protected


### PR DESCRIPTION
VirtualBox provider tried to add synced folders when destroying a docker container running inside the vm causing an error due to machine locks. Added a check if we are destroying before trying to create synced folders. 

Also, for removing synced folders (without destroying the VM), the VirtualBox provider seems to have tried to use the meta driver instead of retrieving the actual driver for VBox version used from it. Fixed that, too.

cc @svogt