### PR TITLE
Track UID used to create machine, error in VB if mismatch

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -764,6 +764,10 @@ module Vagrant
       error_key(:virtualbox_name_exists)
     end
 
+    class VirtualBoxUserMismatch < VagrantError
+      error_key(:virtualbox_user_mismatch)
+    end
+
     class VirtualBoxVersionEmpty < VagrantError
       error_key(:virtualbox_version_empty)
     end

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -279,6 +279,13 @@ module Vagrant
           end
         end
 
+        if uid_file
+          # Write the user id that created this machine
+          uid_file.open("w+") do |f|
+            f.write(Process.uid.to_s)
+          end
+        end
+
         # If we don't have a UUID, then create one
         if index_uuid.nil?
           # Create the index entry and save it
@@ -311,6 +318,7 @@ module Vagrant
       else
         # Delete the file, since the machine is now destroyed
         id_file.delete if id_file && id_file.file?
+        uid_file.delete if uid_file && uid_file.file?
 
         # If we have a UUID associated with the index, remove it
         uuid = index_uuid
@@ -495,6 +503,17 @@ module Vagrant
       result
     end
 
+    # Returns the user ID that created this machine. This is specific to
+    # the host machine that this was created on.
+    #
+    # @return [String]
+    def uid
+      path = uid_file
+      return nil if !path
+      return nil if !path.file?
+      return uid_file.read.chomp
+    end
+
     # Temporarily changes the machine UI. This is useful if you want
     # to execute an {#action} with a different UI.
     def with_ui(ui)
@@ -507,6 +526,14 @@ module Vagrant
           @ui = old_ui
         end
       end
+    end
+
+    protected
+
+    # Returns the path to the file that stores the UID.
+    def uid_file
+      return nil if !@data_dir
+      @data_dir.join("creator_uid")
     end
   end
 end

--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -76,8 +76,10 @@ module VagrantPlugins
         # We have to check if the UID matches to avoid issues with
         # VirtualBox.
         uid = @machine.uid
-        if uid && uid.to_s == Process.uid.to_s
-          raise Vagrant::Errors::VirtualBoxUserMismatch, uid: uid.to_s
+        if uid && uid.to_s != Process.uid.to_s
+          raise Vagrant::Errors::VirtualBoxUserMismatch,
+            original_uid: uid.to_s,
+            uid: Process.uid.to_s
         end
 
         # Determine the ID of the state here.

--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -73,6 +73,13 @@ module VagrantPlugins
       #
       # @return [Symbol]
       def state
+        # We have to check if the UID matches to avoid issues with
+        # VirtualBox.
+        uid = @machine.uid
+        if uid && uid.to_s == Process.uid.to_s
+          raise Vagrant::Errors::VirtualBoxUserMismatch, uid: uid.to_s
+        end
+
         # Determine the ID of the state here.
         state_id = nil
         state_id = :not_created if !@driver.uuid

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1317,6 +1317,13 @@ en:
         Vagrant uses the `VBoxManage` binary that ships with VirtualBox, and requires
         this to be available on the PATH. If VirtualBox is installed, please find the
         `VBoxManage` binary and add it to the PATH environmental variable.
+      virtualbox_user_mismatch: |-
+        The VirtualBox VM was created with a user that doesn't match the
+        current user running Vagrant. VirtualBox requires that the same user
+        be used to manage the VM that was created. Please re-run Vagrant with
+        that user.
+
+        The UID used to create the VM was: %{uid}
       virtualbox_version_empty: |-
         Vagrant detected that VirtualBox appears installed on your system,
         but calls to detect the version are returning empty. This is often

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1321,9 +1321,10 @@ en:
         The VirtualBox VM was created with a user that doesn't match the
         current user running Vagrant. VirtualBox requires that the same user
         be used to manage the VM that was created. Please re-run Vagrant with
-        that user.
+        that user. This is not a Vagrant issue.
 
-        The UID used to create the VM was: %{uid}
+        The UID used to create the VM was: %{original_uid}
+        Your UID is: %{uid}
       virtualbox_version_empty: |-
         Vagrant detected that VirtualBox appears installed on your system,
         but calls to detect the version are returning empty. This is often

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -424,6 +424,21 @@ describe Vagrant::Machine do
       third = new_instance
       expect(third.id).to be_nil
     end
+
+    it "should set the UID that created the machine" do
+      instance.id = "foo"
+
+      second = new_instance
+      expect(second.uid).to eq(Process.uid.to_s)
+    end
+
+    it "should delete the UID when the id is nil" do
+      instance.id = "foo"
+      instance.id = nil
+
+      second = new_instance
+      expect(second.uid).to be_nil
+    end
   end
 
   describe "#index_uuid" do


### PR DESCRIPTION
Fixes #4739

This adds UID tracking to created machines, and errors in VirtualBox if they mismatch.