### PR TITLE
Add Errno::ENETUNREACH to SSH rescue

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -420,7 +420,7 @@ module VagrantPlugins
         rescue Errno::EHOSTDOWN
           # This is raised if we get an ICMP DestinationUnknown error.
           raise Vagrant::Errors::SSHHostDown
-        rescue Errno::EHOSTUNREACH
+        rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH
           # This is raised if we can't work out how to route traffic.
           raise Vagrant::Errors::SSHNoRoute
         rescue Net::SSH::Exception => e


### PR DESCRIPTION
This changes the ssh ready? method to treat ENETUNREACH the same way as
EHOSTUNREACH errors.

When attempting to SSH into a box, it tries up to 5 times to connect to
the box, ignoring various errors.  Later it will catch and gracefully
handle most of those errors so that callers don't have to know the
details.

However, the Errno::ENETUNREACH error is not caught, which means that
callers that expect a clean boolean return from ready? don't get that,
and instead get an exception they probably aren't expecting.