### PR TITLE
Ignore Powershell progress updates on stderr

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -203,10 +203,11 @@ module VagrantPlugins
           file.unlink
         end
 
-        # convert to double byte unicode string then base64 encode
-        # just like PowerShell -EncodedCommand expects
+        # Convert to double byte unicode string then base64 encode
+        # just like PowerShell -EncodedCommand expects.
+        # Suppress the progress stream from leaking to stderr.
         wrapped_encoded_command = Base64.strict_encode64(
-          "#{command}; exit $LASTEXITCODE".encode('UTF-16LE', 'UTF-8'))
+          "$ProgressPreference='SilentlyContinue'; #{command}; exit $LASTEXITCODE".encode('UTF-16LE', 'UTF-8'))
 
         "powershell -executionpolicy bypass -file \"#{guest_script_path}\" " +
           "-username \"#{shell.username}\" -password \"#{shell.password}\" " +

--- a/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
+++ b/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
@@ -1,5 +1,6 @@
 param([String]$username, [String]$password, [String]$encoded_command)
 
+$ProgressPreference = "SilentlyContinue"
 $task_name = "WinRM_Elevated_Shell"
 $out_file = "$env:SystemRoot\Temp\WinRM_Elevated_Shell.log"
 

--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -51,8 +51,10 @@ module VagrantPlugins
       end
 
       def powershell(command, &block)
-        # ensure an exit code
+        # Suppress the progress stream from leaking to stderr
+        command = "$ProgressPreference='SilentlyContinue';\r\n" + command
         command << "\r\n"
+        # Ensure an exit code
         command << "if ($?) { exit 0 } else { if($LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 } }"
         execute_shell(command, :powershell, &block)
       end


### PR DESCRIPTION
This is to fix #6308

Starting with PowerShell 5, the progress bar can be observed via the Write-Progress cmdlet. From WinRM, this appears as a stderr output. This is a cross platform [issue](https://connect.microsoft.com/PowerShell/feedback/details/927384/progress-stream-being-sent-to-stderr-in-winrm-responses) as this is stream can't be distinguished by third party clients. Vagrant assumes that there is an error if output appears on stderr ([code](https://github.com/senglin/vagrant/blob/b721eb62cfbfa93895d0d4cf019436ab6b1df05d/plugins/communicators/winrm/communicator.rb#L158)) even when the return code is 0.

This terminates various scripts which previously executed successfully in Vagrant (prior to Windows 10).

This fix injects a variable assignment at various points of the script execution process to disable display of the progress bar.

## References
* The fix is similar to this [fix](https://github.com/WinRb/winrm-fs/pull/19) in WinRM-FS.
* [PowerShell 5 Preference Variables](https://technet.microsoft.com/en-us/library/hh847796.aspx)