### PR TITLE
Fix for interpolated strings being used for username and passwords

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -214,7 +214,7 @@ module VagrantPlugins
           "#{command}; exit $LASTEXITCODE".encode('UTF-16LE', 'UTF-8'))
 
         "powershell -executionpolicy bypass -file \"#{guest_script_path}\" " +
-          "-username \"#{shell.username}\" -password \"#{shell.password}\" " +
+          "-username \'#{shell.username}\' -password \'#{shell.password}\' " +
           "-encoded_command \"#{wrapped_encoded_command}\""
       end
 


### PR DESCRIPTION
This fix was made in commit 1dd081d but was removed by 1152b4e. This was causing passwords with $ in them to stop working as the dollar sign was getting stripped out. 