### PR TITLE
Fix the resolution of SafeEnv.

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -72,7 +72,7 @@ module Vagrant
       # we add all our plugin dependencies.
       @gemfile = build_gemfile(plugins)
 
-      SafeEnv.change_env do |env|
+      Util::SafeEnv.change_env do |env|
         # Set the environmental variables for Bundler
         env["BUNDLE_APP_CONFIG"] = @appconfigpath
         env["BUNDLE_CONFIG"]     = @configfile.path


### PR DESCRIPTION
Recent change broke bundler.rb due to incorrect scope resolution (the
error is: uninitialized constant Vagrant::Bundler::SafeEnv
(NameError).