### PR TITLE
#6315-FIX Added diversion when Virtualbox is used.

### DIFF
--- a/plugins/guests/debian8/cap/halt.rb
+++ b/plugins/guests/debian8/cap/halt.rb
@@ -1,10 +1,16 @@
 module VagrantPlugins
   module GuestDebian8
     module Cap
-      class Halt
+    class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("shutdown -h -H")
+            machine.communicate.tap do |comm|
+              if comm.test("lsmod |grep -w vboxguest")
+                machine.communicate.sudo("shutdown -h now")
+              else
+                machine.communicate.sudo("shutdown -h -H")
+              end
+            end
           rescue IOError
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.


### PR DESCRIPTION
The debian8 guest addition is mandatory to running GNU/Linux Debian 8 (aka jessie) with the provider plugin 'vmware_fusion'. Virtualbox users complained that shutdown -h -H has broke something and prefer to use the shutdown -h now command.
This patch try to make everybody happy.. ;)
Please before using a head Double Ax and drop the code, make some considération to the "Commercial Users" who uses the vmware provider plugins from https://www.vagrantup.com/vmware.
perhaps the vmware plugins need some patch to fix this bugs ?

Hope this help.