### PR TITLE
Re-enable UNC paths for shared folders on Windows hosts

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -610,6 +610,9 @@ module VagrantPlugins
         def share_folders(folders)
           folders.each do |folder|
             hostpath = folder[:hostpath]
+            if Vagrant::Util::Platform.windows?
+              hostpath = Vagrant::Util::Platform.windows_unc_path(hostpath)
+            end
             args = ["--name",
               folder[:name],
               "--hostpath",

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -611,14 +611,9 @@ module VagrantPlugins
         def share_folders(folders)
           folders.each do |folder|
             hostpath = folder[:hostpath]
-
-=begin
-            # Removed for GH-5933 until further research.
             if Vagrant::Util::Platform.windows?
               hostpath = Vagrant::Util::Platform.windows_unc_path(hostpath)
             end
-=end
-
             args = ["--name",
               folder[:name],
               "--hostpath",


### PR DESCRIPTION
This pull request is essentially the same as #5495 which enables use of long (>260 characters) path names for Windows hosts. This way creating longer than 260 character paths inside a shared folder doesn't fail inside the guest system (most common example: installing npm packages with long dependency chains).

Based on feedback from #5933, which caused the previous PR to be reverted, we contacted VirtualBox team and got them to fix
1. Missing support for shares using UNC paths on VirtualBox 5.0
2. Inability to get information about disk sizes for mounted shares, which used UNC paths on host, dubbed `df -h` issue on VirtualBox 4.3

The fixes are available for builds >=4.3 r103933 and >=5.0 r103713.

Are the changes to those drivers OK as-is or should we enable this only for builds higher than the ones mentioned above so that older builds won't "break"? If so, how?

Closes #6409