### PR TITLE
Fix Slackware Host detection and nfsd checks

### DIFF
--- a/plugins/hosts/slackware/cap/nfs.rb
+++ b/plugins/hosts/slackware/cap/nfs.rb
@@ -3,7 +3,7 @@ module VagrantPlugins
     module Cap
       class NFS
         def self.nfs_check_command(env)
-          "pidof nfsd >/dev/null"
+          "/sbin/pidof nfsd >/dev/null"
         end
 
         def self.nfs_start_command(env)

--- a/plugins/hosts/slackware/host.rb
+++ b/plugins/hosts/slackware/host.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module HostSlackware
     class Host < Vagrant.plugin("2", :host)
       def detect?(env)
-        return File.exists?("/etc/slackware-release") ||
+        return File.exists?("/etc/slackware-version") ||
           !Dir.glob("/usr/lib/setup/Plamo-*").empty?
       end
     end


### PR DESCRIPTION
Slackware's version file is /etc/slackware-version not
/etc/slackware-release.
pidof is not on PATH by default (not running as root) so call it using
full path