### PR TITLE
Fix invalid ini entry error when ansible_ssh_private_key_file contains spaces

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -127,7 +127,7 @@ module VagrantPlugins
             m = @machine.env.machine(*am)
             m_ssh_info = m.ssh_info
             if !m_ssh_info.nil?
-              inventory += "#{m.name} ansible_ssh_host=#{m_ssh_info[:host]} ansible_ssh_port=#{m_ssh_info[:port]} ansible_ssh_private_key_file=#{m_ssh_info[:private_key_path][0]}\n"
+              inventory += "#{m.name} ansible_ssh_host=#{m_ssh_info[:host]} ansible_ssh_port=#{m_ssh_info[:port]} ansible_ssh_private_key_file='#{m_ssh_info[:private_key_path][0]}'\n"
               inventory_machines[m.name] = m
             else
               @logger.error("Auto-generated inventory: Impossible to get SSH information for machine '#{m.name} (#{m.provider_name})'. This machine should be recreated.")

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -168,7 +168,7 @@ VF
         expect(config.inventory_path).to be_nil
         expect(File.exists?(generated_inventory_file)).to be_true
         inventory_content = File.read(generated_inventory_file)
-        expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_private_key_file=#{machine.ssh_info[:private_key_path][0]}\n")
+        expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_private_key_file='#{machine.ssh_info[:private_key_path][0]}'\n")
         expect(inventory_content).to include("# MISSING: '#{iso_env.machine_names[1]}' machine was probably removed without using Vagrant. This machine should be recreated.\n")
       }
     end


### PR DESCRIPTION
This patch fixes `Invalid ini entry` error when ansible_ssh_private_key_file contains spaces in generated inventory file.

The error:
```bash
$ pwd
/Users/konomae/Dropbox (Personal)/test

$ cat Vagrantfile  
Vagrant.configure(2) do |config|
  config.vm.box = "hashicorp/precise64"

  config.vm.provision :ansible do |ansible|
    ansible.playbook = "site.yml"
  end
end

$ cat site.yml 
---
# empty

$ vagrant provision 
==> default: Running provisioner: ansible...
ERROR: /Users/konomae/Dropbox (Personal)/test/.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory:3: Invalid ini entry: (Personal)/test/.vagrant/machines/default/virtualbox/private_key - need more than 1 value to unpack
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.

```

