### PR TITLE
Raise Errno::ETIMEDOUT as "acceptable" Errors::ConnectionTimeout

### DIFF
--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -132,6 +132,9 @@ module VagrantPlugins
           raise Errors::SSLError, message: exception.message
         when HTTPClient::TimeoutError
           raise Errors::ConnectionTimeout, message: exception.message
+        when Errno::ETIMEDOUT
+          raise Errors::ConnectionTimeout
+          # This is raised if the connection timed out
         when Errno::ECONNREFUSED
           # This is raised if we failed to connect the max amount of times
           raise Errors::ConnectionRefused


### PR DESCRIPTION
As described in issue #5970 communicate.ready? returns an exception on connection timeout, instead of returning false.

This catches the Errno::ETIMEDOUT, which will be caught by:
https://github.com/mitchellh/vagrant/blob/master/plugins/communicators/winrm/communicator.rb#L104
```ruby
rescue Errors::TransientError => e
```

And resulting in returning "just" false.