### PR TITLE
Do not throw an error when the Chef node_name is nil

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -122,6 +122,14 @@ module VagrantPlugins
 
         def delete_from_chef_server(deletable)
           node_name = @config.node_name || @machine.config.vm.hostname
+
+          if node_name.to_s.empty?
+            @machine.ui.warn(I18n.t("vagrant.provisioners.chef.missing_node_name",
+              deletable: deletable,
+            ))
+            return
+          end
+
           @machine.ui.info(I18n.t(
             "vagrant.provisioners.chef.deleting_from_server",
             deletable: deletable, name: node_name))

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1984,6 +1984,12 @@ en:
         upload_path_empty: |-
           The Chef Apply provisioner requires that the `config.chef.upload_path`
           be set to a non-nil, non-empty value.
+        missing_node_name: |-
+          The Chef Client provisioner cannot delete the %{deletable} from
+          the Chef server because Vagrant does not know the `node_name'! You
+          need to manually delete the %{deletable} from the Chef server. You
+          can specify the `node_name' in the Chef configuration to prevent this
+          in the future.
         deleting_from_server: "Deleting %{deletable} \"%{name}\" from Chef server..."
 
       file:


### PR DESCRIPTION
- Fixes https://github.com/mitchellh/vagrant/issues/6005
- Fixes https://github.com/mitchellh/vagrant/issues/6064