### PR TITLE
Fix string parse error in the environment path missing error message.

### DIFF
--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -143,7 +143,7 @@ module VagrantPlugins
               if !expanded_environment_file.file? && !expanded_environment_file.directory?
                 errors << I18n.t("vagrant.provisioners.puppet.environment_missing",
                                  environment: environment.to_s,
-                                 environment_path: expanded_path.to_s)
+                                 environmentpath: expanded_path.to_s)
               end
             end
           end


### PR DESCRIPTION
Small typo in the puppet environment code.

Currently if you specify puppet.environmentpath and it is missing, you get this error:

C:/HashiCorp/Vagrant/embedded/gems/gems/i18n-0.7.0/lib/i18n/config.rb:92:in `block in missing_interpolation_argument_handler': missing interpolation argument :environmentpath in "The configured Puppet environment folder %{environment} was not found in the\nspecified environmentpath %{environmentpath}.\nPlease specify a path to an existing Puppet directory environment." ({:environment=>"test", :environment_path=>"C:/Users/bhines/Documents/Code/t/puppet"} given) (I18n::MissingInterpolationArgument)
        from C:/HashiCorp/Vagrant/embedded/gems/gems/i18n-0.7.0/lib/i18n/interpolate/ruby.rb:29:in `call'


post-fix:

There are errors in the configuration of this machine. Please fix
the following errors and try again:

puppet provisioner:
* The configured Puppet environment folder test was not found in the
specified environmentpath C:/Users/bhines/Documents/Code/puppet.
Please specify a path to an existing Puppet directory environment.
