### PR TITLE
Remove upper bounds on bundler in gemspec

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", ">= 1.5.2", "<= 1.10.5"
+  s.add_dependency "bundler", ">= 1.5.2"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"


### PR DESCRIPTION
Because there seem to be fairly [regular bundler releases](https://github.com/bundler/bundler/commits/master/lib/bundler/version.rb),
a strict upper bounds causes problems for those keeping up to date.