### PR TITLE
core: don't do HEAD request for box on non-HTTP [GH-5477]

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -491,6 +491,9 @@ module Vagrant
             end
           end
 
+          # If this isn't HTTP, then don't do the HEAD request
+          return false if !uri.scheme.downcase.start_with?("http")
+
           output = d.head
           match  = output.scan(/^Content-Type: (.+?)$/i).last
           return false if !match

--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -492,7 +492,10 @@ module Vagrant
           end
 
           # If this isn't HTTP, then don't do the HEAD request
-          return false if !uri.scheme.downcase.start_with?("http")
+          if !uri.scheme.downcase.start_with?("http")
+            @logger.info("not checking metadata since box URI isn't HTTP")
+            return false
+          end
 
           output = d.head
           match  = output.scan(/^Content-Type: (.+?)$/i).last

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -4,6 +4,8 @@ require "tempfile"
 require "tmpdir"
 require "webrick"
 
+require "fake_ftp"
+
 require File.expand_path("../../../../base", __FILE__)
 
 require "vagrant/util/file_checksum"
@@ -32,6 +34,21 @@ describe Vagrant::Action::Builtin::BoxAdd do
   # Helper to quickly SHA1 checksum a path
   def checksum(path)
     FileChecksum.new(path, Digest::SHA1).checksum
+  end
+
+  def with_ftp_server(path, **opts)
+    path = Pathname.new(path)
+
+    tf = Tempfile.new("vagrant")
+    tf.close
+
+    port   = 21212
+    server = FakeFtp::Server.new(port, port+1)
+    server.add_file(path.basename, path.read)
+    server.start
+    yield port
+  ensure
+    server.stop rescue nil
   end
 
   def with_web_server(path, **opts)
@@ -108,6 +125,26 @@ describe Vagrant::Action::Builtin::BoxAdd do
       with_web_server(box_path) do |port|
         env[:box_name] = "foo"
         env[:box_url] = "http://127.0.0.1:#{port}/#{box_path.basename}"
+
+        expect(box_collection).to receive(:add).with { |path, name, version, **opts|
+          expect(checksum(path)).to eq(checksum(box_path))
+          expect(name).to eq("foo")
+          expect(version).to eq("0")
+          expect(opts[:metadata_url]).to be_nil
+          true
+        }.and_return(box)
+
+        expect(app).to receive(:call).with(env)
+
+        subject.call(env)
+      end
+    end
+
+    it "adds from FTP URL" do
+      box_path = iso_env.box2_file(:virtualbox)
+      with_ftp_server(box_path) do |port|
+        env[:box_name] = "foo"
+        env[:box_url] = "ftp://127.0.0.1:#{port}/#{box_path.basename}"
 
         expect(box_collection).to receive(:add).with { |path, name, version, **opts|
           expect(checksum(path)).to eq(checksum(box_path))


### PR DESCRIPTION
Fixes #5477 

If the protocol isn't HTTP, we don't do a HEAD request.