### PR TITLE
Remove back tick in puppet facts definitions #6403 (Fix vagrant 1.7.3+ with puppet)

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -212,7 +212,7 @@ module VagrantPlugins
 
             # If we're on Windows, we need to use the PowerShell style
             if windows?
-              facts.map! { |v| "`$env:#{v};" }
+              facts.map! { |v| "$env:#{v};" }
             end
 
             facter = "#{facts.join(" ")} "


### PR DESCRIPTION
Starting with vagrant 1.7.3 (commit 1152b4e1df97fb5f468491954932d4f0c09875b1) we don't
save the command to be executed in the file anymore, but we send
it as a parameter, thus the back tick makes things break.

Fixes #6403 
CC #3958