### PR TITLE
Stop trying to upload minion config to privileged directory

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -20,7 +20,6 @@ module VagrantPlugins
       attr_accessor :bootstrap_script
       attr_accessor :verbose
       attr_accessor :seed_master
-      attr_accessor :config_dir
       attr_reader   :pillar_data
       attr_accessor :colorize
       attr_accessor :log_level
@@ -65,7 +64,6 @@ module VagrantPlugins
         @install_command = UNSET_VALUE
         @no_minion = UNSET_VALUE
         @bootstrap_options = UNSET_VALUE
-        @config_dir = UNSET_VALUE
         @masterless = UNSET_VALUE
         @minion_id = UNSET_VALUE
         @version = UNSET_VALUE
@@ -98,7 +96,6 @@ module VagrantPlugins
         @install_command    = nil if @install_command == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
-        @config_dir         = nil if @config_dir == UNSET_VALUE
         @masterless         = false if @masterless == UNSET_VALUE
         @minion_id          = nil if @minion_id == UNSET_VALUE
         @version            = nil if @version == UNSET_VALUE
@@ -109,17 +106,6 @@ module VagrantPlugins
       def pillar(data)
         @pillar_data = {} if @pillar_data == UNSET_VALUE
         @pillar_data = Vagrant::Util::DeepMerge.deep_merge(@pillar_data, data)
-      end
-
-      def default_config_dir(machine)
-        guest_type = machine.config.vm.guest || :linux
-
-        # FIXME: there should be a way to do that a bit smarter
-        if guest_type == :windows
-          return "C:\\salt\\conf"
-        else
-          return "/etc/salt"
-        end
       end
 
       def validate(machine)
@@ -159,10 +145,6 @@ module VagrantPlugins
 
         if @install_master && !@no_minion && !@seed_master && @run_highstate
           errors << I18n.t("vagrant.provisioners.salt.must_accept_keys")
-        end
-
-        if @config_dir.nil?
-          @config_dir = default_config_dir(machine)
         end
 
         return {"salt provisioner" => errors}

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -342,11 +342,6 @@ module VagrantPlugins
       end
 
       def call_highstate
-        if @config.minion_config
-          @machine.env.ui.info "Copying salt minion config to #{@config.config_dir}"
-          @machine.communicate.upload(expanded_path(@config.minion_config).to_s, @config.config_dir + "/minion")
-        end
-
         if @config.masterless
           call_masterless
         elsif @config.run_highstate


### PR DESCRIPTION
The issue #5973 was caused by commit 74d22069d41b35bae50e32c1c68a92a4958afebb. Normally, the minion config is installed to the privileged `/etc/salt` directory by `salt-bootstrap.sh` as part of the `config_salt()` function. The reverted commit was having Vagrant upload the minion file *directly* to the `/etc/salt` directory - most installations probably don't have permissions to do this since vagrant is not running as root.

The original commit was to address situations where vagrant was being used with a basebox that already had salt installed. For these situations, users can simply provide the "-C" option as part of `bootstrap_options".

I've spent hours sorting this out and [addressing another issue with salt-bootstrap](https://github.com/saltstack/salt-bootstrap/pull/642) (I have to install from `develop` by modifying the `bootstrap-salt.sh` file in my vagrant gem). For the record, just use `rvm` - don't try to install without it.