### PR TITLE
kruthar/disable provisioners

### DIFF
--- a/lib/vagrant/action/builtin/provision.rb
+++ b/lib/vagrant/action/builtin/provision.rb
@@ -102,12 +102,19 @@ module Vagrant
           type_map = provisioner_type_map(env)
           provisioner_instances(env).each do |p, options|
             type_name = type_map[p]
+
+            # Don't run if provision_types does not contain this provisioners type or name
             next if env[:provision_types] && \
               !env[:provision_types].include?(type_name) && \
               !env[:provision_types].include?(options[:name])
 
             # Don't run if sentinel is around and we're not always running
             next if !provision_enabled && options[:run] != :always
+
+            # Don't run if we are never running and not explicitly told to do so by name
+            next if options[:run] == :never && \
+              (env[:provision_types] == nil || \
+              !env[:provision_types].include?(options[:name]))
 
             name = type_name
             if options[:name]

--- a/lib/vagrant/action/builtin/provision.rb
+++ b/lib/vagrant/action/builtin/provision.rb
@@ -103,10 +103,15 @@ module Vagrant
           provisioner_instances(env).each do |p, options|
             type_name = type_map[p]
 
-            # Don't run if provision_types does not contain this provisioners type or name
+            # Don't run if provision_types does not contain this provisioner's type or name
             next if env[:provision_types] && \
               !env[:provision_types].include?(type_name) && \
               !env[:provision_types].include?(options[:name])
+
+            # Don't run if skip_provision_types contains this provisioner's type or name
+            next if env[:skip_provision_types] && \
+              (env[:skip_provision_types].include?(type_name) || \
+              env[:skip_provision_types].include?(options[:name]))
 
             # Don't run if sentinel is around and we're not always running
             next if !provision_enabled && options[:run] != :always

--- a/plugins/commands/provision/command.rb
+++ b/plugins/commands/provision/command.rb
@@ -12,11 +12,19 @@ module VagrantPlugins
         options[:provision_types] = nil
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant provision [vm-name] [--provision-with x,y,z]"
+          o.banner = "Usage: vagrant provision [vm-name] [options]"
+          o.separator ""
+          o.separator "Options:"
+          o.separator ""
 
           o.on("--provision-with x,y,z", Array,
-                    "Enable only certain provisioners, by type.") do |list|
+               "Enable only certain provisioners, by type.") do |list|
             options[:provision_types] = list.map { |type| type.to_sym }
+          end
+
+          o.on("--skip-provision-with x,y,z", Array,
+               "Skip certain provisioners, by type.") do |list|
+            options[:skip_provision_types] = list.map { |type| type.to_sym }
           end
         end
 

--- a/plugins/commands/up/start_mixins.rb
+++ b/plugins/commands/up/start_mixins.rb
@@ -22,6 +22,11 @@ module VagrantPlugins
           options[:provision_enabled] = true
           options[:provision_ignore_sentinel] = true
         end
+
+        parser.on("--skip-provision-with x,y,z", Array,
+             "Skip certain provisioners, by type.") do |list|
+          options[:skip_provision_types] = list.map { |type| type.to_sym }
+        end
       end
 
       # This validates the provisioner flags and raises an exception


### PR DESCRIPTION
This is addressing the feature additions I suggested in #6343. In this push are two simple features:
1. The 'run' attribute on provisioners in the Vagrantfile now accepts 'never' like so: `run: 'never'`. This will cause the provisioner with this attribute to never be run in the provisioning step of the machine unless explicitly told to do so using the --provision-with flag.
2. Added a --skip-provision-with flag that is the counter part to the --provision-with flag on actions that contain a provisioning step. Add `--skip-provision-with x,y,z` will provision with all provisioners specified for a machine except for provisioners x,y,z (type or name).

The combination of these two features give the user more control over what provisioners are getting run.
