### PR TITLE
Restore nodes_path attribute for chef_solo and chef_zero provisioners.

### DIFF
--- a/plugins/provisioners/chef/config/chef_solo.rb
+++ b/plugins/provisioners/chef/config/chef_solo.rb
@@ -17,6 +17,10 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :environments_path
 
+        # The path where node objects are stored on disk.
+        # @return [String]
+        attr_accessor :nodes_path
+
         # A URL download a remote recipe from. Note: you should use chef-apply
         # instead.
         #
@@ -39,6 +43,7 @@ module VagrantPlugins
           @cookbooks_path      = UNSET_VALUE
           @data_bags_path      = UNSET_VALUE
           @environments_path   = UNSET_VALUE
+          @nodes_path          = UNSET_VALUE
           @recipe_url          = UNSET_VALUE
           @roles_path          = UNSET_VALUE
           @synced_folder_type  = UNSET_VALUE
@@ -86,6 +91,7 @@ module VagrantPlugins
           end
 
           @data_bags_path    = [] if @data_bags_path == UNSET_VALUE
+          @nodes_path        = [] if @nodes_path == UNSET_VALUE
           @roles_path        = [] if @roles_path == UNSET_VALUE
           @environments_path = [] if @environments_path == UNSET_VALUE
           @environments_path = [@environments_path].flatten
@@ -93,6 +99,7 @@ module VagrantPlugins
           # Make sure the path is an array.
           @cookbooks_path    = prepare_folders_config(@cookbooks_path)
           @data_bags_path    = prepare_folders_config(@data_bags_path)
+          @nodes_path        = prepare_folders_config(@nodes_path)
           @roles_path        = prepare_folders_config(@roles_path)
           @environments_path = prepare_folders_config(@environments_path)
         end

--- a/plugins/provisioners/chef/config/chef_zero.rb
+++ b/plugins/provisioners/chef/config/chef_zero.rb
@@ -17,6 +17,10 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :environments_path
 
+        # The path where node objects are stored on disk.
+        # @return [String]
+        attr_accessor :nodes_path
+
         # The path where roles are stored on disk.
         # @return [String]
         attr_accessor :roles_path
@@ -31,6 +35,7 @@ module VagrantPlugins
           @cookbooks_path      = UNSET_VALUE
           @data_bags_path      = UNSET_VALUE
           @environments_path   = UNSET_VALUE
+          @nodes_path          = UNSET_VALUE
           @roles_path          = UNSET_VALUE
           @synced_folder_type  = UNSET_VALUE
         end
@@ -47,6 +52,7 @@ module VagrantPlugins
           end
 
           @data_bags_path    = [] if @data_bags_path == UNSET_VALUE
+          @nodes_path        = [] if @nodes_path == UNSET_VALUE
           @roles_path        = [] if @roles_path == UNSET_VALUE
           @environments_path = [] if @environments_path == UNSET_VALUE
           @environments_path = [@environments_path].flatten
@@ -54,6 +60,7 @@ module VagrantPlugins
           # Make sure the path is an array.
           @cookbooks_path    = prepare_folders_config(@cookbooks_path)
           @data_bags_path    = prepare_folders_config(@data_bags_path)
+          @nodes_path        = prepare_folders_config(@nodes_path)
           @roles_path        = prepare_folders_config(@roles_path)
           @environments_path = prepare_folders_config(@environments_path)
 

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
 
         attr_reader :environments_folders
         attr_reader :cookbook_folders
+        attr_reader :node_folders
         attr_reader :role_folders
         attr_reader :data_bags_folders
 
@@ -30,6 +31,7 @@ module VagrantPlugins
 
         def configure(root_config)
           @cookbook_folders  = expanded_folders(@config.cookbooks_path, "cookbooks")
+          @node_folders      = expanded_folders(@config.nodes_path, "nodes")
           @role_folders      = expanded_folders(@config.roles_path, "roles")
           @data_bags_folders = expanded_folders(@config.data_bags_path, "data_bags")
           @environments_folders = expanded_folders(@config.environments_path, "environments")
@@ -39,6 +41,7 @@ module VagrantPlugins
           share_folders(root_config, "csr", @role_folders, existing)
           share_folders(root_config, "csdb", @data_bags_folders, existing)
           share_folders(root_config, "cse", @environments_folders, existing)
+          share_folders(root_config, "csn", @node_folders, existing)
         end
 
         def provision
@@ -158,6 +161,7 @@ module VagrantPlugins
           {
             cookbooks_path: guest_paths(@cookbook_folders),
             recipe_url: @config.recipe_url,
+            nodes_path: guest_paths(@node_folders).first,
             roles_path: guest_paths(@role_folders),
             data_bags_path: guest_paths(@data_bags_folders).first,
             environments_path: guest_paths(@environments_folders).first

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -44,6 +44,7 @@ module VagrantPlugins
             local_mode: true,
             enable_reporting: false,
             cookbooks_path: guest_paths(@cookbook_folders),
+            nodes_path: guest_paths(@node_folders).first,
             roles_path: guest_paths(@role_folders),
             data_bags_path: guest_paths(@data_bags_folders).first,
             environments_path: guest_paths(@environments_folders).first,

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -31,8 +31,8 @@ environment "<%= environment %>"
 <% if local_mode -%>
 local_mode true
 <% end -%>
-<% if node_path -%>
-node_path <%= node_path.inspect %>
+<% if nodes_path -%>
+node_path <%= nodes_path.inspect %>
 <% end -%>
 
 http_proxy <%= http_proxy.inspect %>

--- a/templates/provisioners/chef_zero/zero.erb
+++ b/templates/provisioners/chef_zero/zero.erb
@@ -31,8 +31,8 @@ environment "<%= environment %>"
 chef_zero.enabled true
 local_mode true
 <% end -%>
-<% if node_path -%>
-node_path <%= node_path.inspect %>
+<% if nodes_path -%>
+node_path <%= nodes_path.inspect %>
 <% end -%>
 
 <% if formatter %>

--- a/test/unit/plugins/provisioners/chef/config/chef_solo_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/chef_solo_test.rb
@@ -49,6 +49,14 @@ describe VagrantPlugins::Chef::Config::ChefSolo do
     end
   end
 
+  describe "#nodes_path" do
+    it "defaults to an empty array" do
+      subject.finalize!
+      expect(subject.nodes_path).to be_a(Array)
+      expect(subject.nodes_path).to be_empty
+    end
+  end
+
   describe "#roles_path" do
     it "defaults to an empty array" do
       subject.finalize!

--- a/test/unit/plugins/provisioners/chef/config/chef_zero_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/chef_zero_test.rb
@@ -42,6 +42,14 @@ describe VagrantPlugins::Chef::Config::ChefZero do
     end
   end
 
+  describe "#nodes_path" do
+    it "defaults to an empty array" do
+      subject.finalize!
+      expect(subject.nodes_path).to be_a(Array)
+      expect(subject.nodes_path).to be_empty
+    end
+  end
+
   describe "#roles_path" do
     it "defaults to an empty array" do
       subject.finalize!

--- a/website/docs/source/v2/provisioning/chef_solo.html.md
+++ b/website/docs/source/v2/provisioning/chef_solo.html.md
@@ -46,6 +46,9 @@ available below this section.
   a part of. This requires Chef 11.6.0 or later, and that `environments_path`
   is set.
 
+* `nodes_path` (string) - A path where node objects (in JSON format) are
+  stored. By default, no nodes path is set.
+
 * `recipe_url` (string) - URL to an archive of cookbooks that Chef will download
   and use.
 

--- a/website/docs/source/v2/provisioning/chef_zero.html.md
+++ b/website/docs/source/v2/provisioning/chef_zero.html.md
@@ -45,6 +45,9 @@ available below this section.
   a part of. This requires Chef 11.6.0 or later, and that `environments_path`
   is set.
 
+* `nodes_path` (string) - A path where node objects (in JSON format) are
+  stored. By default, no nodes path is set.
+
 * `roles_path` (string or array) - A list of paths where roles are defined.
   By default this is empty. Multiple role directories are only supported by
   Chef 11.8.0 and later.


### PR DESCRIPTION
This PR restores a working `nodes_path` attribute for both the chef_solo and chef_zero provisioners.

# Why?

I have a multi-VM Vagrantfile which declare a set of VMs, all provisioned by chef. I want to use the `chef search` feature to provision my multiple VMs together with chef (for example, I want to automatically configure a nginx load-balancer by searching all nodes for web services that I export in node attributes).

For the chef search to work, the node objects have to be persisted in a shared folder between chef-runs, so that chef-zero can load those node objects and return the node data in search.

When chef-zero provisioner was changed to use chef-client instead of chef solo (in #5339) the chef-zero provisioner became unusably slow (30+ minutes for me to synchronize the cookbooks, see #6208) so I had to find something else. When @sethvargo wrote that "the original Chef Zero provisioner was actually just Chef solo" I tried to use the chef-solo provisioner and found that it was broken regarding the nodes_path attribute.

Hence this PR to restore the nodes_path attribute for both provisioner.

For those who want to emulate the behavior of the vagrant <= 1.7.2 chef_zero provisioner, simply use the chef_solo provisioner while specifying "local_mode true" in a `custom_config_path` override.