### PR TITLE
Prefer xfreerdp for RDP connections on Linux hosts.

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -408,8 +408,8 @@ module Vagrant
       error_key(:linux_nfs_mount_failed)
     end
 
-    class LinuxRDesktopNotFound < VagrantError
-      error_key(:linux_rdesktop_not_found)
+    class LinuxRDPClientNotFound < VagrantError
+      error_key(:linux_rdp_client_not_found)
     end
 
     class LocalDataDirectoryNotAccessible < VagrantError

--- a/plugins/hosts/linux/cap/rdp.rb
+++ b/plugins/hosts/linux/cap/rdp.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
             elsif Vagrant::Util::Which.which("rdesktop")
               "rdesktop"
             else
-              raise Vagrant::Errors::LinuxRDesktopNotFound
+              raise Vagrant::Errors::LinuxRDPClientNotFound
             end
 
           args = []

--- a/plugins/hosts/linux/cap/rdp.rb
+++ b/plugins/hosts/linux/cap/rdp.rb
@@ -5,17 +5,35 @@ module VagrantPlugins
     module Cap
       class RDP
         def self.rdp_client(env, rdp_info)
-          if !Vagrant::Util::Which.which("rdesktop")
-            raise Vagrant::Errors::LinuxRDesktopNotFound
-          end
+          # Detect if an RDP client is available.
+          # Prefer xfreerdp as it supports newer versions of RDP.
+          rdp_client =
+            if Vagrant::Util::Which.which("xfreerdp")
+              "xfreerdp"
+            elsif Vagrant::Util::Which.which("rdesktop")
+              "rdesktop"
+            else
+              raise Vagrant::Errors::LinuxRDesktopNotFound
+            end
 
           args = []
-          args << "-u" << rdp_info[:username]
-          args << "-p" << rdp_info[:password] if rdp_info[:password]
-          args += rdp_info[:extra_args] if rdp_info[:extra_args]
-          args << "#{rdp_info[:host]}:#{rdp_info[:port]}"
 
-          Vagrant::Util::Subprocess.execute("rdesktop", *args)
+          # Build appropriate arguments for the RDP client.
+          case rdp_client
+          when "xfreerdp"
+            args << "/u:#{rdp_info[:username]}"
+            args << "/p:#{rdp_info[:password]}" if rdp_info[:password]
+            args << "/v:#{rdp_info[:host]}:#{rdp_info[:port]}"
+            args += rdp_info[:extra_args] if rdp_info[:extra_args]
+          when "rdesktop"
+            args << "-u" << rdp_info[:username]
+            args << "-p" << rdp_info[:password] if rdp_info[:password]
+            args += rdp_info[:extra_args] if rdp_info[:extra_args]
+            args << "#{rdp_info[:host]}:#{rdp_info[:port]}"
+          end
+
+          # Finally, run the client.
+          Vagrant::Util::Subprocess.execute(rdp_client, *args)
         end
       end
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -818,10 +818,11 @@ en:
         that the NFS client software is properly installed, and consult any resources
         specific to the linux distro you're using for more information on how to
         do this.
-      linux_rdesktop_not_found: |-
-        The `rdesktop` application was not found. Vagrant requires this
-        in order to connect via RDP to the Vagrant environment. Please ensure
-        this application is installed and available on the path and try again.
+      linux_rdp_client_not_found: |-
+        An appropriate RDP client was not found. Vagrant requires either
+        `xfreerdp` or `rdesktop` in order to connect via RDP to the Vagrant
+        environment. Please ensure one of these applications is installed and
+        available on the path and try again.
       machine_action_locked: |-
         An action '%{action}' was attempted on the machine '%{name}',
         but another process is already executing an action on the machine.


### PR DESCRIPTION
This resolves #6140.

`rdesktop` fails to connect to newer versions of Windows Server due to not supporting newer features of RDP such as Network Level Authentication.

`xfreerdp` [supports such features and is an all-around better option](https://unix.stackexchange.com/questions/140047/what-are-the-differences-between-rdesktop-and-xfreerdp/188168#188168), so I've made it the default RDP client when running `vagrant rdp` on a Linux host. If it's not installed, `rdesktop` will be used as a fallback. If neither are installed, an error message will be displayed as usual.