### PR TITLE
core: machine-readable output should include standard UI output

### DIFF
--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -103,6 +103,12 @@ module Vagrant
         raise Errors::UIExpectsTTY
       end
 
+      [:detail, :warn, :error, :info, :output, :success].each do |method|
+        define_method(method) do |message, *opts|
+          machine("ui", method.to_s, message)
+        end
+      end
+
       def machine(type, *data)
         opts = {}
         opts = data.pop if data.last.kind_of?(Hash)

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -215,6 +215,24 @@ describe Vagrant::UI::MachineReadable do
     end
   end
 
+  [:detail, :warn, :error, :info, :output, :success].each do |method|
+    describe "##{method}" do
+      it "outputs UI type to the machine-readable output" do
+        expect(subject).to receive(:safe_puts).with { |message|
+          parts = message.split(",")
+          expect(parts.length).to eq(5)
+          expect(parts[1]).to eq("")
+          expect(parts[2]).to eq("ui")
+          expect(parts[3]).to eq(method.to_s)
+          expect(parts[4]).to eq("foo")
+          true
+        }
+
+        subject.send(method, "foo")
+      end
+    end
+  end
+
   describe "#machine" do
     it "is formatted properly" do
       expect(subject).to receive(:safe_puts).with { |message|


### PR DESCRIPTION
This includes the standard UI output in the machine-readable UI. We do this because it is sometimes convenient to parse this out and select what UI output you want. 