### PR TITLE
[Fix] Docker Provisioner fails on Debian [ubuntu/trusty64]

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -8,11 +8,11 @@ module VagrantPlugins
             package << "-#{version}" if version != :latest
 
             machine.communicate.tap do |comm|
+              comm.sudo("apt-get update -y")
               # TODO: Perform check on the host machine if aufs is installed and using LXC
               if machine.provider_name != :lxc
                 comm.sudo("lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r`")
               end
-              comm.sudo("apt-get update -y")
               comm.sudo("apt-get install -y --force-yes -q curl")
               comm.sudo("curl -sSL https://get.docker.com/gpg | apt-key add -")
               comm.sudo("echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list")


### PR DESCRIPTION
Depending if a Debian system is up to date or not, Docker install will fail because it may try to install an invalid linux-image-extra- kernel package url.

Fix is to do update before trying to install anything.

--------------------
Error output:
--------------------
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r`

Stdout from the command:

Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  crda iw libnl-3-200 libnl-genl-3-200 wireless-regdb
The following NEW packages will be installed:
  crda iw libnl-3-200 libnl-genl-3-200 linux-image-extra-3.13.0-55-generic
  wireless-regdb
0 upgraded, 6 newly installed, 0 to remove and 0 not upgraded.
Need to get 36.8 MB of archives.
After this operation, 152 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libnl-3-200 amd64 3.2.21-1 [44.5 kB]
Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libnl-genl-3-200 amd64 3.2.21-1 [10.2 kB]
Get:3 http://archive.ubuntu.com/ubuntu/ trusty/main wireless-regdb all 2013.02.13-1ubuntu1 [6,456 B]
Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main crda amd64 1.1.2-1ubuntu2 [15.2 kB]
Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main iw amd64 3.4-1 [51.7 kB]
Err http://archive.ubuntu.com/ubuntu/ trusty-updates/main linux-image-extra-3.13.0-55-generic amd64 3.13.0-55.92
  404  Not Found [IP: 91.189.91.24 80]
Err http://security.ubuntu.com/ubuntu/ trusty-security/main linux-image-extra-3.13.0-55-generic amd64 3.13.0-55.92
  404  Not Found [IP: 91.189.91.14 80]
Fetched 128 kB in 10s (11.7 kB/s)


Stderr from the command:

stdin: is not a tty
modprobe: FATAL: Module aufs not found.
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-image-extra-3.13.0-55-generic_3.13.0-55.92_amd64.deb  404  Not Found [IP: 91.189.91.14 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?