### PR TITLE
'vagrant address' command

### DIFF
--- a/plugins/commands/address/command.rb
+++ b/plugins/commands/address/command.rb
@@ -1,0 +1,24 @@
+require 'optparse'
+
+module VagrantPlugins
+  module CommandAddress
+    class Command < Vagrant.plugin("2", :command)
+      def self.synopsis
+        "outputs public IP address of a guest machine"
+      end
+
+      def execute
+        opts = OptionParser.new do |o|
+          o.banner = "Usage: vagrant address [name]"
+        end
+        argv = parse_options(opts)
+        return if !argv
+
+        with_target_vms(argv, {:single_target=>true}) do |machine|
+          ip = machine.provider.capability(:public_address)
+          @env.ui.info(ip)
+        end
+      end
+    end
+  end
+end

--- a/plugins/commands/address/plugin.rb
+++ b/plugins/commands/address/plugin.rb
@@ -1,0 +1,17 @@
+require "vagrant"
+
+module VagrantPlugins
+  module CommandAddress
+    class Plugin < Vagrant.plugin("2")
+      name "address"
+      description <<-DESC
+      The `address` command outputs public IP address of a guest machine
+      DESC
+
+      command("address", primary: false) do
+        require_relative "command"
+        Command
+      end
+    end
+  end
+end

--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -95,6 +95,7 @@
 								<li<%= sidebar_current("cli") %>><a href="/v2/cli/index.html">Command-Line Interface</a></li>
 								<% if sidebar_section == "cli" %>
 								<ul class="sub unstyled nocap">
+									<li<%= sidebar_current("cli-address") %>><a href="/v2/cli/address.html">address</a></li>
 									<li<%= sidebar_current("cli-box") %>><a href="/v2/cli/box.html">box</a></li>
 									<li<%= sidebar_current("cli-connect") %>><a href="/v2/cli/connect.html">connect</a></li>
 									<li<%= sidebar_current("cli-destroy") %>><a href="/v2/cli/destroy.html">destroy</a></li>

--- a/website/docs/source/v2/cli/address.html.md
+++ b/website/docs/source/v2/cli/address.html.md
@@ -1,0 +1,12 @@
+---
+page_title: "vagrant address - Command-Line Interface"
+sidebar_current: "cli-address"
+---
+
+# Address
+
+**Command: `vagrant address [name]`**
+
+This command outputs a public IP address of a guest machine.
+
+In multi-machine environments a name must be explicitly specified.


### PR DESCRIPTION
`vagrant address` command outputs public IP address of a guest machine, the same value as `vagrant ssh` uses for connection.
```
>vagrant address
172.20.161.192
```

It supports multi-machine Vagrantfiles, but a guest name must be specified explicitly.

This feature depends on https://github.com/mitchellh/vagrant/issues/5978. At the moment Virtualbox provider does not expose `:public_address` capability.