### PR TITLE
Fix/master/6306 chef windows capability

### DIFF
--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
           # @return [true, false]
           def self.chef_installed(machine, version)
             if version != :latest
-              command = 'if ((&knife --version) -Match "Chef: "' + version.to_s + '"){ exit 0 } else { exit 1 }'
+              command = 'if ((&knife --version) -Match "Chef: ' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else
               command = 'if ((&knife --version) -Match "Chef: *"){ exit 0 } else { exit 1 }'
             end

--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
           # @return [true, false]
           def self.chef_installed(machine, version)
             if version != :latest
-              command = 'if ((&knife --version) -Match "Chef: "' + version + '"){ exit 0 } else { exit 1 }'
+              command = 'if ((&knife --version) -Match "Chef: "' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else
               command = 'if ((&knife --version) -Match "Chef: *"){ exit 0 } else { exit 1 }'
             end


### PR DESCRIPTION
Fix for https://github.com/mitchellh/vagrant/issues/6306

Using Vagrant Vagrant 1.7.4, running the chef_client provisioner on a Windows guest (OSX host) fails with the following exception:

    /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/provisioners/chef/cap/windows/chef_installed.rb:11:in `+': no implicit conversion of Symbol into String (TypeError)
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/provisioners/chef/cap/windows/chef_installed.rb:11:in `chef_installed'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/capability_host.rb:111:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/capability_host.rb:111:in `capability'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/guest.rb:43:in `capability'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/provisioners/chef/installer.rb:42:in `should_install_chef?'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/provisioners/chef/installer.rb:23:in `ensure_installed'
    ...

By modifying the offending line to convert the version symbol to a string the command will always return false due to an extra double quote in the powershell 'Match' statement.

    ==> windows-test: Running provisioner: chef_client...
        windows-test: Installing Chef (12.4.1)...
    Vagrant attempted to execute the capability 'chef_install'
    on the detect guest OS 'windows', but the guest doesn't
    support that capability. This capability is required for your
    configuration of Vagrant. Please either reconfigure Vagrant to
    avoid this capability or fix the issue by creating the capability.
