### PR TITLE
Fix salt bootstrap issue after 1.7.3 upgrade with verbose option set

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
       attr_accessor :install_args
       attr_accessor :install_master
       attr_accessor :install_syndic
+      attr_accessor :install_command
       attr_accessor :no_minion
       attr_accessor :bootstrap_options
       attr_accessor :version
@@ -59,6 +60,7 @@ module VagrantPlugins
         @install_args = UNSET_VALUE
         @install_master = UNSET_VALUE
         @install_syndic = UNSET_VALUE
+        @install_command = UNSET_VALUE
         @no_minion = UNSET_VALUE
         @bootstrap_options = UNSET_VALUE
         @config_dir = UNSET_VALUE
@@ -89,6 +91,7 @@ module VagrantPlugins
         @install_args       = nil if @install_args == UNSET_VALUE
         @install_master     = nil if @install_master == UNSET_VALUE
         @install_syndic     = nil if @install_syndic == UNSET_VALUE
+        @install_command     = nil if @install_command == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @config_dir         = nil if @config_dir == UNSET_VALUE

--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -91,7 +91,7 @@ module VagrantPlugins
         @install_args       = nil if @install_args == UNSET_VALUE
         @install_master     = nil if @install_master == UNSET_VALUE
         @install_syndic     = nil if @install_syndic == UNSET_VALUE
-        @install_command     = nil if @install_command == UNSET_VALUE
+        @install_command    = nil if @install_command == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @config_dir         = nil if @config_dir == UNSET_VALUE


### PR DESCRIPTION
After upgrading to 1.7.3 we found that our VMs would not execute salt. I narrowed that down to the use of the verbose option. So removing that is a workaround for now. However we don't get any salt output which makes debugging changes to our config difficult.

I found that #5435 added a new `install_command` option but that seemed to always set the options value to a `DummyConfig` type instead of the expected string. It seems that the option wasn't initialized in `config.rb` so I've added that which fixes the problem on my machine.

Our current VMs already have salt installed but I think this might actually break normal salt install so it might be very urgent to fix for a good amount of people.

Fixes https://github.com/mitchellh/vagrant/issues/5939