### PR TITLE
Chef Zero - Fix 'nodes_path' Support

### DIFF
--- a/plugins/provisioners/chef/config/chef_solo.rb
+++ b/plugins/provisioners/chef/config/chef_solo.rb
@@ -17,6 +17,10 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :environments_path
 
+        # The path where nodes are stored on disk.
+        # @return [String]
+        attr_accessor :nodes_path
+
         # A URL download a remote recipe from. Note: you should use chef-apply
         # instead.
         #
@@ -39,6 +43,7 @@ module VagrantPlugins
           @cookbooks_path      = UNSET_VALUE
           @data_bags_path      = UNSET_VALUE
           @environments_path   = UNSET_VALUE
+          @nodes_path          = UNSET_VALUE
           @recipe_url          = UNSET_VALUE
           @roles_path          = UNSET_VALUE
           @synced_folder_type  = UNSET_VALUE
@@ -86,6 +91,7 @@ module VagrantPlugins
           end
 
           @data_bags_path    = [] if @data_bags_path == UNSET_VALUE
+          @nodes_path        = [] if @nodes_path == UNSET_VALUE
           @roles_path        = [] if @roles_path == UNSET_VALUE
           @environments_path = [] if @environments_path == UNSET_VALUE
           @environments_path = [@environments_path].flatten
@@ -93,6 +99,7 @@ module VagrantPlugins
           # Make sure the path is an array.
           @cookbooks_path    = prepare_folders_config(@cookbooks_path)
           @data_bags_path    = prepare_folders_config(@data_bags_path)
+          @nodes_path        = prepare_folders_config(@nodes_path)
           @roles_path        = prepare_folders_config(@roles_path)
           @environments_path = prepare_folders_config(@environments_path)
         end

--- a/plugins/provisioners/chef/config/chef_zero.rb
+++ b/plugins/provisioners/chef/config/chef_zero.rb
@@ -17,6 +17,10 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :environments_path
 
+        # The path where nodes are stored on disk.
+        # @return [String]
+        attr_accessor :nodes_path
+
         # The path where roles are stored on disk.
         # @return [String]
         attr_accessor :roles_path
@@ -31,6 +35,7 @@ module VagrantPlugins
           @cookbooks_path      = UNSET_VALUE
           @data_bags_path      = UNSET_VALUE
           @environments_path   = UNSET_VALUE
+          @nodes_path          = UNSET_VALUE
           @roles_path          = UNSET_VALUE
           @synced_folder_type  = UNSET_VALUE
         end
@@ -47,6 +52,7 @@ module VagrantPlugins
           end
 
           @data_bags_path    = [] if @data_bags_path == UNSET_VALUE
+          @nodes_path        = [] if @nodes_path == UNSET_VALUE
           @roles_path        = [] if @roles_path == UNSET_VALUE
           @environments_path = [] if @environments_path == UNSET_VALUE
           @environments_path = [@environments_path].flatten
@@ -54,6 +60,7 @@ module VagrantPlugins
           # Make sure the path is an array.
           @cookbooks_path    = prepare_folders_config(@cookbooks_path)
           @data_bags_path    = prepare_folders_config(@data_bags_path)
+          @nodes_path        = prepare_folders_config(@nodes_path)
           @roles_path        = prepare_folders_config(@roles_path)
           @environments_path = prepare_folders_config(@environments_path)
 

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -33,12 +33,14 @@ module VagrantPlugins
           @role_folders      = expanded_folders(@config.roles_path, "roles")
           @data_bags_folders = expanded_folders(@config.data_bags_path, "data_bags")
           @environments_folders = expanded_folders(@config.environments_path, "environments")
+          @node_folders = expanded_folders(@config.nodes_path, "nodes")
 
           existing = synced_folders(@machine, cached: true)
           share_folders(root_config, "csc", @cookbook_folders, existing)
           share_folders(root_config, "csr", @role_folders, existing)
           share_folders(root_config, "csdb", @data_bags_folders, existing)
           share_folders(root_config, "cse", @environments_folders, existing)
+          share_folders(root_config, "csn", @node_folders, existing)
         end
 
         def provision

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
 
         attr_reader :environments_folders
         attr_reader :cookbook_folders
+        attr_reader :node_folders
         attr_reader :role_folders
         attr_reader :data_bags_folders
 
@@ -160,6 +161,7 @@ module VagrantPlugins
           {
             cookbooks_path: guest_paths(@cookbook_folders),
             recipe_url: @config.recipe_url,
+            nodes_path: guest_paths(@node_folders),
             roles_path: guest_paths(@role_folders),
             data_bags_path: guest_paths(@data_bags_folders).first,
             environments_path: guest_paths(@environments_folders).first

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -44,6 +44,7 @@ module VagrantPlugins
             local_mode: true,
             enable_reporting: false,
             cookbooks_path: guest_paths(@cookbook_folders),
+            nodes_path: guest_paths(@node_folders),
             roles_path: guest_paths(@role_folders),
             data_bags_path: guest_paths(@data_bags_folders).first,
             environments_path: guest_paths(@environments_folders).first,

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -31,8 +31,8 @@ environment "<%= environment %>"
 <% if local_mode -%>
 local_mode true
 <% end -%>
-<% if node_path -%>
-node_path <%= node_path.inspect %>
+<% if nodes_path -%>
+node_path <%= nodes_path.inspect %>
 <% end -%>
 
 http_proxy <%= http_proxy.inspect %>

--- a/templates/provisioners/chef_zero/zero.erb
+++ b/templates/provisioners/chef_zero/zero.erb
@@ -31,8 +31,8 @@ environment "<%= environment %>"
 chef_zero.enabled true
 local_mode true
 <% end -%>
-<% if node_path -%>
-node_path <%= node_path.inspect %>
+<% if nodes_path -%>
+node_path <%= nodes_path.inspect %>
 <% end -%>
 
 <% if formatter %>

--- a/test/unit/plugins/provisioners/chef/config/chef_solo_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/chef_solo_test.rb
@@ -57,6 +57,14 @@ describe VagrantPlugins::Chef::Config::ChefSolo do
     end
   end
 
+  describe "#nodes_path" do
+    it "defaults to an empty array" do
+      subject.finalize!
+      expect(subject.nodes_path).to be_a(Array)
+      expect(subject.nodes_path).to be_empty
+    end
+  end
+
   describe "#synced_folder_type" do
     it "defaults to nil" do
       subject.finalize!

--- a/test/unit/plugins/provisioners/chef/config/chef_zero_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/chef_zero_test.rb
@@ -50,6 +50,14 @@ describe VagrantPlugins::Chef::Config::ChefZero do
     end
   end
 
+  describe "#nodes_path" do
+    it "defaults to an empty array" do
+      subject.finalize!
+      expect(subject.nodes_path).to be_a(Array)
+      expect(subject.nodes_path).to be_empty
+    end
+  end
+
   describe "#synced_folder_type" do
     it "defaults to nil" do
       subject.finalize!

--- a/website/docs/source/v2/provisioning/chef_solo.html.md
+++ b/website/docs/source/v2/provisioning/chef_solo.html.md
@@ -42,6 +42,9 @@ available below this section.
 * `environments_path` (string) - A path where environment definitions are
   located. By default, no environments folder is set.
 
+* `nodes_path` (string or array) - A list of paths where node objects (in JSON format) are stored. By default, no
+  nodes path is set.
+
 * `environment` (string) - The environment you want the Chef run to be
   a part of. This requires Chef 11.6.0 or later, and that `environments_path`
   is set.

--- a/website/docs/source/v2/provisioning/chef_zero.html.md
+++ b/website/docs/source/v2/provisioning/chef_zero.html.md
@@ -41,6 +41,9 @@ available below this section.
 * `environments_path` (string) - A path where environment definitions are
   located. By default, no environments folder is set.
 
+* `nodes_path` (string or array) - A list of paths where node objects (in JSON format) are stored. By default, no
+  nodes path is set.
+
 * `environment` (string) - The environment you want the Chef run to be
   a part of. This requires Chef 11.6.0 or later, and that `environments_path`
   is set.


### PR DESCRIPTION
This fixes an issue #6025 by re-adding support for the `nodes_path` declaration to feed Chef Zero a directory (or an array of directories) containing nodes in JSON format.