### PR TITLE
Check that NetworkManager is running before issuing an nmcli command

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -110,7 +110,7 @@ module VagrantPlugins
           interfaces.each do |interface|
             retryable(on: Vagrant::Errors::VagrantError, tries: 3, sleep: 2) do
               machine.communicate.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-#{interface}")
-              machine.communicate.sudo("! which nmcli >/dev/null 2>&1 || nmcli c reload #{interface}")
+              machine.communicate.sudo("! which nmcli >/dev/null 2>&1 || ! service NetworkManager status >/dev/null 2>&1 || nmcli c reload #{interface}")
               machine.communicate.sudo("/sbin/ifdown #{interface}", error_check: true)
               machine.communicate.sudo("/sbin/ifup #{interface}")
             end


### PR DESCRIPTION
This is a followup to https://github.com/mitchellh/vagrant/pull/5931 where a
change was made to check that nmcli is installed. To further prevent errors
with vagrant up, we need to also make sure that NetworkManager is running.

The following error is seen when bringing up a VM where NetworkManager is
installed but not running.

        Configuring network adapters within the VM...
        The following SSH command responded with a non-zero exit status.
        Vagrant assumes that this means the command failed!

        ! which nmcli >/dev/null 2>&1 || nmcli c reload eth1

        Stdout from the command:

        Stderr from the command:

        Error: NetworkManager is not running.

This commit simply checks to see if the service is running before passing off to nmcli.

fixes mitchellh/vagrant#6518