### PR TITLE
Update to bundler 1.10.6 which fixes parallel gem installations

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", ">= 1.5.2", "<= 1.10.5"
+  s.add_dependency "bundler", ">= 1.5.2", "<= 1.10.6"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"


### PR DESCRIPTION
Parallel installation with (e.g. `bundle install --jobs=<n>`) got broken with earlier 1.10.x versions.

This was fixed again in 1.10.6, see bundler/bundler#3799

See also chef/omnibus-chef#464