### PR TITLE
core: prune machine if non-existent CWD from index [GH-4742]

### DIFF
--- a/lib/vagrant/machine_index.rb
+++ b/lib/vagrant/machine_index.rb
@@ -78,7 +78,7 @@ module Vagrant
           @machines.delete(entry.id)
           unlocked_save
 
-          # Release acccess on this machine
+          # Release access on this machine
           unlocked_release(entry.id)
         end
       end

--- a/lib/vagrant/plugin/v2/command.rb
+++ b/lib/vagrant/plugin/v2/command.rb
@@ -133,8 +133,17 @@ module Vagrant
               # machine in that environment. We silence warnings here because
               # Vagrantfiles often have constants, so people would otherwise
               # constantly (heh) get "already initialized constant" warnings.
-              env = entry.vagrant_env(
-                @env.home_path, ui_class: @env.ui_class)
+              begin
+                env = entry.vagrant_env(
+                  @env.home_path, ui_class: @env.ui_class)
+              rescue Vagrant::Errors::EnvironmentNonExistentCWD
+                # This means that this environment working directory
+                # no longer exists, so delete this entry.
+                entry = @env.machine_index.get(name.to_s)
+                @env.machine_index.delete(entry) if entry
+                raise
+              end
+
               next env.machine(entry.name.to_sym, entry.provider.to_sym)
             end
 


### PR DESCRIPTION
Fixes #4742

If `vagrant something ID` is used where ID represents a machine where the cwd was deleted, we now automatically prune the index from the global status DB. Tests included.