### PR TITLE
guests/linux: POSIX sed [GH-6104]

### DIFF
--- a/plugins/guests/linux/cap/remove_public_key.rb
+++ b/plugins/guests/linux/cap/remove_public_key.rb
@@ -10,8 +10,10 @@ module VagrantPlugins
 
           machine.communicate.tap do |comm|
             if comm.test("test -f ~/.ssh/authorized_keys")
-              comm.execute(
-                "sed -i '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys")
+              comm.execute(<<SCRIPT)
+sed -e '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.new
+mv ~/.ssh/authorized_keys.new ~/.ssh/authorized_keys
+SCRIPT
             end
           end
         end


### PR DESCRIPTION
Fixes #6104 

`-i` isn't a POSIX flag, just do the move manually.