### PR TITLE
Automatically generate a node_name for Chef

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -31,8 +31,13 @@ module VagrantPlugins
         end
 
         def cleanup
-          delete_from_chef_server('node') if @config.delete_node
-          delete_from_chef_server('client') if @config.delete_client
+          if @config.delete_node
+            delete_from_chef_server("node")
+          end
+
+          if @config.delete_client
+            delete_from_chef_server("client")
+          end
         end
 
         def create_client_key_folder

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1931,6 +1931,8 @@ en:
           "The cookbook path '%{path}' doesn't exist. Ignoring..."
         json: "Generating chef JSON and uploading..."
         client_key_folder: "Creating folder to hold client key..."
+        generating_node_name: |-
+          Auto-generating node name for Chef...
         install_failed: |-
           Vagrant could not detect Chef on the guest! Even after Vagrant
           attempted to install Chef, it could still not find Chef on the system.

--- a/test/unit/plugins/provisioners/chef/provisioner/base_test.rb
+++ b/test/unit/plugins/provisioners/chef/provisioner/base_test.rb
@@ -5,10 +5,22 @@ require Vagrant.source_root.join("plugins/provisioners/chef/provisioner/base")
 describe VagrantPlugins::Chef::Provisioner::Base do
   include_context "unit"
 
-  let(:machine) { double("machine") }
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
   let(:config)  { double("config") }
 
   subject { described_class.new(machine, config) }
+
+  before do
+    allow(config).to receive(:node_name)
+    allow(config).to receive(:node_name=)
+  end
 
   describe "#encrypted_data_bag_secret_key_path" do
     let(:env) { double("env") }


### PR DESCRIPTION
This is required because the Chef Server almost always needs a node name to interact. This will default to the hostname, but that's always going to be `vagrant.vm`, which will collide easily.

This generates a random hostname with `vagrant-` as the prefix and stores the result in the machine's data directory.