### PR TITLE
fix typo when removing tmp files

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -85,6 +85,7 @@ module Vagrant
       FileUtils.rm_rf(ENV["BUNDLE_APP_CONFIG"]) rescue nil
       File.unlink(ENV["BUNDLE_CONFIG"]) rescue nil
       File.unlink(ENV["BUNDLE_GEMFILE"]) rescue nil
+      File.unlink(ENV["BUNDLE_GEMFILE"]+".lock") rescue nil
     end
 
     # Installs the list of plugins.

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -81,7 +81,7 @@ module Vagrant
     def deinit
       File.unlink(ENV["BUNDLE_APP_CONFIG"]) rescue nil
       File.unlink(ENV["BUNDLE_CONFIG"]) rescue nil
-      File.unlink(ENV["GEMFILE"]) rescue nil
+      File.unlink(ENV["BUNDLE_GEMFILE"]) rescue nil
     end
 
     # Installs the list of plugins.

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -61,7 +61,9 @@ module Vagrant
       end
 
       # Setup the Bundler configuration
-      @configfile = File.open(Tempfile.new("vagrant").path + "1", "w+")
+      tempname = Tempfile.new("vagrant").path
+      File.unlink(tempname) rescue nil
+      @configfile = File.open(tempname + "1", "w+")
       @configfile.close
 
       # Build up the Gemfile for our Bundler context. We make sure to

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -2,6 +2,7 @@ require "monitor"
 require "pathname"
 require "set"
 require "tempfile"
+require "fileutils"
 
 require "bundler"
 
@@ -79,7 +80,7 @@ module Vagrant
 
     # Removes any temporary files created by init
     def deinit
-      File.unlink(ENV["BUNDLE_APP_CONFIG"]) rescue nil
+      FileUtils.rm_rf(ENV["BUNDLE_APP_CONFIG"]) rescue nil
       File.unlink(ENV["BUNDLE_CONFIG"]) rescue nil
       File.unlink(ENV["BUNDLE_GEMFILE"]) rescue nil
     end

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -177,7 +177,9 @@ module Vagrant
     def build_gemfile(plugins)
       sources = plugins.values.map { |p| p["sources"] }.flatten.compact.uniq
 
-      f = File.open(Tempfile.new("vagrant").path + "2", "w+")
+      tempname = Tempfile.new("vagrant").path
+      File.unlink(tempname) rescue nil
+      f = File.open(tempname + "2", "w+")
       f.tap do |gemfile|
         if !sources.include?("http://rubygems.org")
           gemfile.puts(%Q[source "https://rubygems.org"])

--- a/plugins/commands/ssh/command.rb
+++ b/plugins/commands/ssh/command.rb
@@ -55,6 +55,7 @@ module VagrantPlugins
             exit_status = env[:ssh_run_exit_status] || 0
             return exit_status
           else
+            Vagrant::Bundler.instance.deinit();
             @logger.debug("Invoking `ssh` action on machine")
             vm.action(:ssh, ssh_opts: ssh_opts)
 


### PR DESCRIPTION
This patch starts fixing #6116 and #6231 to remove at least the /tmp/d... folders and the temporary gemfile.