### PR TITLE
Start required NFS services on Fedora guests

### DIFF
--- a/plugins/guests/fedora/cap/nfs_client.rb
+++ b/plugins/guests/fedora/cap/nfs_client.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
       class NFSClient
         def self.nfs_client_install(machine)
           machine.communicate.sudo("yum -y install nfs-utils nfs-utils-lib")
+          machine.communicate.sudo("/bin/systemctl restart rpcbind nfs")
         end
       end
     end


### PR DESCRIPTION
@sethvargo This pull https://github.com/mitchellh/vagrant/pull/5770 does not contain the call to start the necessary services for NFS, so it still does not work out of the box. This fixed the issue for me.