### PR TITLE
Fix for detecting upstart, refs #6074

### DIFF
--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -80,7 +80,7 @@ module VagrantPlugins
           end
 
           # Emit an upstart event if we can
-          if machine.communicate.test("test -x /sbin/initctl && test 'upstart' = $(basename $(sudo readlink /proc/1/exe))")
+          if machine.communicate.test("test ! -L /sbin/init && init --version | grep -q upstart")
             machine.communicate.sudo(
               "/sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{expanded_guest_path}")
           end


### PR DESCRIPTION
This should hopefully fix #6074. I don't have a working ruby environment, so this hasn't been tested, but executing `test ! -L /sbin/init && init --version | grep -q upstart` produces the expected results on both ubuntu 14.04 (upstart) and 15.10 (systemd).