### PR TITLE
Add setting config.ssh.ssh_command

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -429,6 +429,8 @@ module Vagrant
       info[:forward_agent] = @config.ssh.forward_agent
       info[:forward_x11]   = @config.ssh.forward_x11
 
+      info[:ssh_command] = @config.ssh.ssh_command if @config.ssh.ssh_command
+
       # Add in provided proxy command config
       info[:proxy_command] = @config.ssh.proxy_command if @config.ssh.proxy_command
 

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -158,17 +158,20 @@ module Vagrant
         # we really don't care since both work.
         ENV["nodosfilewarning"] = "1" if Platform.cygwin?
 
+        ssh = ssh_info[:ssh_command] || 'ssh'
+
         # Invoke SSH with all our options
         if !opts[:subprocess]
-          LOGGER.info("Invoking SSH: #{command_options.inspect}")
-          SafeExec.exec("ssh", *command_options)
+          LOGGER.info("Invoking SSH: #{ssh} #{command_options.inspect}")
+          # msabramo
+          SafeExec.exec(ssh, *command_options)
           return
         end
 
         # If we're still here, it means we're supposed to subprocess
         # out to ssh rather than exec it.
-        LOGGER.info("Executing SSH in subprocess: #{command_options.inspect}")
-        process = ChildProcess.build("ssh", *command_options)
+        LOGGER.info("Executing SSH in subprocess: #{ssh} #{command_options.inspect}")
+        process = ChildProcess.build(ssh, *command_options)
         process.io.inherit!
         process.start
         process.wait

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -40,7 +40,8 @@ module VagrantPlugins
             private_key_path: ssh_info[:private_key_path],
             forward_agent: ssh_info[:forward_agent],
             forward_x11:   ssh_info[:forward_x11],
-            proxy_command: ssh_info[:proxy_command]
+            proxy_command: ssh_info[:proxy_command],
+            ssh_command: ssh_info[:ssh_command]
           }
 
           # Render the template and output directly to STDOUT

--- a/plugins/kernel_v2/config/ssh.rb
+++ b/plugins/kernel_v2/config/ssh.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :keep_alive
       attr_accessor :shell
       attr_accessor :proxy_command
+      attr_accessor :ssh_command
       attr_accessor :pty
 
       attr_reader :default
@@ -23,6 +24,7 @@ module VagrantPlugins
         @guest_port    = UNSET_VALUE
         @keep_alive    = UNSET_VALUE
         @proxy_command = UNSET_VALUE
+        @ssh_command   = UNSET_VALUE
         @pty           = UNSET_VALUE
         @shell         = UNSET_VALUE
 
@@ -44,6 +46,7 @@ module VagrantPlugins
         @guest_port = 22 if @guest_port == UNSET_VALUE
         @keep_alive = true if @keep_alive == UNSET_VALUE
         @proxy_command = nil if @proxy_command == UNSET_VALUE
+        @ssh_command = nil if @ssh_command == UNSET_VALUE
         @pty        = false if @pty == UNSET_VALUE
         @shell      = "bash -l" if @shell == UNSET_VALUE
 


### PR DESCRIPTION
Lets the user specify what ssh to use or even direct Vagrant to use an ssh wrapper like sshrc (https://github.com/Russell91/sshrc).

I haven't added tests or documentation yet, but I can add it if you're interested in the idea.

In my `Vagrantfile`, I set:

```ruby
config.ssh.ssh_command = 'sshrc'
```

Now I can do `vagrant ssh` and have it invoke `sshrc` instead of `ssh`.

```
$ bundle exec vagrant ssh
...
-------> marca-mac2.local:~/.sshrc
vagrant@localmonkey:~$ exit
```

