### PR TITLE
Don't warn about an .1 IP for DHCP networks

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -688,7 +688,7 @@ module VagrantPlugins
               end
             end
 
-            if options[:ip] && options[:ip].end_with?(".1")
+            if options[:ip] && options[:ip].end_with?(".1") && options[:type].to_sym != :dhcp
               machine.ui.warn(I18n.t(
                 "vagrant.config.vm.network_ip_ends_in_one"))
             end


### PR DESCRIPTION
When the network's type is :dhcp, the :ip option is used to derive the DHCP server configuration, and it doesn't actually indicate the IP that will be received by the VM(s).