### PR TITLE
Add ssh-user to ansible inventory

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -127,7 +127,7 @@ module VagrantPlugins
             m = @machine.env.machine(*am)
             m_ssh_info = m.ssh_info
             if !m_ssh_info.nil?
-              inventory += "#{m.name} ansible_ssh_host=#{m_ssh_info[:host]} ansible_ssh_port=#{m_ssh_info[:port]} ansible_ssh_private_key_file=#{m_ssh_info[:private_key_path][0]}\n"
+              inventory += "#{m.name} ansible_ssh_host=#{m_ssh_info[:host]} ansible_ssh_port=#{m_ssh_info[:port]} ansible_ssh_private_key_file=#{m_ssh_info[:private_key_path][0]} ansible_ssh_user=#{m_ssh_info[:username]}\n"
               inventory_machines[m.name] = m
             else
               @logger.error("Auto-generated inventory: Impossible to get SSH information for machine '#{m.name} (#{m.provider_name})'. This machine should be recreated.")

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -168,7 +168,7 @@ VF
         expect(config.inventory_path).to be_nil
         expect(File.exists?(generated_inventory_file)).to be_true
         inventory_content = File.read(generated_inventory_file)
-        expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_private_key_file=#{machine.ssh_info[:private_key_path][0]}\n")
+        expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_private_key_file=#{machine.ssh_info[:private_key_path][0]} ansible_ssh_user=#{machine.ssh_info[:username]}\n")
         expect(inventory_content).to include("# MISSING: '#{iso_env.machine_names[1]}' machine was probably removed without using Vagrant. This machine should be recreated.\n")
       }
     end


### PR DESCRIPTION
The configured ssh user is not added to ansible's inventory file, causing connection errors late one.
While vagrant connects as "vagrant", ansible connects as the current one.

Example:
```
GNS-3node-2 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2207 ansible_ssh_private_key_file=/home/jan/vagrant/.vagrant/machines/GNS-3node-2/virtualbox/private_key 
```
Error:
```
 ansible -vvv -i inventory GNS-3node-2 -m ping
<127.0.0.1> ESTABLISH CONNECTION FOR USER: jan
<127.0.0.1> REMOTE_MODULE ping
<127.0.0.1> EXEC ['ssh', '-C', '-tt', '-q', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/home/jan/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=2207', '-o', 'IdentityFile="/home/jan/vagrant/.vagrant/machines/GNS-3node-2/virtualbox/private_key"', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey', '-o', 'PasswordAuthentication=no', '-o', 'ConnectTimeout=10', '127.0.0.1', "/bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1440842011.53-32279685471205 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1440842011.53-32279685471205 && echo $HOME/.ansible/tmp/ansible-tmp-1440842011.53-32279685471205'"]
GNS-3node-2 | FAILED => SSH encountered an unknown error during the connection. We recommend you re-run the command using -vvvv, which will enable SSH debugging output to help diagnose the issue

```

This patches changes the way the inventory is generated by adding the configured user
Example:
```
GNS-3node-2 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2207 ansible_ssh_private_key_file=/home/jan/vagrant/.vagrant/machines/GNS-3node-2/virtualbox/private_key ansible_ssh_user=vagrant
```