### PR TITLE
Add 'Edit this page' links to `www` and `docs` websites

### DIFF
--- a/website/docs/Makefile
+++ b/website/docs/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+init:
+	bundle
+
+dev: init
+	bundle exec middleman server
+
+build: init
+	bundle exec middleman build

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -14,13 +14,7 @@ requests like any normal GitHub project, and we'll merge it in.
 
 ## Running the Site Locally
 
-Running the site locally is simple. Clone this repo and run the following
-commands:
+Running the site locally is simple. Clone this repo and run `make dev`.
 
-```
-$ bundle
-$ bundle exec middleman server
-```
-
-Then open up `localhost:4567`. Note that some URLs you may need to append
+Then open up `localhost:4567/v2`. Note that some URLs you may need to append
 ".html" to make them work (in the navigation and such).

--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -324,6 +324,8 @@
 							<li><a href="https://docs.vagrantup.com/">Documentation</a></li>
 							<li><a href="https://www.vagrantup.com/about">About</a></li>
 							<li><a href="https://www.vagrantup.com/support">Support</a></li>
+							<% github_link = 'https://github.com/mitchellh/vagrant/blob/master/' + current_page.source_file.match(/website.*/)[0] %>
+							<li class="li-under"><a href="<%= github_link %>">Edit this page</a></li>
 							<a href="https://www.vagrantup.com/downloads">
 								<li class="button inline-button">Download</li>
 							</a>

--- a/website/www/Makefile
+++ b/website/www/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+init:
+	bundle
+
+dev: init
+	bundle exec middleman server
+
+build: init
+	bundle exec middleman build

--- a/website/www/README.md
+++ b/website/www/README.md
@@ -14,13 +14,7 @@ requests like any normal GitHub project, and we'll merge it in.
 
 ## Running the Site Locally
 
-Running the site locally is simple. Clone this repo and run the following
-commands:
-
-```
-$ bundle
-$ bundle exec middleman server
-```
+Running the site locally is simple. Clone this repo and run `make dev`.
 
 Then open up `localhost:4567`. Note that some URLs you may need to append
 ".html" to make them work (in the navigation and such).

--- a/website/www/source/layouts/layout.erb
+++ b/website/www/source/layouts/layout.erb
@@ -59,6 +59,10 @@
 							 <li><a href="https://docs.vagrantup.com/">Documentation</a></li>
 							 <li><a href="/about.html">About</a></li>
 							 <li><a href="/support.html">Support</a></li>
+							 <% if current_page.url != "/" %>
+							 	<% github_link = 'https://github.com/mitchellh/vagrant/blob/master/' + current_page.source_file.match(/website.*/)[0] %>
+							 	<li class="li-under"><a href="<%= github_link %>">Edit this page</a></li>
+							 <% end %>
 							 <a href="/downloads.html">
 								 <li class="button inline-button">Download</li>
 							 </a>


### PR DESCRIPTION
Following [this pattern](https://github.com/mitchellh/packer/pull/2396), this PR adds 'edit this page' links to the footers of the Vagrant `docs` and `www` sites. Note that it also adds Makefiles for each Middleman site.