### PR TITLE
Fix for #6151 / provisioner puppet_server with Puppet Collection 1

### DIFF
--- a/plugins/provisioners/puppet/config/puppet_server.rb
+++ b/plugins/provisioners/puppet/config/puppet_server.rb
@@ -2,6 +2,10 @@ module VagrantPlugins
   module Puppet
     module Config
       class PuppetServer < Vagrant.plugin("2", :config)
+        # The path to Puppet's bin/ directory.
+        # @return [String]
+        attr_accessor :binary_path
+
         attr_accessor :client_cert_path
         attr_accessor :client_private_key_path
         attr_accessor :facter
@@ -12,6 +16,7 @@ module VagrantPlugins
         def initialize
           super
 
+          @binary_path             = UNSET_VALUE
           @client_cert_path        = UNSET_VALUE
           @client_private_key_path = UNSET_VALUE
           @facter                  = {}
@@ -29,6 +34,7 @@ module VagrantPlugins
         def finalize!
           super
 
+          @binary_path      = nil if @binary_path == UNSET_VALUE
           @client_cert_path = nil if @client_cert_path == UNSET_VALUE
           @client_private_key_path = nil if @client_private_key_path == UNSET_VALUE
           @puppet_node   = nil if @puppet_node == UNSET_VALUE

--- a/plugins/provisioners/puppet/provisioner/puppet_server.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet_server.rb
@@ -17,8 +17,14 @@ module VagrantPlugins
         end
 
         def verify_binary(binary)
+          if @config.binary_path
+            test_cmd = "test -x #{@config.binary_path}/#{binary}"
+          else
+            test_cmd = "which #{binary}"
+          end
+
           @machine.communicate.sudo(
-            "which #{binary}",
+            test_cmd,
             error_class: PuppetServerError,
             error_key: :not_detected,
             binary: binary)
@@ -83,8 +89,13 @@ module VagrantPlugins
             facter = "#{facts.join(" ")} "
           end
 
+
+          puppet_bin = "puppet"
+          if @config.binary_path
+            puppet_bin = File.join(@config.binary_path, puppet_bin)
+          end
           options = options.join(" ")
-          command = "#{facter}puppet agent --onetime --no-daemonize #{options} " +
+          command = "#{facter} #{puppet_bin} agent --onetime --no-daemonize #{options} " +
             "--server #{config.puppet_server} --detailed-exitcodes || [ $? -eq 2 ]"
 
           @machine.ui.info I18n.t("vagrant.provisioners.puppet_server.running_puppetd")

--- a/website/docs/source/v2/provisioning/puppet_agent.html.md
+++ b/website/docs/source/v2/provisioning/puppet_agent.html.md
@@ -26,6 +26,8 @@ the set of modules and manifests from there.
 The `puppet_server` provisioner takes various options. None are strictly
 required. They are listed below:
 
+* `binary_path` (string) - Path on the guest to Puppet's `bin/` directory.
+
 * `client_cert_path` (string) - Path to the client certificate for the
   node on your disk. This defaults to nothing, in which case a client
   cert won't be uploaded.


### PR DESCRIPTION
puppet_server provisioner fails with Puppet Collection 1 with the
following error:

```bash
==> default: Running provisioner: puppet_server...
The `puppet` binary appears not to be in the PATH of the guest. This
could be because the PATH is not properly setup or perhaps Puppet is not
installed on this guest. Puppet provisioning can not continue without
Puppet properly installed.
```

refs #6151