### PR TITLE
Fixed salt minion configuration directory typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ BUG FIXES:
   - pushes/atlas: send additional box metadata [GH-5283]
   - pushes/ftp: improve check for remote directory existence [GH-5549]
   - synced\_folders/rsync: add `IdentitiesOnly=yes` to the rsync command. [GH-5175]
+  - synced\_folders/smb: use correct `password` option [GH-5805]
   - virtualbox/config: fix misleading error message for private_network [GH-5536, GH-5418]
 
 ## 1.7.2 (January 6, 2015)

--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -1,11 +1,33 @@
 Param(
-    [string]$version
+  [string]$version,
+  [string]$runservice,
+  [string]$minion,
+  [string]$master
 )
- 
-# Salt version to install - default to latest if there is an issue
-if ($version -notmatch "201[0-9]\.[0-9]\.[0-9](\-\d{1})?"){
+
+# Constants
+$ServiceName = "salt-minion"
+$startupType = "Manual"
+
+# Version to install - default to latest if there is an issue
+If ($version -notmatch "201[0-9]\.[0-9]\.[0-9](\-\d{1})?"){
   $version = '2015.5.2'
 }
+
+If ($runservice.ToLower() -eq "true"){
+  Write-Host "Service is set to run."
+  [bool]$runservice = $True
+}
+ElseIf ($runservice.ToLower() -eq "false"){
+  Write-Host "Service will be stopped and set to manual."
+  [bool]$runservice = $False
+}
+Else {
+  # Param passed in wasn't clear so defaulting to true.
+   Write-Host "Service defaulting to run."
+  [bool]$runservice = $True
+}
+
 
 # Create C:\tmp\ - if Vagrant doesn't upload keys and/or config it might not exist
 New-Item C:\tmp\ -ItemType directory -force | out-null
@@ -14,32 +36,48 @@ New-Item C:\tmp\ -ItemType directory -force | out-null
 New-Item C:\salt\conf\pki\minion\ -ItemType directory -force | out-null
 
 # Check if minion keys have been uploaded
-if (Test-Path C:\tmp\minion.pem) {
+If (Test-Path C:\tmp\minion.pem) {
   cp C:\tmp\minion.pem C:\salt\conf\pki\minion\
   cp C:\tmp\minion.pub C:\salt\conf\pki\minion\
 }
 
 # Detect architecture
-if ([IntPtr]::Size -eq 4) {
+If ([IntPtr]::Size -eq 4) {
   $arch = "x86"
-} else {
+} Else {
   $arch = "AMD64"
 }
 
 # Download minion setup file
-Write-Host "Downloading Salt minion installer $version-$arch..."
+Write-Host "Downloading Salt minion installer Salt-Minion-$version-$arch-Setup.exe"
 $webclient = New-Object System.Net.WebClient
 $url = "https://docs.saltstack.com/downloads/Salt-Minion-$version-$arch-Setup.exe"
 $file = "C:\tmp\salt.exe"
 $webclient.DownloadFile($url, $file)
 
+
 # Install minion silently
 Write-Host "Installing Salt minion..."
 #Wait for process to exit before continuing...
-C:\tmp\salt.exe /S | Out-Null
+If($PSBoundParameters.ContainsKey('minion') -and $PSBoundParameters.ContainsKey('master')) {
+  C:\tmp\salt.exe /S /minion-name=$minion /master=$master | Out-Null
+  Write-Host C:\tmp\salt.exe /S /minion-name=$minion /master=$master | Out-Null
+}
+ElseIf($PSBoundParameters.ContainsKey('minion') -and !$PSBoundParameters.ContainsKey('master')) {
+  C:\tmp\salt.exe /S /minion-name=$minion | Out-Null
+  Write-Host C:\tmp\salt.exe /S /minion-name=$minion | Out-Null
+}
+ElseIf(!$PSBoundParameters.ContainsKey('minion') -and $PSBoundParameters.ContainsKey('master')) {
+  C:\tmp\salt.exe /S /master=$master | Out-Null
+  Write-Host C:\tmp\salt.exe /S /master=$master | Out-Null
+}
+Else {
+  C:\tmp\salt.exe /S | Out-Null
+  Write-Host C:\tmp\salt.exe /S | Out-Null 
+}
 
 # Check if minion config has been uploaded
-if (Test-Path C:\tmp\minion) {
+If (Test-Path C:\tmp\minion) {
   cp C:\tmp\minion C:\salt\conf\
 }
 
@@ -50,24 +88,31 @@ While (!$service) {
   $service = Get-Service salt-minion -ErrorAction SilentlyContinue
 }
 
-# Start service
-Start-Service -Name "salt-minion" -ErrorAction SilentlyContinue
-
-# Check if service is started, otherwise retry starting the 
-# service 4 times.
-$try = 0
-While (($service.Status -ne "Running") -and ($try -ne 4)) {
+If($runservice) {
+  # Start service
   Start-Service -Name "salt-minion" -ErrorAction SilentlyContinue
-  $service = Get-Service salt-minion -ErrorAction SilentlyContinue
-  Start-Sleep -s 2
-  $try += 1
-}
 
-# If the salt-minion service is still not running, something probably
-# went wrong and user intervention is required - report failure.
-if ($service.Status -eq "Stopped") {
-  Write-Host "Failed to start Salt minion"
-  exit 1
+  # Check if service is started, otherwise retry starting the 
+  # service 4 times.
+  $try = 0
+  While (($service.Status -ne "Running") -and ($try -ne 4)) {
+    Start-Service -Name "salt-minion" -ErrorAction SilentlyContinue
+    $service = Get-Service salt-minion -ErrorAction SilentlyContinue
+    Start-Sleep -s 2
+    $try += 1
+  }
+
+  # If the salt-minion service is still not running, something probably
+  # went wrong and user intervention is required - report failure.
+  If ($service.Status -eq "Stopped") {
+    Write-Host "Failed to start Salt minion"
+    exit 1
+  }
+}
+Else {
+  Write-Host "Stopping salt minion"
+  Set-Service "$ServiceName" -startupType "$startupType"
+  Stop-Service "$ServiceName"
 }
 
 Write-Host "Salt minion successfully installed"

--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -1,5 +1,11 @@
-# Salt version to install
-$version = '2014.7.1'
+Param(
+    [string]$version
+)
+ 
+# Salt version to install - default to latest if there is an issue
+if ($version -notmatch "201[0-9]\.[0-9]\.[0-9](\-\d{1})?"){
+  $version = '2015.5.2'
+}
 
 # Create C:\tmp\ - if Vagrant doesn't upload keys and/or config it might not exist
 New-Item C:\tmp\ -ItemType directory -force | out-null
@@ -21,7 +27,7 @@ if ([IntPtr]::Size -eq 4) {
 }
 
 # Download minion setup file
-Write-Host "Downloading Salt minion installer ($arch)..."
+Write-Host "Downloading Salt minion installer $version-$arch..."
 $webclient = New-Object System.Net.WebClient
 $url = "https://docs.saltstack.com/downloads/Salt-Minion-$version-$arch-Setup.exe"
 $file = "C:\tmp\salt.exe"

--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -35,6 +35,7 @@ module VagrantPlugins
       attr_accessor :install_syndic
       attr_accessor :no_minion
       attr_accessor :bootstrap_options
+      attr_accessor :version
 
       def initialize
         @minion_config = UNSET_VALUE
@@ -63,6 +64,7 @@ module VagrantPlugins
         @config_dir = UNSET_VALUE
         @masterless = UNSET_VALUE
         @minion_id = UNSET_VALUE
+        @version = UNSET_VALUE
       end
 
       def finalize!
@@ -90,8 +92,9 @@ module VagrantPlugins
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @config_dir         = nil if @config_dir == UNSET_VALUE
-        @masterless 	    = false if @masterless == UNSET_VALUE
-        @minion_id 	    = nil if @minion_id == UNSET_VALUE
+        @masterless         = false if @masterless == UNSET_VALUE
+        @minion_id          = nil if @minion_id == UNSET_VALUE
+        @version            = nil if @version == UNSET_VALUE
       end
 
       def pillar(data)

--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -36,6 +36,8 @@ module VagrantPlugins
       attr_accessor :no_minion
       attr_accessor :bootstrap_options
       attr_accessor :version
+      attr_accessor :run_service
+      attr_accessor :master_id
 
       def initialize
         @minion_config = UNSET_VALUE
@@ -65,6 +67,8 @@ module VagrantPlugins
         @masterless = UNSET_VALUE
         @minion_id = UNSET_VALUE
         @version = UNSET_VALUE
+        @run_service = UNSET_VALUE
+        @master_id = UNSET_VALUE
       end
 
       def finalize!
@@ -95,6 +99,8 @@ module VagrantPlugins
         @masterless         = false if @masterless == UNSET_VALUE
         @minion_id          = nil if @minion_id == UNSET_VALUE
         @version            = nil if @version == UNSET_VALUE
+        @run_service        = nil if @run_service == UNSET_VALUE
+        @master_id          = nil if @master_id == UNSET_VALUE
       end
 
       def pillar(data)

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -336,7 +336,7 @@ module VagrantPlugins
 
       def call_highstate
         if @config.minion_config
-          @machine.env.ui.info "Copying salt minion config to #{@config.config dir}"
+          @machine.env.ui.info "Copying salt minion config to #{@config.config_dir}"
           @machine.communicate.upload(expanded_path(@config.minion_config).to_s, @config.config_dir + "/minion")
         end
 

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -76,7 +76,7 @@ module VagrantPlugins
       end
 
       def need_configure
-        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key or @config.grains_config
+        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key or @config.grains_config or @config.version
       end
 
       def need_install
@@ -237,6 +237,9 @@ module VagrantPlugins
 
           bootstrap_path = get_bootstrap
           if @machine.config.vm.communicator == :winrm
+            if @config.version
+              options = "-version %s" % @config.version            
+            end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
@@ -248,7 +251,7 @@ module VagrantPlugins
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
           @machine.communicate.sudo("chmod +x %s" % bootstrap_destination)
           if @machine.config.vm.communicator == :winrm
-            bootstrap = @machine.communicate.sudo("powershell.exe -executionpolicy bypass -file %s" % [bootstrap_destination]) do |type, data|
+            bootstrap = @machine.communicate.sudo("powershell.exe -executionpolicy bypass -file %s %s" % [bootstrap_destination, options]) do |type, data|
               if data[0] == "\n"
                 # Remove any leading newline but not whitespace. If we wanted to
                 # remove newlines and whitespace we would have used data.lstrip

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -104,7 +104,7 @@ module VagrantPlugins
           options = "%s %s" % [options, @config.bootstrap_options]
         end
 
-        if configure
+        if configure && !@machine.config.vm.communicator == :winrm
           options = "%s -F -c %s" % [options, config_dir]
         end
 
@@ -238,7 +238,19 @@ module VagrantPlugins
           bootstrap_path = get_bootstrap
           if @machine.config.vm.communicator == :winrm
             if @config.version
-              options = "-version %s" % @config.version            
+              options += " -version %s" % @config.version            
+            end
+            if @config.run_service
+              @machine.env.ui.info "Salt minion will be stopped after installing."
+              options += " -runservice %s" % @config.run_service            
+            end
+            if @config.minion_id
+              @machine.env.ui.info "Setting minion to @config.minion_id."
+              options += " -minion %s" % @config.minion_id            
+            end
+            if @config.master_id
+              @machine.env.ui.info "Setting master to @config.master_id."
+              options += " -master %s" % @config.master_id            
             end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else


### PR DESCRIPTION
Simple typo was killing the copy of the minion file when masterless config flag was set.