### PR TITLE
Fix typo in Salt provisioner documentation

### DIFF
--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -121,9 +121,9 @@ Either of the following may be used to actually execute runners
 during provisioning.
 
 * `run_overstate` - (boolean) Executes `state.over` on
-vagrant up. Can be applied to the master only. This is superceded by orchestrate. Not supported on Windows guest machines.
+vagrant up. Can be applied to the master only. This is superseded by orchestrate. Not supported on Windows guest machines.
 * `orchestrations` - (boolean) Executes `state.orchestrate` on
-vagrant up. Can be applied to the master only. This is supercedes by run_overstate. Not supported on Windows guest machines.
+vagrant up. Can be applied to the master only. This is superseded by run_overstate. Not supported on Windows guest machines.
 
 ## Output Control
 


### PR DESCRIPTION
Fixes #6227. A quick google search shows that "superseded" is more commonly used than "superceded", and vim's spellchecker agrees (as does Chrome's).