### PR TITLE
Add check if NetworkManager is actually running inside the guest

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -107,7 +107,9 @@ module VagrantPlugins
           interfaces.each do |interface|
             retryable(on: Vagrant::Errors::VagrantError, tries: 3, sleep: 2) do
               machine.communicate.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-#{interface}")
-              machine.communicate.sudo("! which nmcli >/dev/null 2>&1 || nmcli c reload #{interface}")
+              if machine.communicate.test("/usr/bin/systemctl --quiet is-active NetworkManager")
+                 machine.communicate.sudo("! which nmcli >/dev/null 2>&1 || nmcli c reload #{interface}")
+               end
               machine.communicate.sudo("/sbin/ifdown #{interface}", error_check: true)
               machine.communicate.sudo("/sbin/ifup #{interface}")
             end


### PR DESCRIPTION
Hi,
Our custom boxes are based on oracle linux 7.X, but we have disabled NetworkManager, because of our product specific. AFAIK other peoples also prefer to disable NM, due to different reasons.

My request try to address the situation when NM rpm is installed but the service isn't running inside the guest.