### PR TITLE
"Split" the handling of WinRM port forwarding rules (plaintext, ssl)

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -416,7 +416,8 @@ module VagrantPlugins
               host_ip: "127.0.0.1",
               id: "winrm",
               auto_correct: true
-
+          end
+          if !@__networks["forwarded_port-winrm-ssl"]
             network :forwarded_port,
               guest: 5986,
               host: 55986,

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -204,25 +204,25 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     it "allows overriding WinRM" do
       subject.communicator = :winrm
       subject.network "forwarded_port",
-        guest: 22, host: 14100, id: "winrm"
+        guest: 5985, host: 14100, id: "winrm"
       subject.finalize!
 
       winrm_network = find_network 'winrm'
-      expect(winrm_network[:guest]).to eq(22)
+      expect(winrm_network[:guest]).to eq(5985)
       expect(winrm_network[:host]).to eq(14100)
       expect(winrm_network[:id]).to eq("winrm")
     end
 
     it "allows overriding WinRM SSL" do
-      subject.communicator = :winrmssl
+      subject.communicator = :winrm
       subject.network "forwarded_port",
-        guest: 22, host: 14100, id: "winrmssl"
+        guest: 5986, host: 14100, id: "winrm-ssl"
       subject.finalize!
 
-      winrmssl_network = find_network 'winrmssl'
-      expect(winrmssl_network[:guest]).to eq(22)
+      winrmssl_network = find_network 'winrm-ssl'
+      expect(winrmssl_network[:guest]).to eq(5986)
       expect(winrmssl_network[:host]).to eq(14100)
-      expect(winrmssl_network[:id]).to eq("winrmssl")
+      expect(winrmssl_network[:id]).to eq("winrm-ssl")
     end
 
     it "turns all forwarded port ports to ints" do


### PR DESCRIPTION
Without this change a custom "winrm-ssl" port forwarding rule
could be wrongly shadowed in absence of a "winrm" custom rule.

It also fix little issues in the related unit tests:
* remove the misleading usage of inexistent `:winrmssl` connector (see https://github.com/mitchellh/vagrant/pull/4236/files#r24350557)
* forward to correct guest ports instead of ssh/22 (probable copy-paste errors)

Review request to @sneal