### PR TITLE
Fix puppet apply environment default manifest

### DIFF
--- a/website/docs/source/v2/provisioning/puppet_apply.html.md
+++ b/website/docs/source/v2/provisioning/puppet_apply.html.md
@@ -140,8 +140,9 @@ that the path is located in the "vm" at "/path/to/manifests".
 
 ## Environments
 
-If you are using Puppet 4 or higher, you can also specify the name of the
-Puppet environment and the path on the local disk to the environment files:
+If you are using Puppet 4 or higher, you can proivision using
+[Puppet Environments](https://docs.puppetlabs.com/puppet/latest/reference/environments.html) by specifying the name of the environment and the path on the
+local disk to the environment files:
 
 ```ruby
 Vagrant.configure("2") do |config|
@@ -151,6 +152,13 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
+
+The default manifest is the environment's `manifests` directory.
+If the environment has an `environment.conf` the manifest path is parsed
+from there. Relative paths are assumed to be relative to the directory of
+the environment. If the manifest setting in `environment.conf` use
+the Puppet variables `$codedir` or `$environment` they are resoled to
+the parent directory of `environment_path` and `environment` respectively.
 
 ## Modules
 


### PR DESCRIPTION
Fixes: #5987
Please review: @benh57 

To test this I used a Vagrantfile with the following code:

```
config.vm.provision 'puppet' do |puppet|
  puppet.environment = 'all'
  puppet.environment_path = 'environments'
end
```
I also created a `environments/all/` directory.

To verify what command Vagrant sent through to the VM I used:
`vagrant provision --debug --provision-with puppet`

### Before PR

**Without environment.conf**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/all/manifests/site.pp`

**With environment.conf but no manifest setting**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/all/manifests/site.pp`

**With environment.conf and manifest set to relative path**
manifest = manifests/hello_world.pp
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all manifests/hello_world.pp`

**With environment.conf and manifest set to absolute path**
manifest = /tmp/hello_world.pp
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/hello_world.pp`

### After PR

**Without environment.conf**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/all/manifests`

**With environment.conf but no manifest setting**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/all/manifests`

**With environment.conf and manifest set to relative path**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/all/manifests/hello_world.pp`

**With environment.conf and manifest set to relative path with ..**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/all/../default_env/manifests`

**With environment.conf and manifest set to absolute path**
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/hello_world.pp`

**Manifest setting that use variable**
manifest = $codedir/environments/another/manifests
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/environments/another/manifests`

**Manifest setting that use two variables**
manifest = $codedir/another_environments_dir/$environment/manifests/default.pp
`puppet apply --detailed-exitcodes --environmentpath /tmp/vagrant-puppet/environments/ --environment all /tmp/vagrant-puppet/another_environments_dir/all/manifests/default.pp`