### PR TITLE
Use a .NET API call instead of a Win8+ cmdlet 

### DIFF
--- a/plugins/synced_folders/smb/scripts/host_info.ps1
+++ b/plugins/synced_folders/smb/scripts/host_info.ps1
@@ -1,11 +1,21 @@
 $ErrorAction = "Stop"
 
-$net = Get-NetIPAddress | Where-Object {
-    ($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")
-} | Sort-Object $_.AddressFamily
+# Find all of the NICsq
+$nics = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()
+
+# Save the IP addresses somewhere
+$nic_ip_addresses = @()
+
+foreach ($nic in $nics) {
+    $nic_ip_addresses += $nic.GetIPProperties().UnicastAddresses | Where-Object {
+      ($_.Address.IPAddressToString -ne "127.0.0.1") -and ($_.Address.IPAddressToString -ne "::1")
+    } | Select -ExpandProperty Address
+}
+
+$nic_ip_addresses = $nic_ip_addresses | Sort-Object $_.AddressFamily
 
 $result = @{
-	ip_addresses = $net.IPAddress
+	ip_addresses = $nic_ip_addresses.IPAddressToString
 }
 
 Write-Output $(ConvertTo-Json $result)


### PR DESCRIPTION
Resolves Issue #6046 

The root cause is that Windows 7 doesn't have Get-NetIPAddress (see: https://stackoverflow.com/questions/19529442/gather-ip-address-information)
but the change was to try and solve the bug that the VPN IP addresses aren't visible detailed
here: https://support.microsoft.com/en-us/kb/2549091

Resolved using the 2nd solution from http://serverfault.com/questions/145259/powershell-win32-networkadapterconfiguration-not-seeing-ppp-adapter