### PR TITLE
synced_folders/rsync: SSH control for faster rsync

### DIFF
--- a/plugins/synced_folders/rsync/command/rsync_auto.rb
+++ b/plugins/synced_folders/rsync/command/rsync_auto.rb
@@ -185,7 +185,10 @@ module VagrantPlugins
 
               ssh_info = opts[:machine].ssh_info
               begin
+                start = Time.now
                 RsyncHelper.rsync_single(opts[:machine], ssh_info, opts[:opts])
+                finish = Time.now
+                @logger.info("Time spent in rsync: #{finish-start} (in seconds)")
               rescue Vagrant::Errors::MachineGuestNotReady
                 # Error communicating to the machine, probably a reload or
                 # halt is happening. Just notify the user but don't fail out.

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -66,9 +66,17 @@ module VagrantPlugins
           proxy_command = "-o ProxyCommand='#{ssh_info[:proxy_command]}' "
         end
 
+        # Create the path for the control sockets. We used to do this
+        # in the machine data dir but this can result in paths that are
+        # too long for unix domain sockets.
+        controlpath = File.join(Dir.tmpdir, "ssh.#{rand(1000)}")
+
         rsh = [
           "ssh -p #{ssh_info[:port]} " +
           proxy_command +
+          "-o ControlMaster=auto " +
+          "-o ControlPath=#{controlpath} " +
+          "-o ControlPersist=10m " +
           "-o StrictHostKeyChecking=no " +
           "-o IdentitiesOnly=true " +
           "-o UserKnownHostsFile=/dev/null",


### PR DESCRIPTION
Fixes #6399 

This uses OpenSSH control paths for a faster rsync. On my system where rsync was already fairly fast, it went from ~250ms on every invocation to ~175ms. I've heard on some systems executing rsync is hundreds more ms, so this should speed up even more.