### PR TITLE
[salt] [bugfix] Restablize Salt provisioner 

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -33,7 +33,6 @@ module VagrantPlugins
       attr_accessor :install_args
       attr_accessor :install_master
       attr_accessor :install_syndic
-      attr_accessor :install_command
       attr_accessor :no_minion
       attr_accessor :bootstrap_options
       attr_accessor :version
@@ -62,7 +61,6 @@ module VagrantPlugins
         @install_args = UNSET_VALUE
         @install_master = UNSET_VALUE
         @install_syndic = UNSET_VALUE
-        @install_command = UNSET_VALUE
         @no_minion = UNSET_VALUE
         @bootstrap_options = UNSET_VALUE
         @config_dir = UNSET_VALUE
@@ -95,7 +93,6 @@ module VagrantPlugins
         @install_args       = nil if @install_args == UNSET_VALUE
         @install_master     = nil if @install_master == UNSET_VALUE
         @install_syndic     = nil if @install_syndic == UNSET_VALUE
-        @install_command     = nil if @install_command == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @config_dir         = nil if @config_dir == UNSET_VALUE

--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -95,7 +95,7 @@ module VagrantPlugins
         @install_args       = nil if @install_args == UNSET_VALUE
         @install_master     = nil if @install_master == UNSET_VALUE
         @install_syndic     = nil if @install_syndic == UNSET_VALUE
-        @install_command    = nil if @install_command == UNSET_VALUE
+        @install_command     = nil if @install_command == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @config_dir         = nil if @config_dir == UNSET_VALUE

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -136,11 +136,7 @@ module VagrantPlugins
         end
 
         if @config.install_type
-          # Allow passing install_args as an arbitrary string rather
-          # than trying to format it based on known options
-          if @config.install_type != "custom"
-            options = "%s %s" % [options, @config.install_type]
-          end
+          options = "%s %s" % [options, @config.install_type]
         end
 
         if @config.install_args

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -136,18 +136,15 @@ module VagrantPlugins
         end
 
         if @config.install_type
-          options = "%s %s" % [options, @config.install_type]
+          # Allow passing install_args as an arbitrary string rather
+          # than trying to format it based on known options
+          if @config.install_type != "custom"
+            options = "%s %s" % [options, @config.install_type]
+          end
         end
 
         if @config.install_args
           options = "%s %s" % [options, @config.install_args]
-        end
-
-        if @config.install_command
-          # If this is defined, we will ignore both install_type and
-          # install_args and use this instead. Every necessary command option
-          # will need to be specified by the user.
-          options = @config.install_command
         end
 
         if @config.verbose

--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -54,18 +54,13 @@ on this machine. Not supported on Windows guest machines.
 * `install_syndic`   (boolean) - Install the salt-syndic, default
 `false`. Not supported on Windows guest machines.
 
-* `install_type`  (stable | git | daily | testing) - Whether to install from a
+* `install_type`  (stable | git | daily | testing | custom) - Whether to install from a
 distribution's stable package manager, git tree-ish, daily ppa, or testing repository.
-Not supported on Windows guest machines.
 
 * `install_args` (develop) - When performing a git install,
 you can specify a branch, tag, or any treeish. If using the `custom` install type,
 you can also specify a different repository to install from.
 Not supported on Windows guest machines.
-
-* `install_command` (string) - Allow specifying an arbitrary string of arguments
-to the bootstrap script. This will completely ignore `install_type` and `install_args`
-to allow more flexibility with the bootstrap process.
 
 * `always_install`   (boolean) - Installs salt binaries even
  if they are already detected, default `false`

--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -54,13 +54,10 @@ on this machine. Not supported on Windows guest machines.
 * `install_syndic`   (boolean) - Install the salt-syndic, default
 `false`. Not supported on Windows guest machines.
 
-* `install_type`  (stable | git | daily | testing | custom) - Whether to install from a
+* `install_type`  (stable | git | daily | testing) - Whether to install from a
 distribution's stable package manager, git tree-ish, daily ppa, or testing repository.
 
-* `install_args` (develop) - When performing a git install,
-you can specify a branch, tag, or any treeish. If using the `custom` install type,
-you can also specify a different repository to install from.
-Not supported on Windows guest machines.
+* `install_args` (develop) - When performing a git install, you can specify a branch, tag, or any treeish. Not supported on Windows.
 
 * `always_install`   (boolean) - Installs salt binaries even
  if they are already detected, default `false`


### PR DESCRIPTION
Hey all! This PR answers #6276. For the brave/bored, feel free to drill down through the referenced issues and PRs. 

For the everyone else, this PR reverts the show stopper bug introduced in #5435 and the work done on top of it in #5936. My goal was to simply bring the salt provisioner back to a working state. The issue seeming to involve vagrant using the Salt dummy config file instead of the file set with the `minion_config` setting.

### The Good

At provision time, the user supplied `minion_config` is copied to the inside the vagrant VM as you would expect. Therefore, the provisioner no longer hangs at "Bootstrapping Salt... (this may take a while)". This unblocks the Salt community. :confetti_ball: 

### The Bad

[There were no provision tests for the salt provisioner to begin with](https://github.com/mitchellh/vagrant/tree/master/test/unit/plugins/provisioners/salt). For the past 2 weeks, I've attempted to add some testing around the provisioner, however I've been unsuccessful. :disappointed: I would like the time/space to talk about why testing around the salt provisioner can not leverage the approach used in the [ansible](https://github.com/mitchellh/vagrant/blob/master/test/unit/plugins/provisioners/ansible/provisioner_test.rb), [shell](https://github.com/mitchellh/vagrant/blob/master/test/unit/plugins/provisioners/shell/provisioner_test.rb) and [chef](https://github.com/mitchellh/vagrant/blob/master/test/unit/plugins/provisioners/chef/provisioner/base_test.rb) provisioners, but for the sake of brevity let's make that a separate issue, if that's :cool:.

@mitchellh @timoguin @cachedout @thatch45 @wkral 