### PR TITLE
Bump to latest bundler

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", ">= 1.5.2", "<= 1.10.5"
+  s.add_dependency "bundler", ">= 1.5.2", "<= 1.10.6"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"


### PR DESCRIPTION
The changelog for Bundler 1.10.6 can be found here:
https://github.com/bundler/bundler/blob/c784ea3ade399fd487184493f7e8c0e340e7d6d7/CHANGELOG.md

I could find no changes which would affect vagrant.