### PR TITLE
Fix broken masterless minion configuration

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -104,7 +104,7 @@ module VagrantPlugins
           options = "%s %s" % [options, @config.bootstrap_options]
         end
 
-        if configure && !@machine.config.vm.communicator == :winrm
+        if configure && @machine.config.vm.communicator != :winrm
           options = "%s -F -c %s" % [options, config_dir]
         end
 


### PR DESCRIPTION
Vagrant 1.7.4 seems to break the masterless provisioning process for SaltStack.

It throws an error during provisioning:

```
Salt binaries found. Configuring only.
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

/tmp/bootstrap_salt.sh  -C

Stdout from the command:



Stderr from the command:

  % Total    % Received % Xferd  Average Speed  Time    Time    Time  Current
                                Dload  Upload  Total  Spent    Left  Speed
  0    0    0    0    0    0      0      0 --:--:-- --:--:-- --:--:--    0 * ERROR: In order to run the script in configuration only mode you also need to provide the configuration directory.
23  204k  23 48521    0    0  257k      0 --:--:-- --:--:-- --:--:--  929k
curl: (23) Failed writing body (631 != 16384)
```

The parameters for the configuration path are missing. Seems to be due to a typo in the code in a recently merged PR (#5980)