### PR TITLE
Fix verify_binary for Puppet for Windows guests.

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -150,7 +150,7 @@ module VagrantPlugins
           # This is very platform dependent.
           test_cmd = "sh -c 'command -v #{binary}'"
           if windows?
-            test_cmd = "which #{binary}"
+            test_cmd = "where #{binary}"
             if @config.binary_path
               test_cmd = "where \"#{@config.binary_path}:#{binary}\""
             end


### PR DESCRIPTION
Fixes a bug in the fix for https://github.com/mitchellh/vagrant/issues/5943 whereby 'which' is mistakenly used on Windows instead of 'where' to locate the Puppet binary.