### PR TITLE
Debian 8 machines will not shutdown gracefully

### DIFF
--- a/plugins/guests/debian8/cap/halt.rb
+++ b/plugins/guests/debian8/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("shutdown -h -H")
+            machine.communicate.sudo("shutdown -h now")
           rescue IOError
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.


### PR DESCRIPTION
-H causes the machine to halt instead of poweroff and leaving a time causes the machine to wait 1 minute before shutdown.