### PR TITLE
[website] load external scripts without schema

### DIFF
--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -22,8 +22,8 @@
 		<%= javascript_include_tag "vagrantup" %>
 
 		<!-- fonts -->
-		<link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
-		<script type="text/javascript" src="http://use.typekit.net/xfs6zus.js"></script>
+		<link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+		<script type="text/javascript" src="//use.typekit.net/xfs6zus.js"></script>
 		<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 	</head>
 	<body>

--- a/website/www/source/layouts/layout.erb
+++ b/website/www/source/layouts/layout.erb
@@ -20,8 +20,8 @@
 		<%= javascript_include_tag "vagrantup" %>
 
 		<!-- fonts -->
-		<link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
-		<script type="text/javascript" src="http://use.typekit.net/xfs6zus.js"></script>
+		<link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+		<script type="text/javascript" src="//use.typekit.net/xfs6zus.js"></script>
 		<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 
 		<!-- Blog -->


### PR DESCRIPTION
Hello,
currently www.vagrantup.com and docs.vagrantup.com are loading web fonts using HTTP even when HTTPS is used (default for vagrant's website).
This causes most browsers (Chromium and Firefox at least) to block those resources by default due to security issues (HTTPS is useless if an active element such as a script is loaded using plain HTTP because it has access to the whole DOM...).

Loading the external resources over HTTPS avoids this issue.

Thanks,
Marcello