### PR TITLE
Add provider install to `vagrant up`

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -383,6 +383,26 @@ module Vagrant
       raise Errors::NoDefaultProvider
     end
 
+    # Returns whether or not we know how to install the provider with
+    # the given name.
+    #
+    # @return [Boolean]
+    def can_install_provider?(name)
+      host.capability?(provider_install_key(name))
+    end
+
+    # Installs the provider with the given name.
+    #
+    # This will raise an exception if we don't know how to install the
+    # provider with the given name. You should guard this call with
+    # `can_install_provider?` for added safety.
+    #
+    # An exception will be raised if there are any failures installing
+    # the provider.
+    def install_provider(name)
+      host.capability(provider_install_key(name))
+    end
+
     # Returns the collection of boxes for the environment.
     #
     # @return [BoxCollection]
@@ -881,6 +901,12 @@ module Vagrant
       end
 
       nil
+    end
+
+    # Returns the key used for the host capability for provider installs
+    # of the given name.
+    def provider_install_key(name)
+      "provider_install_#{name}".to_sym
     end
 
     # This upgrades a home directory that was in the v1.1 format to the

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -309,6 +309,7 @@ module Vagrant
     def default_provider(**opts)
       opts[:exclude]       = Set.new(opts[:exclude]) if opts[:exclude]
       opts[:force_default] = true if !opts.key?(:force_default)
+      opts[:check_usable] = true if !opts.key?(:check_usable)
 
       default = ENV["VAGRANT_DEFAULT_PROVIDER"]
       default = nil if default == ""
@@ -376,6 +377,7 @@ module Vagrant
 
       # Find the matching implementation
       ordered.each do |_, key, impl, _|
+        return key if !opts[:check_usable]
         return key if impl.usable?(false)
       end
 

--- a/lib/vagrant/plugin/v2/provider.rb
+++ b/lib/vagrant/plugin/v2/provider.rb
@@ -24,6 +24,21 @@ module Vagrant
           true
         end
 
+        # This is called early, before a machine is instantiated, to check
+        # if this provider is installed. This should return true or false.
+        #
+        # If the provider is not installed and Vagrant determines it is
+        # able to install this provider, then it will do so. Installation
+        # is done by calling Environment.install_provider.
+        #
+        # If Environment.can_install_provider? returns false, then an error
+        # will be shown to the user.
+        def self.installed?
+          # By default return true for backwards compat so all providers
+          # continue to work.
+          true
+        end
+
         # Initialize the provider to represent the given machine.
         #
         # @param [Vagrant::Machine] machine The machine that this provider

--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -5,6 +5,15 @@ module VagrantPlugins
     class Provider < Vagrant.plugin("2", :provider)
       attr_reader :driver
 
+      def self.installed?
+        Driver::Meta.new
+        true
+      rescue Vagrant::Errors::VirtualBoxInvalidVersion
+        return false
+      rescue Vagrant::Errors::VirtualBoxNotDetected
+        return false
+      end
+
       def self.usable?(raise_error=false)
         # Instantiate the driver, which will determine the VirtualBox
         # version and all that, which checks for VirtualBox being present

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -154,6 +154,13 @@ en:
       Inserting generated public key within guest...
     inserting_remove_key: |-
       Removing insecure key from the guest if it's present...
+    installing_provider: |-
+      Provider '%{provider}' not found. We'll automatically install it now...
+    installing_provider_detail: |-
+      The installation process will start below. Human interaction may be
+      required at some points. If you're uncomfortable with automatically
+      installing this provider, you can safely Ctrl-C this process and install
+      it manually.
     list_commands: |-
       Below is a listing of all available Vagrant commands and a brief
       description of what they do.

--- a/test/unit/vagrant/plugin/v2/provider_test.rb
+++ b/test/unit/vagrant/plugin/v2/provider_test.rb
@@ -12,6 +12,10 @@ describe Vagrant::Plugin::V2::Provider do
     expect(described_class).to be_usable
   end
 
+  it "should be installed by default" do
+    expect(described_class).to be_installed
+  end
+
   it "should return nil by default for actions" do
     expect(instance.action(:whatever)).to be_nil
   end

--- a/website/docs/source/v2/cli/up.html.md
+++ b/website/docs/source/v2/cli/up.html.md
@@ -20,6 +20,10 @@ on a day-to-day basis.
   unexpected error occurs. This will only happen on the first `vagrant up`.
   By default this is set.
 
+* `--[no-]install-provider` - If the requested provider is not installed,
+  Vagrant will attempt to automatically install it if it can. By default this
+  is enabled.
+
 * `--[no-]parallel` - Bring multiple machines up in parallel if the provider
   supports it. Please consult the provider documentation to see if this feature
   is supported.


### PR DESCRIPTION
This introduces a new flag `--install-provider` (set by default) that automatically installs the requested provider if possible. This is a completely backwards compatible change: any providers that don't explicitly implement the `installed?` function will just always be seen as installed.