### PR TITLE
Guard against modifying 'localhost' in /etc/hosts

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -48,7 +48,9 @@ module VagrantPlugins
         # 127.0.0.1   localhost
         # 127.0.1.1   host.fqdn.com host.fqdn host
         def update_etc_hosts
-          if test("grep '#{current_hostname}' /etc/hosts")
+          # We don't want to modify a localhost entry
+          if current_hostname != 'localhost' &&
+            test("grep '#{current_hostname}' /etc/hosts")
             # Current hostname entry is in /etc/hosts
             ip_address = '([0-9]{1,3}\.){3}[0-9]{1,3}'
             search     = "^(#{ip_address})\\s+#{Regexp.escape(current_hostname)}(\\s.*)?$"


### PR DESCRIPTION
If /etc/hostname is initially set to 'localhost' then the localhost line in /etc/hosts can get mangled.

Addresses https://github.com/mitchellh/vagrant/issues/6446