### PR TITLE
#5186: Warning: Authentication failure. Retrying... after packaging box

### DIFF
--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -59,12 +59,20 @@ module VagrantPlugins
         # If the VM is not running that we can't possibly SSH into it
         return nil if state.id != :running
 
+        # If the insecure key was automatically replaced with a newly generated key pair,
+        # use this key to connect to the machine
+        private_key_path = nil
+        if @machine.data_dir.join("private_key").file?
+          private_key_path = @machine.data_dir.join("private_key")
+        end
+
         # Return what we know. The host is always "127.0.0.1" because
         # VirtualBox VMs are always local. The port we try to discover
         # by reading the forwarded ports.
         return {
           host: "127.0.0.1",
-          port: @driver.ssh_port(@machine.config.ssh.guest_port)
+          port: @driver.ssh_port(@machine.config.ssh.guest_port),
+          private_key_path: private_key_path
         }
       end
 


### PR DESCRIPTION
After replacing the insecure key and writing a new key to .vagrant/machines/default/virtualbox/private_key vagrant continues to use the old insecure key ( /Users/myuser/.vagrant.d/boxes/mybox/0/virtualbox/vagrant_private_key)

This patch instructs vagrant to search first for the newly generated key and use this key if it is already generated.