### PR TITLE
The docs typo'd the nic_type parameter

### DIFF
--- a/website/docs/source/v2/virtualbox/networking.html.md
+++ b/website/docs/source/v2/virtualbox/networking.html.md
@@ -36,8 +36,8 @@ end
 
 ## VirtualBox NIC Type
 
-You can specify a specific nictype for the created network interface
-by using the `nictype` parameter. This isn't prefixed by `virtualbox__`
+You can specify a specific NIC type for the created network interface
+by using the `nic_type` parameter. This isn't prefixed by `virtualbox__`
 for legacy reasons, but is VirtualBox-specific.
 
 This is an advanced option and should only be used if you know what
@@ -48,6 +48,6 @@ Example:
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.network "private_network", ip: "192.168.50.4",
-    nictype: "virtio"
+    nic_type: "virtio"
 end
 ```


### PR DESCRIPTION
The parameter name in the VirtualBox provider source is nic_type, not nictype.

The typo is probably caused by the fact that the parameter maps to nictype args in the VirtualBox CLI.