### PR TITLE
guests/fedora: don't fail if nmcli doesn't exist on the guest

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -107,7 +107,7 @@ module VagrantPlugins
           interfaces.each do |interface|
             retryable(on: Vagrant::Errors::VagrantError, tries: 3, sleep: 2) do
               machine.communicate.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-#{interface}")
-              machine.communicate.sudo("which nmcli >/dev/null 2>&1 && nmcli c reload #{interface}")
+              machine.communicate.sudo("! which nmcli >/dev/null 2>&1 || nmcli c reload #{interface}")
               machine.communicate.sudo("/sbin/ifdown #{interface}", error_check: true)
               machine.communicate.sudo("/sbin/ifup #{interface}")
             end


### PR DESCRIPTION
Running `vagrant up` with the fedora box where `nmcli` is not installed fails to configure guest networks.

Here is the reproducing step:

    $ vagrant box add --name fedora-cloud-22 https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
    $ cat <<EOF > Vagrantfile
    Vagrant.configure('2') do |config|
      config.vm.box = 'fedora-cloud-22'
      config.vm.network :private_network, ip: '10.0.0.2'
    end
    EOF
    $ vagrant up
    (snip)
    ==> default: Configuring and enabling network interfaces...
    The following SSH command responded with a non-zero exit status.
    Vagrant assumes that this means the command failed!
    
    which nmcli >/dev/null 2>&1 && nmcli c reload eth1
    
    Stdout from the command:
    
    
    
    Stderr from the command:

This PR fixes this issue.