### PR TITLE
Specify time and don't do -h -H which is not really a valid usage.

### DIFF
--- a/plugins/guests/debian8/cap/halt.rb
+++ b/plugins/guests/debian8/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("shutdown -h -H")
+            machine.communicate.sudo("shutdown -h now")
           rescue IOError
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.


### PR DESCRIPTION
The current (1.7.3) behaviour leads to vagrant force-shutdown every time I halt a Debian 8 box:
```
vagrant halt
==> d8: Attempting graceful shutdown of VM...
==> d8: Forcing shutdown of VM...
```
On executing ```shutdown -h -H``` I understand why, because this simply schedules a shutdown in one minute:
```
root@vagrant:~# shutdown -h -H
Shutdown scheduled for Fri 2015-07-17 21:32:54 CEST, use 'shutdown -c' to cancel.
Broadcast message from root@vagrant (Fri 2015-07-17 21:31:54 CEST):
The system is going down for system halt at Fri 2015-07-17 21:32:54 CEST!
```

Also the usage of shutdown says:
```
shutdown [OPTIONS...] [TIME] [WALL...]
  -H --halt      Halt the machine
  -h             Equivalent to --poweroff, overridden by --halt
```
