### PR TITLE
Fixes Fedora network issues when biosdevname command is not present.

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -17,7 +17,10 @@ module VagrantPlugins
           virtual = false
           interface_names = Array.new
           interface_names_by_slot = Array.new
-          machine.communicate.sudo("/usr/sbin/biosdevname; echo $?") do |_, result|
+          machine.communicate.sudo("/usr/sbin/biosdevname &>/dev/null; echo $?") do |_, result|
+            # The above command returns:
+            #   - '4' if /usr/sbin/biosdevname detects it is running in a virtual machine
+            #   - '127' if /usr/sbin/biosdevname doesn't exist
             virtual = true if ['4', '127'].include? result.chomp
           end
 


### PR DESCRIPTION
Previously, configuring and enabling network interfaces failed with:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

/usr/sbin/biosdevname --policy=all_ethN -i bash: /usr/sbin/biosdevname:
No such file or directory

Stdout from the command:

bash: /usr/sbin/biosdevname: No such file or directory
```

The previous attempt to fix this (ccc4162) doesn't work since it doesn't
properly parse the `bash: /usr/sbin/biosdevname: No such file or
directory` error message.

This patch works around that problem and adds a comment explaining the
meaning of the return codes.