### PR TITLE
linux/cap/remove_public_key: Fix permissions on "~/.ssh/authorized_keys"

### DIFF
--- a/plugins/guests/linux/cap/remove_public_key.rb
+++ b/plugins/guests/linux/cap/remove_public_key.rb
@@ -13,6 +13,7 @@ module VagrantPlugins
               comm.execute(<<SCRIPT)
 sed -e '/^.*#{contents}.*$/d' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.new
 mv ~/.ssh/authorized_keys.new ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
 SCRIPT
             end
           end


### PR DESCRIPTION
This PR fixes an error introduced by GH-6565:

```
$ vagrant up
...
==> centos: Waiting for machine to boot. This may take a few minutes...
    centos: SSH address: 10.211.55.235:22
    centos: SSH username: vagrant
    centos: SSH auth method: private key
    centos: Warning: Connection refused. Retrying...
    centos:
    centos: Vagrant insecure key detected. Vagrant will automatically replace
    centos: this with a newly generated keypair for better security.
    centos:
    centos: Inserting generated public key within guest...
    centos: Removing insecure key from the guest if it's present...
    centos: Key inserted! Disconnecting and reconnecting using new SSH key...
    centos: Warning: Authentication failure. Retrying...
    centos: Warning: Authentication failure. Retrying...
    centos: Warning: Authentication failure. Retrying...
    centos: Warning: Authentication failure. Retrying...
    centos: Warning: Authentication failure. Retrying...
...
```

Due to `mv`, permissions on `~/.ssh/authorized_keys` become 644, but should be 600.

