### PR TITLE
Stabilize wait_for_ready to fix Windows 10 start problem

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -30,7 +30,10 @@ module VagrantPlugins
           # Wait for winrm_info to be ready
           winrm_info = nil
           while true
-            winrm_info = Helper.winrm_info(@machine)
+            begin
+              winrm_info = Helper.winrm_info(@machine)
+            rescue Errors::WinRMNotReady
+            end
             break if winrm_info
             sleep 0.5
           end


### PR DESCRIPTION
The `wait_for_ready` helper waits until WinRM is ready. Spinning up a Windows 10 guest VM sometimes the inner function `winrm_info` raises the exection `WinRMNotReady`. By ignoring this exception the `wait_for_ready` waits correctly until an IP address could be retrieved.

This solves my problem on OSX 10.10.4 with VMware Fusion 7.1.2 spinning up a Windows 10 VM in issue #6131.
