### PR TITLE
Corrected masterless example for salt provisioner in documentation

### DIFF
--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -30,7 +30,8 @@ on a single minion, without a master:
 
     ## Use all the defaults:
     config.vm.provision :salt do |salt|
-
+    
+      salt.masterless = true
       salt.minion_config = "salt/minion"
       salt.run_highstate = true
 


### PR DESCRIPTION
The basic Vagrantfile file example for a masterless setup wasn't setting the masterless value to true.  That value defaults to false in config.rb and used on line 350 here:  https://github.com/mitchellh/vagrant/blob/master/plugins/provisioners/salt/provisioner.rb