### PR TITLE
Allow setting of ssh LogLevel in Vagrantfile

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -442,6 +442,8 @@ module Vagrant
       # Add in provided proxy command config
       info[:proxy_command] = @config.ssh.proxy_command if @config.ssh.proxy_command
 
+      info[:log_level] = @config.ssh.log_level if @config.ssh.log_level
+
       # Set the private key path. If a specific private key is given in
       # the Vagrantfile we set that. Otherwise, we use the default (insecure)
       # private key, but only if the provider didn't give us one.

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -102,7 +102,7 @@ module Vagrant
         options[:username] = ssh_info[:username]
         options[:private_key_path] = ssh_info[:private_key_path]
 
-        log_level = ssh_info[:log_level] || "FATAL"
+        log_level = ssh_info[:log_level]
 
         # Command line options
         command_options = [

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -41,7 +41,8 @@ module VagrantPlugins
             forward_agent: ssh_info[:forward_agent],
             forward_x11:   ssh_info[:forward_x11],
             proxy_command: ssh_info[:proxy_command],
-            ssh_command: ssh_info[:ssh_command]
+            ssh_command: ssh_info[:ssh_command],
+            log_level: ssh_info[:log_level]
           }
 
           # Render the template and output directly to STDOUT

--- a/plugins/kernel_v1/config/ssh.rb
+++ b/plugins/kernel_v1/config/ssh.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :forward_agent
       attr_accessor :forward_x11
       attr_accessor :shell
+      attr_accessor :log_level
 
       def initialize
         @username         = UNSET_VALUE
@@ -27,6 +28,7 @@ module VagrantPlugins
         @forward_agent    = UNSET_VALUE
         @forward_x11      = UNSET_VALUE
         @shell            = UNSET_VALUE
+        @log_level        = UNSET_VALUE
       end
 
       def upgrade(new)
@@ -38,6 +40,7 @@ module VagrantPlugins
         new.ssh.forward_agent    = @forward_agent if @forward_agent != UNSET_VALUE
         new.ssh.forward_x11      = @forward_x11 if @forward_x11 != UNSET_VALUE
         new.ssh.shell            = @shell if @shell != UNSET_VALUE
+        new.ssh.log_level        = @log_level if @log_level != UNSET_VALUE
       end
     end
   end

--- a/plugins/kernel_v2/config/ssh.rb
+++ b/plugins/kernel_v2/config/ssh.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       attr_accessor :forward_x11
       attr_accessor :guest_port
       attr_accessor :keep_alive
+      attr_accessor :log_level
       attr_accessor :shell
       attr_accessor :proxy_command
       attr_accessor :ssh_command
@@ -24,6 +25,7 @@ module VagrantPlugins
         @forward_x11   = UNSET_VALUE
         @guest_port    = UNSET_VALUE
         @keep_alive    = UNSET_VALUE
+        @log_level     = UNSET_VALUE
         @proxy_command = UNSET_VALUE
         @ssh_command   = UNSET_VALUE
         @pty           = UNSET_VALUE
@@ -47,6 +49,7 @@ module VagrantPlugins
         @forward_x11   = false if @forward_x11 == UNSET_VALUE
         @guest_port = 22 if @guest_port == UNSET_VALUE
         @keep_alive = true if @keep_alive == UNSET_VALUE
+        @log_level = "FATAL" if @log_level == UNSET_VALUE
         @proxy_command = nil if @proxy_command == UNSET_VALUE
         @ssh_command = nil if @ssh_command == UNSET_VALUE
         @pty        = false if @pty == UNSET_VALUE

--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -13,7 +13,7 @@ Host <%= host_key %>
 <% end -%>
 <% end -%>
   IdentitiesOnly yes
-  LogLevel FATAL
+  LogLevel <%= log_level %>
 <% if forward_agent -%>
   ForwardAgent yes
 <% end -%>

--- a/test/unit/plugins/commands/ssh_config/command_test.rb
+++ b/test/unit/plugins/commands/ssh_config/command_test.rb
@@ -24,7 +24,8 @@ describe VagrantPlugins::CommandSSHConfig::Command do
     username:         "testuser",
     private_key_path: [],
     forward_agent:    false,
-    forward_x11:      false
+    forward_x11:      false,
+    log_level:        "FATAL"
   }}
 
   subject { described_class.new(argv, iso_env) }
@@ -80,6 +81,19 @@ Host #{machine.name}
       subject.execute
 
       expect(output).to include("ForwardX11 yes")
+    end
+
+    it "sets log level to whatever it is configured to" do
+      allow(machine).to receive(:ssh_info) { ssh_info.merge(log_level: "QUIET") }
+
+      output = ""
+      allow(subject).to receive(:safe_puts) do |data|
+        output += data if data
+      end
+
+      subject.execute
+
+      expect(output).to include("LogLevel QUIET")
     end
 
     it "handles multiple private key paths" do

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -584,6 +584,13 @@ describe Vagrant::Machine do
         expect(instance.ssh_info[:forward_x11]).to eq(false)
       end
 
+      it "should set the configured log level" do
+        provider_ssh_info[:log_level] = "FATAL"
+        instance.config.ssh.log_level = "QUIET"
+
+        expect(instance.ssh_info[:log_level]).to eq("QUIET")
+      end
+
       it "should return the provider private key if given" do
         provider_ssh_info[:private_key_path] = "/foo"
 

--- a/website/docs/source/v2/vagrantfile/ssh_settings.html.md
+++ b/website/docs/source/v2/vagrantfile/ssh_settings.html.md
@@ -67,6 +67,13 @@ is enabled. Defaults to false.
 
 <hr>
 
+`config.ssh.log_level` - Sets the verbosity level of SSH logging messages.
+Possible values are QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2,
+and DEBUG3. The same values found in `ssh_config`'s man page. Defaults to
+FATAL.
+
+<hr>
+
 `config.ssh.insert_key` - If `true`, Vagrant will automatically insert
 an keypair to use for SSH, replacing the default Vagrant's insecure key
 inside the machine if detected. By default, this is true.


### PR DESCRIPTION
This PR allows users to set the LogLevel ssh configuration whenever they do `vagrant ssh`.