### PR TITLE
Add `vagrant port` command

### DIFF
--- a/plugins/commands/port/command.rb
+++ b/plugins/commands/port/command.rb
@@ -7,7 +7,6 @@ module VagrantPlugins
         "displays information about guest port mappings"
       end
 
-      # @todo support multiple strategies if requested by the community
       def execute
         opts = OptionParser.new do |o|
           o.banner = "Usage: vagrant port [options] [name]"

--- a/plugins/commands/port/command.rb
+++ b/plugins/commands/port/command.rb
@@ -1,0 +1,71 @@
+require "optparse"
+
+module VagrantPlugins
+  module CommandPort
+    class Command < Vagrant.plugin("2", :command)
+      def self.synopsis
+        "displays information about guest port mappings"
+      end
+
+      # @todo support multiple strategies if requested by the community
+      def execute
+        opts = OptionParser.new do |o|
+          o.banner = "Usage: vagrant port [options] [name]"
+          o.separator ""
+          o.separator "Options:"
+          o.separator ""
+
+          o.on("--machine-readable", "Display machine-readable output")
+        end
+
+        # Parse the options
+        argv = parse_options(opts)
+        return if !argv
+
+        @logger.debug("Port command: #{argv.inspect}")
+        with_target_vms(argv, single_target: true) do |vm|
+          vm.action_raw(:config_validate,
+            Vagrant::Action::Builtin::ConfigValidate)
+
+          if vm.state.id != :running
+            @env.ui.error "not running - make this a better error or use the middleware"
+            return 1
+          end
+
+          # This only works for vbox? should it be everywhere?
+          # vm.action_raw(:check_running,
+          #   Vagrant::Action::Builtin::CheckRunning)
+
+          if !vm.provider.capability?(:forwarded_ports)
+            @env.ui.error <<-EOH.strip
+The #{vm.provider_name} provider does not support listing forwarded ports. This
+is most likely a limitation of the provider and not a bug in Vagrant. If you
+believe this is a bug in Vagrant, please search existing issues before opening
+a new one.
+EOH
+            return 1
+          end
+
+          ports = vm.provider.capability(:forwarded_ports)
+
+          if ports.empty?
+            @env.ui.info("The machine has no configured forwarded ports")
+            return 0
+          end
+
+          @env.ui.info <<-EOH
+The forwarded ports for the machine are listed below. Please note that these
+values may differ from values configured in the Vagrantfile if the provider
+supports automatic port collision detection and resolution.
+EOH
+          ports.each do |guest, host|
+            @env.ui.info("#{guest.to_s.rjust(6)} (guest) => #{host} (host)")
+            @env.ui.machine("forwarded_port", guest, host, target: vm.name.to_s)
+          end
+        end
+
+        0
+      end
+    end
+  end
+end

--- a/plugins/commands/port/command.rb
+++ b/plugins/commands/port/command.rb
@@ -36,27 +36,21 @@ module VagrantPlugins
           #   Vagrant::Action::Builtin::CheckRunning)
 
           if !vm.provider.capability?(:forwarded_ports)
-            @env.ui.error <<-EOH.strip
-The #{vm.provider_name} provider does not support listing forwarded ports. This
-is most likely a limitation of the provider and not a bug in Vagrant. If you
-believe this is a bug in Vagrant, please search existing issues before opening
-a new one.
-EOH
+            @env.ui.error(I18n.t("port_command.missing_capability",
+              provider: vm.provider_name,
+            ))
             return 1
           end
 
           ports = vm.provider.capability(:forwarded_ports)
 
           if ports.empty?
-            @env.ui.info("The machine has no configured forwarded ports")
+            @env.ui.info(I18n.t("port_command.empty_ports"))
             return 0
           end
 
-          @env.ui.info <<-EOH
-The forwarded ports for the machine are listed below. Please note that these
-values may differ from values configured in the Vagrantfile if the provider
-supports automatic port collision detection and resolution.
-EOH
+          @env.ui.info(I18n.t("port_command.details"))
+          @env.ui.info("")
           ports.each do |guest, host|
             @env.ui.info("#{guest.to_s.rjust(6)} (guest) => #{host} (host)")
             @env.ui.machine("forwarded_port", guest, host, target: vm.name.to_s)

--- a/plugins/commands/port/locales/en.yml
+++ b/plugins/commands/port/locales/en.yml
@@ -14,3 +14,7 @@ en:
       most likely a limitation of the provider and not a bug in Vagrant. If you
       believe this is a bug in Vagrant, please search existing issues before
       opening a new one.
+    no_matching_port: |-
+      The guest is not currently mapping port %{port} to the host machine. Is
+      the port configured in the Vagrantfile? You may need to run `vagrant reload`
+      if changes were made to the port configuration in the Vagrantfile.

--- a/plugins/commands/port/locales/en.yml
+++ b/plugins/commands/port/locales/en.yml
@@ -1,0 +1,16 @@
+en:
+  port_command:
+    details: |-
+      The forwarded ports for the machine are listed below. Please note that
+      these values may differ from values configured in the Vagrantfile if the
+      provider supports automatic port collision detection and resolution.
+    empty_ports: |-
+      The provider reported there are no forwarded ports for this virtual
+      machine. This can be caused if there are no ports specified in the
+      Vagrantfile or if the virtual machine is not currently running. Please
+      check that the virtual machine is running and try again.
+    missing_capability: |-
+      The %{provider} provider does not support listing forwarded ports. This is
+      most likely a limitation of the provider and not a bug in Vagrant. If you
+      believe this is a bug in Vagrant, please search existing issues before
+      opening a new one.

--- a/plugins/commands/port/plugin.rb
+++ b/plugins/commands/port/plugin.rb
@@ -1,0 +1,17 @@
+require "vagrant"
+
+module VagrantPlugins
+  module CommandPort
+    class Plugin < Vagrant.plugin("2")
+      name "port command"
+      description <<-DESC
+      The `port` command displays guest port mappings.
+      DESC
+
+      command("port") do
+        require File.expand_path("../command", __FILE__)
+        Command
+      end
+    end
+  end
+end

--- a/plugins/commands/port/plugin.rb
+++ b/plugins/commands/port/plugin.rb
@@ -9,8 +9,18 @@ module VagrantPlugins
       DESC
 
       command("port") do
-        require File.expand_path("../command", __FILE__)
+        require_relative "command"
+        self.init!
         Command
+      end
+
+      protected
+
+      def self.init!
+        return if defined?(@_init)
+        I18n.load_path << File.expand_path("../locales/en.yml", __FILE__)
+        I18n.reload!
+        @_init = true
       end
     end
   end

--- a/plugins/providers/virtualbox/cap.rb
+++ b/plugins/providers/virtualbox/cap.rb
@@ -9,6 +9,8 @@ module VagrantPlugins
       #
       # @return [Hash<Integer, Integer>] Host => Guest port mappings.
       def self.forwarded_ports(machine)
+        return nil if machine.state.id != :running
+
         {}.tap do |result|
           machine.provider.driver.read_forwarded_ports.each do |_, _, h, g|
             result[h] = g

--- a/test/unit/plugins/commands/port/command_test.rb
+++ b/test/unit/plugins/commands/port/command_test.rb
@@ -22,6 +22,11 @@ describe VagrantPlugins::CommandPort::Command do
 
   let(:machine) { env.machine(env.machine_names[0], :dummy) }
 
+  before(:all) do
+    I18n.load_path << Vagrant.source_root.join("plugins/commands/port/locales/en.yml")
+    I18n.reload!
+  end
+
   subject { described_class.new(argv, env) }
 
   before do
@@ -51,7 +56,7 @@ describe VagrantPlugins::CommandPort::Command do
     it "ensures the vm is running" do
       allow(state).to receive(:id).and_return(:stopped)
       expect(env.ui).to receive(:error).with { |message, _|
-        expect(message).to include("make this a better error")
+        expect(message).to include("does not support listing forwarded ports")
       }
 
       expect(subject.execute).to eq(1)
@@ -72,7 +77,7 @@ describe VagrantPlugins::CommandPort::Command do
         .and_return([])
 
       expect(env.ui).to receive(:info).with { |message, _|
-        expect(message).to include("has no configured forwarded ports")
+        expect(message).to include("there are no forwarded ports")
       }
 
       expect(subject.execute).to eq(0)

--- a/test/unit/plugins/commands/port/command_test.rb
+++ b/test/unit/plugins/commands/port/command_test.rb
@@ -135,15 +135,3 @@ describe VagrantPlugins::CommandPort::Command do
     end
   end
 end
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/unit/plugins/commands/port/command_test.rb
+++ b/test/unit/plugins/commands/port/command_test.rb
@@ -1,0 +1,98 @@
+require File.expand_path("../../../../base", __FILE__)
+
+require Vagrant.source_root.join("plugins/commands/port/command")
+
+describe VagrantPlugins::CommandPort::Command do
+  include_context "unit"
+  include_context "command plugin helpers"
+
+  let(:iso_env) { isolated_environment }
+  let(:env) do
+    iso_env.vagrantfile(<<-VF)
+      Vagrant.configure("2") do |config|
+        config.vm.box = "hashicorp/precise64"
+      end
+    VF
+    iso_env.create_vagrant_env
+  end
+
+  let(:argv)   { [] }
+  let(:pushes) { {} }
+  let(:state)  { double(:state, id: :running) }
+
+  let(:machine) { env.machine(env.machine_names[0], :dummy) }
+
+  subject { described_class.new(argv, env) }
+
+  before do
+    allow(machine).to receive(:state).and_return(state)
+    allow(subject).to receive(:with_target_vms) { |&block| block.call(machine) }
+  end
+
+  describe "#execute" do
+    it "validates the configuration" do
+      iso_env.vagrantfile <<-EOH
+        Vagrant.configure("2") do |config|
+          config.vm.box = "hashicorp/precise64"
+
+          config.push.define "noop" do |push|
+            push.bad = "ham"
+          end
+        end
+      EOH
+
+      subject = described_class.new(argv, iso_env.create_vagrant_env)
+
+      expect { subject.execute }.to raise_error(Vagrant::Errors::ConfigInvalid) { |err|
+        expect(err.message).to include("The following settings shouldn't exist: bad")
+      }
+    end
+
+    it "ensures the vm is running" do
+      allow(state).to receive(:id).and_return(:stopped)
+      expect(env.ui).to receive(:error).with { |message, _|
+        expect(message).to include("make this a better error")
+      }
+
+      expect(subject.execute).to eq(1)
+    end
+
+    it "shows a friendly error when the capability is not supported" do
+      allow(machine.provider).to receive(:capability?).and_return(false)
+      expect(env.ui).to receive(:error).with { |message, _|
+        expect(message).to include("does not support listing forwarded ports")
+      }
+
+      expect(subject.execute).to eq(1)
+    end
+
+    it "returns a friendly message when there are no forwarded ports" do
+      allow(machine.provider).to receive(:capability?).and_return(true)
+      allow(machine.provider).to receive(:capability).with(:forwarded_ports)
+        .and_return([])
+
+      expect(env.ui).to receive(:info).with { |message, _|
+        expect(message).to include("has no configured forwarded ports")
+      }
+
+      expect(subject.execute).to eq(0)
+    end
+
+    it "returns the list of ports" do
+      allow(machine.provider).to receive(:capability?).and_return(true)
+      allow(machine.provider).to receive(:capability).with(:forwarded_ports)
+        .and_return([[2222,22], [1111,11]])
+
+      output = ""
+      allow(env.ui).to receive(:info) do |data|
+        output << data
+      end
+
+      expect(subject.execute).to eq(0)
+
+      expect(output).to include("forwarded ports for the machine")
+      expect(output).to include("2222 (guest) => 22 (host)")
+      expect(output).to include("1111 (guest) => 11 (host)")
+    end
+  end
+end

--- a/test/unit/plugins/providers/virtualbox/cap_test.rb
+++ b/test/unit/plugins/providers/virtualbox/cap_test.rb
@@ -15,14 +15,16 @@ describe VagrantPlugins::ProviderVirtualBox::Cap do
   let(:machine) do
     iso_env.machine(iso_env.machine_names[0], :dummy).tap do |m|
       m.provider.stub(driver: driver)
+      m.stub(state: state)
     end
   end
 
   let(:driver) { double("driver") }
+  let(:state)  { double("state", id: :running) }
 
   describe "#forwarded_ports" do
     it "returns all the forwarded ports" do
-      expect(driver).to receive(:read_forwarded_ports).and_return([
+      allow(driver).to receive(:read_forwarded_ports).and_return([
         [nil, nil, 123, 456],
         [nil, nil, 245, 245],
       ])
@@ -31,6 +33,11 @@ describe VagrantPlugins::ProviderVirtualBox::Cap do
         123 => 456,
         245 => 245,
       })
+    end
+
+    it "returns nil when the machine is not running" do
+      allow(machine).to receive(:state).and_return(double(:state, id: :stopped))
+      expect(described_class.forwarded_ports(machine)).to be(nil)
     end
   end
 end

--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -104,6 +104,7 @@
 									<li<%= sidebar_current("cli-login") %>><a href="/v2/cli/login.html">login</a></li>
 									<li<%= sidebar_current("cli-package") %>><a href="/v2/cli/package.html">package</a></li>
 									<li<%= sidebar_current("cli-plugin") %>><a href="/v2/cli/plugin.html">plugin</a></li>
+									<li<%= sidebar_current("cli-port") %>><a href="/v2/cli/port.html">port</a></li>
 									<li<%= sidebar_current("cli-powershell") %>><a href="/v2/cli/powershell.html">powershell</a></li>
 									<li<%= sidebar_current("cli-provision") %>><a href="/v2/cli/provision.html">provision</a></li>
 									<li<%= sidebar_current("cli-rdp") %>><a href="/v2/cli/rdp.html">rdp</a></li>

--- a/website/docs/source/v2/cli/port.html.md
+++ b/website/docs/source/v2/cli/port.html.md
@@ -1,0 +1,35 @@
+---
+page_title: "vagrant port - Command-Line Interface"
+sidebar_current: "cli-port"
+---
+
+# Port
+
+**Command: `vagrant port`**
+
+The port command displays the full list of guest ports mapped to the host
+machine ports:
+
+```
+$ vagrant port
+    22 (guest) => 2222 (host)
+    80 (guest) => 8080 (host)
+```
+
+In a multi-machine Vagrantfile, the name of the machine must be specified:
+
+```
+$ vagrant port my-machine
+```
+
+## Options
+
+* `--guest PORT` - This displays just the host port that corresponds to the
+  given guest port. If the guest is not forwarding that port, an error is
+  returned. This is useful for quick scripting, for example:
+
+        $ ssh -p $(vagrant port --guest 22)
+
+* `--machine-readable` - This tells Vagrant to display machine-readable output
+  instead of the human-friendly output. More information is available in the
+  [machine-readable output](/v2/cli/machine-readable.html) documentation.


### PR DESCRIPTION
This is still a :construction: but I have some questions around structure for @mitchellh 

- [x] Docs
- [ ] Name - should it be `vagrant port`, `vagrant ports`, `vagrant list-ports`?

- - -

- Fixes #1415
- Fixes #2826
- Fixes #3009
- Fixes #5650