### PR TITLE
salt-call file extension wrong for windows guest

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
         if !@config.no_minion
           if @machine.config.vm.communicator == :winrm
             desired_binaries.push('C:\\salt\\salt-minion.exe')
-            desired_binaries.push('C:\\salt\\salt-call.exe')
+            desired_binaries.push('C:\\salt\\salt-call.bat')
           else
             desired_binaries.push('salt-minion')
             desired_binaries.push('salt-call')


### PR DESCRIPTION
Salt-minion is an executable, but salt-call is a batch file.