### PR TITLE
Copy grains file to the minion config directory for salt provisioner

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -347,6 +347,11 @@ module VagrantPlugins
           @machine.communicate.upload(expanded_path(@config.minion_config).to_s, @config.config_dir + "/minion")
         end
 
+        if @config.grains_config
+          @machine.env.ui.info "Copying salt grains config to #{@config.config_dir}"
+          @machine.communicate.upload(expanded_path(@config.grains_config).to_s, @config.config_dir + "/grains")
+        end
+
         if @config.masterless
           call_masterless
         elsif @config.run_highstate


### PR DESCRIPTION
Grains file is being copied to the guest, but it's not being copied where the minion can automatically pick it up next to the minion config.