### PR TITLE
fix network detection on pld-linux

### DIFF
--- a/plugins/guests/pld/cap/flavor.rb
+++ b/plugins/guests/pld/cap/flavor.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module GuestPld
+    module Cap
+      class Flavor
+        def self.flavor(machine)
+          return :pld
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/pld/plugin.rb
+++ b/plugins/guests/pld/plugin.rb
@@ -20,6 +20,11 @@ module VagrantPlugins
         require_relative "cap/network_scripts_dir"
         Cap::NetworkScriptsDir
       end
+
+      guest_capability("pld", "flavor") do
+        require_relative "cap/flavor"
+        Cap::Flavor
+      end
     end
   end
 end


### PR DESCRIPTION
pld linux uses redhat as base, but lacks :flavour
this will add it