### PR TITLE
website/www: Add Atlas box search to nav

### DIFF
--- a/website/www/source/layouts/layout.erb
+++ b/website/www/source/layouts/layout.erb
@@ -41,6 +41,7 @@
 			 <ul class="pull-right unstyled">
 				 <li class="pill"><a href="/vmware">VMware Integration</a></li>
 				 <li><a href="/downloads.html">Downloads</a></li>
+				 <li><a href="https://atlas.hashicorp.com/boxes/search">Boxes</a></li>
 				 <li><a href="https://docs.vagrantup.com/">Documentation</a></li>
 				 <li><a href="/blog.html">Blog</a></li>
 				 <li><a href="/about.html">About</a></li>


### PR DESCRIPTION
I think that there should be a prominent link to box discovery on the Vagrant home page.
A few times I've Googled "vagrant", ended up here, and didn't know how to get to a box search page without doing another Google search.

However, a better solution may be to add a `<section>` with "Discover Vagrant Boxes on Atlas".