### PR TITLE
Add Atomic guest support

### DIFF
--- a/plugins/guests/atomic/cap/change_host_name.rb
+++ b/plugins/guests/atomic/cap/change_host_name.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module GuestAtomic
+    module Cap
+      class ChangeHostName
+        def self.change_host_name(machine, name)
+          machine.communicate.sudo("hostnamectl set-hostname #{name}")
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/atomic/cap/docker.rb
+++ b/plugins/guests/atomic/cap/docker.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module GuestAtomic
+    module Cap
+      module Docker
+        def self.docker_daemon_running(machine)
+          machine.communicate.test("test -S /run/docker.sock")
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/atomic/guest.rb
+++ b/plugins/guests/atomic/guest.rb
@@ -1,0 +1,11 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestAtomic
+    class Guest < Vagrant.plugin("2", :guest)
+      def detect?(machine)
+        machine.communicate.test("grep 'ostree=' /proc/cmdline")
+      end
+    end
+  end
+end

--- a/plugins/guests/atomic/plugin.rb
+++ b/plugins/guests/atomic/plugin.rb
@@ -1,0 +1,25 @@
+require 'vagrant'
+
+module VagrantPlugins
+  module GuestAtomic
+    class Plugin < Vagrant.plugin("2")
+      name "Atomic Host guest"
+      description "Atomic Host guest support."
+
+      guest("atomic", "fedora") do
+        require File.expand_path("../guest", __FILE__)
+        Guest
+      end
+
+      guest_capability("atomic", "change_host_name") do
+        require_relative "cap/change_host_name"
+        Cap::ChangeHostName
+      end
+
+      guest_capability("atomic", "docker_daemon_running") do
+        require_relative "cap/docker"
+        Cap::Docker
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new guest to Vagrant: Atomic.

More info on Atomic: http://www.projectatomic.io/
Rationale on why this is a guest and not flavour: https://github.com/projectatomic/vagrant-atomic/issues/5

Note that this was already released as a vagrant-atomic plugin[0], but we would like to have this in Vagrant itself.

[0] https://github.com/projectatomic/vagrant-atomic/