### PR TITLE
Updated version for windows and added passing in version via vagrantfile

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -1,5 +1,11 @@
-# Salt version to install
-$version = '2014.7.1'
+Param(
+    [string]$version
+)
+ 
+# Salt version to install - default to latest if there is an issue
+if ($version -notmatch "201[0-9]\.[0-9]\.[0-9](\-\d{1})?"){
+  $version = '2015.5.2'
+}
 
 # Create C:\tmp\ - if Vagrant doesn't upload keys and/or config it might not exist
 New-Item C:\tmp\ -ItemType directory -force | out-null
@@ -21,7 +27,7 @@ if ([IntPtr]::Size -eq 4) {
 }
 
 # Download minion setup file
-Write-Host "Downloading Salt minion installer ($arch)..."
+Write-Host "Downloading Salt minion installer $version-$arch..."
 $webclient = New-Object System.Net.WebClient
 $url = "https://docs.saltstack.com/downloads/Salt-Minion-$version-$arch-Setup.exe"
 $file = "C:\tmp\salt.exe"

--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -35,6 +35,7 @@ module VagrantPlugins
       attr_accessor :install_syndic
       attr_accessor :no_minion
       attr_accessor :bootstrap_options
+      attr_accessor :version
 
       def initialize
         @minion_config = UNSET_VALUE
@@ -63,6 +64,7 @@ module VagrantPlugins
         @config_dir = UNSET_VALUE
         @masterless = UNSET_VALUE
         @minion_id = UNSET_VALUE
+        @version = UNSET_VALUE
       end
 
       def finalize!
@@ -90,8 +92,9 @@ module VagrantPlugins
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @config_dir         = nil if @config_dir == UNSET_VALUE
-        @masterless 	    = false if @masterless == UNSET_VALUE
-        @minion_id 	    = nil if @minion_id == UNSET_VALUE
+        @masterless         = false if @masterless == UNSET_VALUE
+        @minion_id          = nil if @minion_id == UNSET_VALUE
+        @version            = nil if @version == UNSET_VALUE
       end
 
       def pillar(data)

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -76,7 +76,7 @@ module VagrantPlugins
       end
 
       def need_configure
-        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key or @config.grains_config
+        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key or @config.grains_config or @config.version
       end
 
       def need_install
@@ -237,6 +237,9 @@ module VagrantPlugins
 
           bootstrap_path = get_bootstrap
           if @machine.config.vm.communicator == :winrm
+            if @config.version
+              options = "-version %s" % @config.version            
+            end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
@@ -248,7 +251,7 @@ module VagrantPlugins
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
           @machine.communicate.sudo("chmod +x %s" % bootstrap_destination)
           if @machine.config.vm.communicator == :winrm
-            bootstrap = @machine.communicate.sudo("powershell.exe -executionpolicy bypass -file %s" % [bootstrap_destination]) do |type, data|
+            bootstrap = @machine.communicate.sudo("powershell.exe -executionpolicy bypass -file %s %s" % [bootstrap_destination, options]) do |type, data|
               if data[0] == "\n"
                 # Remove any leading newline but not whitespace. If we wanted to
                 # remove newlines and whitespace we would have used data.lstrip


### PR DESCRIPTION
Updated version to latest, 2015.5.2. Added passing in the version via vagrantfile. This is only for windows, but the linux bootstrap script is outside of this repo. This is my first PR so let me know if I missed anything.