### PR TITLE
Use dnf on Fedora guests instead of yum if available.

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -3,7 +3,11 @@ module VagrantPlugins
     module Cap
       class NFSClient
         def self.nfs_client_install(machine)
-          machine.communicate.sudo("yum -y install nfs-utils nfs-utils-lib")
+          if VagrantPlugins::GuestRedHat::Plugin.dnf?(machine)
+            machine.communicate.sudo("dnf -y install nfs-utils nfs-utils-lib")
+          else
+            machine.communicate.sudo("yum -y install nfs-utils nfs-utils-lib")
+          end
           restart_nfs(machine)
         end
 

--- a/plugins/guests/redhat/cap/rsync.rb
+++ b/plugins/guests/redhat/cap/rsync.rb
@@ -4,7 +4,11 @@ module VagrantPlugins
       class RSync
         def self.rsync_install(machine)
           machine.communicate.tap do |comm|
-            comm.sudo("yum -y install rsync")
+            if VagrantPlugins::GuestRedHat::Plugin.dnf?(machine)
+              comm.sudo("dnf -y install rsync")
+            else
+              comm.sudo("yum -y install rsync")
+            end
           end
         end
       end

--- a/plugins/guests/redhat/plugin.rb
+++ b/plugins/guests/redhat/plugin.rb
@@ -45,6 +45,10 @@ module VagrantPlugins
         require_relative "cap/rsync"
         Cap::RSync
       end
+
+      def self.dnf?(machine)
+        machine.communicate.test("/usr/bin/which -s dnf")
+      end
     end
   end
 end

--- a/plugins/provisioners/cfengine/cap/redhat/cfengine_install.rb
+++ b/plugins/provisioners/cfengine/cap/redhat/cfengine_install.rb
@@ -14,8 +14,18 @@ module VagrantPlugins
               logger.info("Installing CFEngine Community Yum Repository GPG KEY from #{config.repo_gpg_key_url}")
               comm.sudo("GPGFILE=$(mktemp) && wget -O $GPGFILE #{config.repo_gpg_key_url} && rpm --import $GPGFILE; rm -f $GPGFILE")
 
-              comm.sudo("yum -y install #{config.package_name}")
+              if dnf?(machine)
+                comm.sudo("dnf -y install #{config.package_name}")
+              else
+                comm.sudo("yum -y install #{config.package_name}")
+              end
             end
+          end
+
+          protected
+
+          def self.dnf?(machine)
+            machine.communicate.test("/usr/bin/which -s dnf")
           end
         end
       end

--- a/plugins/provisioners/chef/cap/redhat/chef_install.rb
+++ b/plugins/provisioners/chef/cap/redhat/chef_install.rb
@@ -6,10 +6,20 @@ module VagrantPlugins
       module Redhat
         module ChefInstall
           def self.chef_install(machine, version, prerelease, download_path)
-            machine.communicate.sudo("yum install -y -q curl")
+            if dnf?(machine)
+              machine.communicate.sudo("dnf install -y -q curl")
+            else
+              machine.communicate.sudo("yum install -y -q curl")
+            end
 
             command = Omnibus.build_command(version, prerelease, download_path)
             machine.communicate.sudo(command)
+          end
+
+          protected
+
+          def self.dnf?(machine)
+            machine.communicate.test("/usr/bin/which -s dnf")
           end
         end
       end

--- a/plugins/provisioners/docker/cap/fedora/docker_install.rb
+++ b/plugins/provisioners/docker/cap/fedora/docker_install.rb
@@ -1,0 +1,31 @@
+module VagrantPlugins
+  module DockerProvisioner
+    module Cap
+      module Fedora
+        module DockerInstall
+          def self.docker_install(machine, version)
+            if version != :latest
+              machine.ui.warn(I18n.t("vagrant.docker_install_with_version_not_supported"))
+            end
+
+            machine.communicate.tap do |comm|
+              if dnf?(machine)
+                comm.sudo("dnf -y install docker")
+              else
+                comm.sudo("yum -y install docker")
+              end
+              comm.sudo("systemctl start docker.service")
+              comm.sudo("systemctl enable docker.service")
+            end
+          end
+
+          protected
+
+          def self.dnf?(machine)
+            machine.communicate.test("/usr/bin/which -s dnf")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/docker/plugin.rb
+++ b/plugins/provisioners/docker/plugin.rb
@@ -24,6 +24,11 @@ module VagrantPlugins
         Cap::Debian::DockerStartService
       end
 
+      guest_capability("fedora", "docker_install") do
+        require_relative "cap/fedora/docker_install"
+        Cap::Fedora::DockerInstall
+      end
+
       guest_capability("redhat", "docker_install") do
         require_relative "cap/redhat/docker_install"
         Cap::Redhat::DockerInstall


### PR DESCRIPTION
Fixes #6286 now properly installs Docker on Fedora guests.
Fixes #6287 use dnf if available.