### PR TITLE
Make global-status output JSON [GH-6236]

### DIFF
--- a/plugins/commands/global-status/command.rb
+++ b/plugins/commands/global-status/command.rb
@@ -16,6 +16,9 @@ module VagrantPlugins
           o.on("--prune", "Prune invalid entries.") do |p|
             options[:prune] = true
           end
+          o.on("--json", "Output in JSON-format.") do |p|
+            options[:json] = true
+          end
         end
 
         # Parse the options
@@ -63,6 +66,18 @@ module VagrantPlugins
         prune.each do |entry|
           deletable = @env.machine_index.get(entry.id)
           @env.machine_index.delete(deletable) if deletable
+        end
+
+        if options[:json]
+          entries_as_hashes = entries.map do |entry|
+            columns.each_with_object({}) do |(header, method), hash|
+              hash[header] = entry.send(method).to_s
+            end
+          end
+          @env.ui.info(JSON.pretty_generate(entries_as_hashes))
+
+          # Success, exit status 0
+          return 0
         end
 
         total_width = 0

--- a/test/unit/plugins/commands/global-status/command_test.rb
+++ b/test/unit/plugins/commands/global-status/command_test.rb
@@ -77,4 +77,22 @@ describe VagrantPlugins::CommandGlobalStatus::Command do
       expect(entries[0].name).to eq(entryC_machine.name.to_s)
     end
   end
+
+  describe "execute with --json" do
+    let(:argv) { ["--json"] }
+
+    it "outputs JSON" do
+      # Let's put some things in the index
+      iso_env.machine_index.set(new_entry("foo"))
+      iso_env.machine_index.set(new_entry("bar"))
+
+      expect(iso_env.ui).to receive(:info).with { |message, _|
+        global_status_hash_list = JSON.parse(message)
+        expect(global_status_hash_list[0]["name"]).to eq("foo")
+        expect(global_status_hash_list[1]["name"]).to eq("bar")
+      }
+
+      expect(subject.execute).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Adds a "--json" flag to global-status to switch the command's output to
JSON.

Fixes #6236