### PR TITLE
samphippen/bugfix/5605

### DIFF
--- a/test/unit/vagrant/config/loader_test.rb
+++ b/test/unit/vagrant/config/loader_test.rb
@@ -61,8 +61,11 @@ describe Vagrant::Config::Loader do
           end
         end.new(klass_with_bad_inspect_string)
       }
+
       it "does not raise the ascii encoding exception" do
-        instance.set(:arbitrary, test_source)
+        expect {
+          instance.set(:arbitrary, test_source)
+        }.to raise_error(ArgumentError, /Unknown configuration source/)
       end
     end
   end


### PR DESCRIPTION
Here we implement a naive solution to #5605 which catches the case that
a provided source contains an object which cannot be inspected, because
an object contained within in has an #inspect string that returns a
string that is incompatible with the encoding in
`Encoding.default_external` or a string which cannot be downcast to
7-bit ascii.

The Ruby VM implementation of "#inspect" implements this checking on
these lines of code: http://git.io/vZYNS. A Ruby level override of
this method does not cause this problem. For example:

```ruby
class Foo
  def inspect
    "😍".encode("UTF-16LE")
  end
```

will not cause the problem, because that's a Ruby implementation and the
VM's checks don't occur.

However, if we have an Object which **does** use the VM implementation
of inspect, that contains an object that has an inspect string which
returns non-ascii, we encounter the bug. For example:

```ruby
class Bar
  def inspect
    "😍".encode("UTF-16LE")
  end
end

class Foo
  def initialize
     @bar = Bar.new
  end
end

Foo.new.inspect
```

Will cause the issue.

The solution this patch provides basically catches the encoding error
and inserts a string which attempts to help the user work out which
object was provided without blowing up. Most likely, this was caused
by a user having a weird encoding coming out of one of the sources
passed in, but without a full repro case, it's not clear whether a patch
should be applied to a different object in the system.

Closes #5605.
