### PR TITLE
Update bundler version

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", ">= 1.5.2", "<= 1.10.5"
+  s.add_dependency "bundler", ">= 1.5.2", "<= 1.11"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"


### PR DESCRIPTION
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    vagrant (>= 0) x64-mingw32 depends on
      bundler (<= 1.10.5, >= 1.5.2) x64-mingw32

  Current Bundler version:
    bundler (1.10.6)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
Could not find gem 'bundler (<= 1.10.5, >= 1.5.2) x64-mingw32', which is
required by gem 'vagrant (>= 0) x64-mingw32', in any of the sources.