### PR TITLE
Fixing failure to use smb shared folders on Windows 7.

### DIFF
--- a/plugins/synced_folders/smb/scripts/host_info.ps1
+++ b/plugins/synced_folders/smb/scripts/host_info.ps1
@@ -1,8 +1,15 @@
 $ErrorAction = "Stop"
 
-$net = Get-NetIPAddress | Where-Object {
-    ($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")
-} | Sort-Object $_.AddressFamily
+Try{
+	$net = Get-NetIPAddress | Where-Object {
+	    ($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")
+	} | Sort-Object $_.AddressFamily
+}
+Catch{
+	$net = get-WmiObject Win32_NetworkAdapterConfiguration | Where-Object {
+	    $_.IPAddress -and ($_.IPAddress -ne "127.0.0.1") -and ($_.IPAddress -ne "::1")
+	}
+}
 
 $result = @{
 	ip_addresses = $net.IPAddress


### PR DESCRIPTION
The script being used to get all available IPs utilizes the PS command Get-NetIPAddress, which supported only on Windows 8+, causing Vagrant to explode while trying to vagrant up on lower versions (when using smb shared folders).

I've added a small Windows 7 fallback.