### PR TITLE
Fix for Issue #6006 - cfengine will now install

### DIFF
--- a/plugins/provisioners/cfengine/config.rb
+++ b/plugins/provisioners/cfengine/config.rb
@@ -51,7 +51,7 @@ module VagrantPlugins
         end
 
         if @deb_repo_line == UNSET_VALUE
-          @deb_repo_line = "deb http://cfengine.com/pub/apt $(lsb_release -cs) main"
+          @deb_repo_line = "deb http://cfengine.com/pub/apt/packages stable main"
         end
 
         @extra_agent_args = nil if @extra_agent_args == UNSET_VALUE


### PR DESCRIPTION
With this fix, Debian will now work with `cfengine` provisioner.