### PR TITLE
core: don't make dotfile path if no Vagrantfile

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -832,7 +832,7 @@ module Vagrant
 
     # This creates the local data directory and show an error if it
     # couldn't properly be created.
-    def setup_local_data_path
+    def setup_local_data_path(force=false)
       if @local_data_path.nil?
         @logger.warn("No local data path is set. Local data cannot be stored.")
         return
@@ -846,6 +846,9 @@ module Vagrant
       if @local_data_path.file?
         upgrade_v1_dotfile(@local_data_path)
       end
+
+      # If we don't have a root path, we don't setup anything
+      return if !force && root_path.nil?
 
       begin
         @logger.debug("Creating: #{@local_data_path}")
@@ -965,7 +968,7 @@ module Vagrant
 
       # Now, we create the actual local data directory. This should succeed
       # this time since we renamed the old conflicting V1.
-      setup_local_data_path
+      setup_local_data_path(true)
 
       if json_data["active"]
         @logger.debug("Upgrading to V2 style for each active VM")

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -905,8 +905,13 @@ VF
     end
 
     it "is expanded relative to the cwd" do
-      instance = described_class.new(local_data_path: "foo")
-      expect(instance.local_data_path).to eq(instance.cwd.join("foo"))
+      Dir.mktmpdir do |temp_dir|
+        Dir.chdir(temp_dir) do
+          instance = described_class.new(local_data_path: "foo")
+          expect(instance.local_data_path).to eq(instance.cwd.join("foo"))
+          expect(File.exist?(instance.local_data_path)).to be_false
+        end
+      end
     end
 
     it "is set to the given value" do
@@ -933,7 +938,7 @@ VF
         end
 
         expect { instance }.to_not raise_error
-        expect(Pathname.new(local_data_path)).to be_directory
+        expect(Pathname.new(local_data_path)).to_not be_exist
       end
 
       it "should upgrade all active VMs" do


### PR DESCRIPTION
Fixes #6336 

If we have a custom set `VAGRANT_DOTFILE_PATH`, don't litter the drive with dot folders everywhere.