### PR TITLE
Safer way to build 'edit this page' link

### DIFF
--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -324,7 +324,10 @@
 							<li><a href="https://docs.vagrantup.com/">Documentation</a></li>
 							<li><a href="https://www.vagrantup.com/about">About</a></li>
 							<li><a href="https://www.vagrantup.com/support">Support</a></li>
-							<% github_link = 'https://github.com/mitchellh/vagrant/blob/master/' + current_page.source_file.match(/website.*/)[0] %>
+							<% relative_path = current_page.path.match(/.*\//).to_s
+							file = current_page.source_file.split("/").last
+							github_link = "https://github.com/mitchellh/vagrant/blob/master/website/docs/source/#{relative_path}#{file}"
+							%>
 							<li class="li-under"><a href="<%= github_link %>">Edit this page</a></li>
 							<a href="https://www.vagrantup.com/downloads">
 								<li class="button inline-button">Download</li>

--- a/website/www/source/layouts/layout.erb
+++ b/website/www/source/layouts/layout.erb
@@ -60,8 +60,11 @@
 							 <li><a href="/about.html">About</a></li>
 							 <li><a href="/support.html">Support</a></li>
 							 <% if current_page.url != "/" %>
-							 	<% github_link = 'https://github.com/mitchellh/vagrant/blob/master/' + current_page.source_file.match(/website.*/)[0] %>
-							 	<li class="li-under"><a href="<%= github_link %>">Edit this page</a></li>
+								<% relative_path = current_page.path.match(/.*\//).to_s
+								file = current_page.source_file.split("/").last
+								github_link = "https://github.com/mitchellh/vagrant/blob/master/website/www/source/#{relative_path}#{file}"
+								%>
+								<li class="li-under"><a href="<%= github_link %>">Edit this page</a></li>
 							 <% end %>
 							 <a href="/downloads.html">
 								 <li class="button inline-button">Download</li>


### PR DESCRIPTION
This PR more safely builds the `edit this page` link on the main website and the docs website.

We ran into some issues deploying other Middleman sites with the `current_page.source_file.match(/website.*/)[0]` strategy, because the server's file structure may not map directly to the GitHub repo's file structure (if there's no `website` directory, the method errors out). The new strategy doesn't assume that the server's file structure has the same layout.