### PR TITLE
Update docker installer to work on custom kernels

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -11,7 +11,9 @@ module VagrantPlugins
               comm.sudo("apt-get update -y")
               # TODO: Perform check on the host machine if aufs is installed and using LXC
               if machine.provider_name != :lxc
-                comm.sudo("lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r`")
+                # Attempt to install linux-image-extra for this kernel, if it exists
+                 package_name = "linux-image-extra-`uname -r`"
+                 comm.sudo("lsmod | grep aufs || modprobe aufs || apt-cache show #{package_name} && apt-get install -y #{package_name} || true")
               end
               comm.sudo("apt-get install -y --force-yes -q curl")
               comm.sudo("curl -sSL https://get.docker.com/gpg | apt-key add -")


### PR DESCRIPTION
The current docker installer attempt to install the linux-image-extra-`uname -r` DEB package on Debian systems.
This package may not exist, for example on custom kernels (e.g., Linode servers).
If this happens, Vagrant halts the provisioning. However, this package is not really needed in newer Debian releases (such as Ubuntu 14.04).

This small patch checks if the linux-image-extra-`uname -r` package exists, and it will install it if it does. In either case, it will continue provisioning.