### PR TITLE
Update winrm-fs to fix Windows 10 problems

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rest-client", ">= 1.6.0", "< 2.0"
   s.add_dependency "wdm", "~> 0.1.0"
   s.add_dependency "winrm", "~> 1.3"
-  s.add_dependency "winrm-fs", "~> 0.2.0"
+  s.add_dependency "winrm-fs", "~> 0.2.2"
 
   # We lock this down to avoid compilation issues.
   s.add_dependency "nokogiri", "= 1.6.3.1"


### PR DESCRIPTION
Update winrm-fs 0.2.2 fixes some problems with Windows 10 guests.
I have solved my issue similar to #6060 and #6055 running on OSX 10.10.4 with VirtualBox 5.0.0 spinning up a Windows 10 guest VM.
