### PR TITLE
push/heroku: use correct current branch [GH-6123]

### DIFF
--- a/plugins/pushes/heroku/push.rb
+++ b/plugins/pushes/heroku/push.rb
@@ -69,7 +69,8 @@ module VagrantPlugins
         result = execute!("git",
           "--git-dir", git_dir(path),
           "--work-tree", path,
-          "branch",
+          "symbolic-ref",
+          "HEAD",
         )
 
         # Returns something like "* master"

--- a/test/unit/plugins/pushes/heroku/push_test.rb
+++ b/test/unit/plugins/pushes/heroku/push_test.rb
@@ -252,22 +252,6 @@ describe VagrantPlugins::HerokuPush::Push do
 
     let(:branch) { subject.git_branch("/path") }
 
-    context "when the branch is prefixed with a star" do
-      let(:stdout) { "*bacon" }
-
-      it "returns the correct name" do
-        expect(branch).to eq("bacon")
-      end
-    end
-
-    context "when the branch is prefixed with a star space" do
-      let(:stdout) { "* bacon" }
-
-      it "returns the correct name" do
-        expect(branch).to eq("bacon")
-      end
-    end
-
     context "when the branch is not prefixed" do
       let(:stdout) { "bacon" }
 


### PR DESCRIPTION
Fixes #6123 

This changes the way we get the branch to be the current branch.

This will fail (exit code != 0) on things that aren't on branches, which will be exposed to the user.