### PR TITLE
Fix custom minion_config upload

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -344,7 +344,7 @@ module VagrantPlugins
       def call_highstate
         if @config.minion_config
           @machine.env.ui.info "Copying salt minion config to #{@config.config_dir}"
-          @machine.communicate.upload(expanded_path(@config.minion_config).to_s, @config.config_dir + "/minion")
+          @machine.communicate.sudo("cp #{temp_config_dir + "/minion"} #{@config.config_dir + "/minion"}")
         end
 
         if @config.masterless


### PR DESCRIPTION
If a custom minion_config is specified, upload it during
the upload_configs step, then use sudo to copy into the config_dir
instead of uploading it again.