### PR TITLE
Added execution_time_limit for WinRM.

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -210,7 +210,8 @@ module VagrantPlugins
 
         "powershell -executionpolicy bypass -file \"#{guest_script_path}\" " +
           "-username \"#{shell.username}\" -password \"#{shell.password}\" " +
-          "-encoded_command \"#{wrapped_encoded_command}\""
+          "-encoded_command \"#{wrapped_encoded_command}\" " +
+          "-execution_time_limit \"#{shell.config.execution_time_limit}\""
       end
 
       # Handles the raw WinRM shell result and converts it to a

--- a/plugins/communicators/winrm/config.rb
+++ b/plugins/communicators/winrm/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :timeout
       attr_accessor :transport
       attr_accessor :ssl_peer_verification
+      attr_accessor :execution_time_limit
 
       def initialize
         @username               = UNSET_VALUE
@@ -23,6 +24,7 @@ module VagrantPlugins
         @timeout                = UNSET_VALUE
         @transport              = UNSET_VALUE
         @ssl_peer_verification  = UNSET_VALUE
+        @execution_time_limit   = UNSET_VALUE
       end
 
       def finalize!
@@ -37,6 +39,7 @@ module VagrantPlugins
         @retry_delay = 2       if @retry_delay == UNSET_VALUE
         @timeout = 1800        if @timeout == UNSET_VALUE
         @ssl_peer_verification = true if @ssl_peer_verification == UNSET_VALUE
+        @execution_time_limit = "PT2H"   if @execution_time_limit == UNSET_VALUE
       end
 
       def validate(machine)
@@ -49,6 +52,7 @@ module VagrantPlugins
         errors << "winrm.max_tries cannot be nil."   if @max_tries.nil?
         errors << "winrm.retry_delay cannot be nil." if @max_tries.nil?
         errors << "winrm.timeout cannot be nil."     if @timeout.nil?
+        errors << "winrm.execution_time_limit cannot be nil."     if @execution_time_limit.nil?
         unless @ssl_peer_verification == true || @ssl_peer_verification == false
           errors << "winrm.ssl_peer_verification must be a boolean."
         end

--- a/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
+++ b/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
@@ -33,7 +33,7 @@ $task_xml = @'
     <Hidden>false</Hidden>
     <RunOnlyIfIdle>false</RunOnlyIfIdle>
     <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+    <ExecutionTimeLimit>{execution_time_limit}</ExecutionTimeLimit>
     <Priority>4</Priority>
   </Settings>
   <Actions Context="Author">
@@ -49,6 +49,7 @@ $arguments = "/c powershell.exe -EncodedCommand $encoded_command &gt; $out_file 
 
 $task_xml = $task_xml.Replace("{arguments}", $arguments)
 $task_xml = $task_xml.Replace("{username}", $username)
+$task_xml = $task_xml.Replace("{execution_time_limit}", $execution_time_limit)
 
 $schedule = New-Object -ComObject "Schedule.Service"
 $schedule.Connect()


### PR DESCRIPTION
This pull request adds a configurable value for winrm and the elevated permission shell max execution time. Please see mitchellh/vagrant#5506

I have tested with my the machine that I have been running but I have not ran the suite of tests.