### PR TITLE
Docker Provider: Don't destroy built Docker image on reload

### DIFF
--- a/plugins/providers/docker/action.rb
+++ b/plugins/providers/docker/action.rb
@@ -117,8 +117,12 @@ module VagrantPlugins
 
             b2.use Call, IsBuild do |env2, b3|
               if env2[:result]
-                b3.use EnvSet, force_confirm_destroy: true
-                b3.use action_destroy.flatten
+                b3.use ConfigValidate
+                b3.use EnvSet, force_halt: true
+                b3.use action_halt
+                b3.use HostMachineSyncFoldersDisable
+                b3.use Destroy
+                b3.use ProvisionerCleanup
               end
             end
 


### PR DESCRIPTION
Resolves #5353

After this change Docker's caching mechanism is now applicable to the build process during `vagrant reload` by default, speeding up the reload process considerably for large/complex Dockerfiles.

Forcing the image to be rebuilt from scratch, without cache, can still be achieved via adding the `--no-cache` flag to the `build_args` array.