### PR TITLE
Winrm execution timeout

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -210,7 +210,8 @@ module VagrantPlugins
 
         "powershell -executionpolicy bypass -file \"#{guest_script_path}\" " +
           "-username \"#{shell.username}\" -password \"#{shell.password}\" " +
-          "-encoded_command \"#{wrapped_encoded_command}\""
+          "-encoded_command \"#{wrapped_encoded_command}\" " +
+          "-execution_time_limit \"#{shell.execution_time_limit}\""
       end
 
       # Handles the raw WinRM shell result and converts it to a

--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -38,6 +38,7 @@ module VagrantPlugins
           # Got it! Let the user know what we're connecting to.
           @machine.ui.detail("WinRM address: #{shell.host}:#{shell.port}")
           @machine.ui.detail("WinRM username: #{shell.username}")
+          @machine.ui.detail("WinRM execution_time_limit: #{shell.execution_time_limit}")
           @machine.ui.detail("WinRM transport: #{shell.config.transport}")
 
           last_message = nil

--- a/plugins/communicators/winrm/config.rb
+++ b/plugins/communicators/winrm/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :timeout
       attr_accessor :transport
       attr_accessor :ssl_peer_verification
+      attr_accessor :execution_time_limit
 
       def initialize
         @username               = UNSET_VALUE
@@ -23,6 +24,7 @@ module VagrantPlugins
         @timeout                = UNSET_VALUE
         @transport              = UNSET_VALUE
         @ssl_peer_verification  = UNSET_VALUE
+        @execution_time_limit   = UNSET_VALUE
       end
 
       def finalize!
@@ -37,6 +39,7 @@ module VagrantPlugins
         @retry_delay = 2       if @retry_delay == UNSET_VALUE
         @timeout = 1800        if @timeout == UNSET_VALUE
         @ssl_peer_verification = true if @ssl_peer_verification == UNSET_VALUE
+        @execution_time_limit = "PT2H"   if @execution_time_limit == UNSET_VALUE
       end
 
       def validate(machine)
@@ -49,6 +52,7 @@ module VagrantPlugins
         errors << "winrm.max_tries cannot be nil."   if @max_tries.nil?
         errors << "winrm.retry_delay cannot be nil." if @max_tries.nil?
         errors << "winrm.timeout cannot be nil."     if @timeout.nil?
+        errors << "winrm.execution_time_limit cannot be nil."     if @execution_time_limit.nil?
         unless @ssl_peer_verification == true || @ssl_peer_verification == false
           errors << "winrm.ssl_peer_verification must be a boolean."
         end

--- a/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
+++ b/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
@@ -1,4 +1,4 @@
-param([String]$username, [String]$password, [String]$encoded_command)
+param([String]$username, [String]$password, [String]$encoded_command, [String]$execution_time_limit)
 
 $task_name = "WinRM_Elevated_Shell"
 $out_file = "$env:SystemRoot\Temp\WinRM_Elevated_Shell.log"
@@ -33,7 +33,7 @@ $task_xml = @'
     <Hidden>false</Hidden>
     <RunOnlyIfIdle>false</RunOnlyIfIdle>
     <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+    <ExecutionTimeLimit>{execution_time_limit}</ExecutionTimeLimit>
     <Priority>4</Priority>
   </Settings>
   <Actions Context="Author">
@@ -49,6 +49,7 @@ $arguments = "/c powershell.exe -EncodedCommand $encoded_command &gt; $out_file 
 
 $task_xml = $task_xml.Replace("{arguments}", $arguments)
 $task_xml = $task_xml.Replace("{username}", $username)
+$task_xml = $task_xml.Replace("{execution_time_limit}", $execution_time_limit)
 
 $schedule = New-Object -ComObject "Schedule.Service"
 $schedule.Connect()

--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -37,6 +37,7 @@ module VagrantPlugins
       attr_reader :port
       attr_reader :username
       attr_reader :password
+      attr_reader :execution_time_limit
       attr_reader :config
 
       def initialize(host, port, config)
@@ -47,6 +48,7 @@ module VagrantPlugins
         @port                  = port
         @username              = config.username
         @password              = config.password
+        @execution_time_limit  = config.execution_time_limit
         @config                = config
       end
 

--- a/test/unit/plugins/communicators/winrm/communicator_test.rb
+++ b/test/unit/plugins/communicators/winrm/communicator_test.rb
@@ -20,6 +20,7 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
   before do
     allow(shell).to receive(:username).and_return('vagrant')
     allow(shell).to receive(:password).and_return('password')
+    allow(shell).to receive(:execution_time_limit).and_return('PT2H')
   end
 
   describe ".ready?" do
@@ -56,7 +57,7 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
       expect(shell).to receive(:upload).with(kind_of(String), "c:/tmp/vagrant-elevated-shell.ps1")
       expect(shell).to receive(:powershell) do |cmd|
         expect(cmd).to eq("powershell -executionpolicy bypass -file \"c:/tmp/vagrant-elevated-shell.ps1\" " +
-          "-username \"vagrant\" -password \"password\" -encoded_command \"ZABpAHIAOwAgAGUAeABpAHQAIAAkAEwAQQBTAFQARQBYAEkAVABDAE8ARABFAA==\"")
+          "-username \"vagrant\" -password \"password\" -encoded_command \"ZABpAHIAOwAgAGUAeABpAHQAIAAkAEwAQQBTAFQARQBYAEkAVABDAE8ARABFAA==\" -execution_time_limit \"PT2H\"")
       end.and_return({ exitcode: 0 })
       expect(subject.execute("dir", { elevated: true })).to eq(0)
     end


### PR DESCRIPTION
Please see mitchellh/vagrant#5506

Adds a configurable value for WinRm and the elevated permission shell ExecutionTimeLimit.

Ex: config.winrm.execution_time_limit = "P1D"

Unit tests are passing, please consider for merge.