### PR TITLE
Change docs for checkpoint environment variable

### DIFF
--- a/website/docs/source/v2/other/environmental-variables.html.md
+++ b/website/docs/source/v2/other/environmental-variables.html.md
@@ -17,13 +17,16 @@ when launching Vagrant from the official installer, you can specify the
 `VAGRANT_DEBUG_LAUNCHER` environment variable to output debugging information
 about the launch process.
 
-## CHECKPOINT\_DISABLE
+## VAGRANT\_CHECKPOINT\_DISABLE
 
 Vagrant does occasional network calls to check whether the version of Vagrant
 that is running locally is up to date. We understand that software making remote
 calls over the internet for any reason can be undesirable. To surpress these
-calls, set the environment variable `CHECKPOINT_DISABLE` to any
+calls, set the environment variable `VAGRANT_CHECKPOINT_DISABLE` to any
 non-empty value.
+
+If you use other HashiCorp tools like Packer and would prefer to configure this
+setting only once, you can set `CHECKPOINT_DISABLE` instead.
 
 ## VAGRANT\_CWD
 

--- a/website/docs/source/v2/other/environmental-variables.html.md
+++ b/website/docs/source/v2/other/environmental-variables.html.md
@@ -17,12 +17,12 @@ when launching Vagrant from the official installer, you can specify the
 `VAGRANT_DEBUG_LAUNCHER` environment variable to output debugging information
 about the launch process.
 
-## VAGRANT\_CHECKPOINT\_DISABLE
+## CHECKPOINT\_DISABLE
 
 Vagrant does occasional network calls to check whether the version of Vagrant
 that is running locally is up to date. We understand that software making remote
 calls over the internet for any reason can be undesirable. To surpress these
-calls, set the environment variable `VAGRANT_CHECKPOINT_DISABLE` to any
+calls, set the environment variable `CHECKPOINT_DISABLE` to any
 non-empty value.
 
 ## VAGRANT\_CWD


### PR DESCRIPTION
Now reflects the not-vagrant-specific version, `CHECKPOINT_DISABLE`