### PR TITLE
Bugfix: Remove redundant app call from action "handle_forwarded_port_collisions"

### DIFF
--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -156,8 +156,6 @@ module Vagrant
                                    new_port:   repaired_port.to_s))
             end
           end
-
-          @app.call(env)
         end
 
         def lease_check(port)


### PR DESCRIPTION
This call should not be in the `handle` helper method. It is specified in the `call` method already.

It is not critical in the current implementation of `HandleForwardedPortCollisions` class. 
But it causes a pretty big problems if we want to crate a child class (in the 3rd-party plugin) and call `handle` helper there:

```ruby
module VagrantPlugins
  module PluginName
    module Action
      class HandleForwardedPortCollisions < Vagrant::Action::Builtin::HandleForwardedPortCollisions
        @@lock = Mutex.new
        # ...

        def call(env)
          # Acquire a class- and process-level locks so that we don't choose
          # a port that someone else also chose.
          @@lock.synchronize do
            begin
              env[:machine].env.lock('fpcollision') do
                handle(env)
                my_custom_method(env)
              end
            rescue Vagrant::Errors::EnvironmentLockedError
              sleep 1
              retry
            end
          end

          @app.call(env)
        end

        # ...
      end
    end
  end
end
```
In the result, `my_custom_method` will be never executed because `handle` method have caused the middleware exit.