### PR TITLE
Fix for interpolated strings being used for username and passwords

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -214,7 +214,7 @@ module VagrantPlugins
           "#{command}; exit $LASTEXITCODE".encode('UTF-16LE', 'UTF-8'))
 
         "powershell -executionpolicy bypass -file \"#{guest_script_path}\" " +
-          "-username \"#{shell.username}\" -password \"#{shell.password}\" " +
+          "-username \'#{shell.username}\' -password \'#{shell.password}\' " +
           "-encoded_command \"#{wrapped_encoded_command}\""
       end
 

--- a/test/unit/plugins/communicators/winrm/communicator_test.rb
+++ b/test/unit/plugins/communicators/winrm/communicator_test.rb
@@ -88,7 +88,7 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
       expect(shell).to receive(:upload).with(kind_of(String), "c:/tmp/vagrant-elevated-shell.ps1")
       expect(shell).to receive(:powershell) do |cmd|
         expect(cmd).to eq("powershell -executionpolicy bypass -file \"c:/tmp/vagrant-elevated-shell.ps1\" " +
-          "-username \"vagrant\" -password \"password\" -encoded_command \"ZABpAHIAOwAgAGUAeABpAHQAIAAkAEwAQQBTAFQARQBYAEkAVABDAE8ARABFAA==\"")
+          "-username \'vagrant\' -password \'password\' -encoded_command \"ZABpAHIAOwAgAGUAeABpAHQAIAAkAEwAQQBTAFQARQBYAEkAVABDAE8ARABFAA==\"")
       end.and_return({ exitcode: 0 })
       expect(subject.execute("dir", { elevated: true })).to eq(0)
     end


### PR DESCRIPTION
This fix was made in commit 1dd081d but was removed by 1152b4e. This was causing passwords with $ in them to stop working as the dollar sign was getting stripped out