### PR TITLE
Samphippen/bugfix/6065

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -182,7 +182,11 @@ module VagrantPlugins
         # Replace Windows line endings with Unix ones unless binary file
         # or we're running on Windows.
         if !config.binary && @machine.config.vm.communicator != :winrm
-          script.gsub!(/\r\n?$/, "\n")
+          begin
+            script.gsub!(/\r\n?$/, "\n")
+          rescue ArgumentError
+            script = script.force_encoding("ASCII-8BIT").gsub(/\r\n?$/, "\n")
+          end
         end
 
         # Otherwise we have an inline script, we need to Tempfile it,

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -1,0 +1,39 @@
+require File.expand_path("../../../../base", __FILE__)
+require Vagrant.source_root.join("plugins/provisioners/shell/provisioner")
+
+describe "Vagrant::Shell::Provisioner" do
+
+  let(:machine) {
+    double(:machine).tap { |machine|
+      machine.stub_chain(:config, :vm, :communicator).and_return(:not_winrm)
+      machine.stub_chain(:communicate, :tap) {}
+    }
+  }
+
+
+  context "with a script that contains invalid us-ascii byte sequences" do
+    let(:config) {
+      double(
+        :config,
+        :args        => "doesn't matter",
+        :upload_path => "arbitrary",
+        :remote?     => false,
+        :path        => nil,
+        :inline      => script_that_is_incorrectly_us_ascii_encoded,
+        :binary      => false,
+      )
+    }
+
+    let(:script_that_is_incorrectly_us_ascii_encoded) {
+      [207].pack("c*").force_encoding("US-ASCII")
+    }
+
+    it "does not raise an exception when normalizing newlines" do
+      vsp = VagrantPlugins::Shell::Provisioner.new(machine, config)
+
+      expect {
+        vsp.provision
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
The problem demonstrated in #6065 is that a string has incorrectly been
encoded with US-ASCII even though it contains invalid US-ASCII byte
sequences (any byte with the most significant bit on is invalid in the
US-ASCII encoding).

The thing about doing newline normalization is that it is not actually
sensitive to the presence of US-ASCII byte sequenzes. Additionally, it
is very unlikely that a user will ever be using an encoding where \r\n
is not encoded the same as it would be in ASCII.

This patch first tries the existing method of normalizing the newlines
in the provided script file, if that fails for any reason it force
encodes the string to ASCII-8BIT (which allows the most significant bit
to be on in any individual byte) and then performs the substitution in
that byte space.
