### PR TITLE
communicators/winrm: respect boot_timeout when fetching winrm_info

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -30,7 +30,12 @@ module VagrantPlugins
           # Wait for winrm_info to be ready
           winrm_info = nil
           while true
-            winrm_info = Helper.winrm_info(@machine)
+            winrm_info = nil
+            begin
+              winrm_info = Helper.winrm_info(@machine)
+            rescue Errors::WinRMNotReady
+              @logger.debug("WinRM not ready yet; retrying until boot_timeout is reached.")
+            end
             break if winrm_info
             sleep 0.5
           end


### PR DESCRIPTION
We gained a ton of improvemnts to WinRM error handling in
https://github.com/mitchellh/vagrant/pull/4943, but we also got one bug.

The new code raises an exception when `winrm_info` does not return right
away. This was preventing us from catching the retry/timout logic that's
meant to wait until boot_timeout for the WinRM communicator to be ready.

This restores the proper behavior by rescuing the WinRMNotReady
exception and continuing to retry until the surrounding timeout fires.