### PR TITLE
Add acceptance test for linked clones

### DIFF
--- a/test/acceptance/provider-virtualbox/linked_clone_spec.rb
+++ b/test/acceptance/provider-virtualbox/linked_clone_spec.rb
@@ -1,0 +1,35 @@
+# This tests that VM is up as a linked clone
+shared_examples 'provider/linked_clone' do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+      "box option must be specified for provider: #{provider}"
+  end
+
+  include_context 'acceptance'
+
+  before do
+    environment.skeleton('linked_clone')
+    assert_execute('vagrant', 'box', 'add', 'basic', options[:box])
+  end
+
+  after do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  it 'creates machine as linked clone' do
+    status('Test: machine is created successfully')
+    result = execute('vagrant', 'up', "--provider=#{provider}")
+    expect(result).to exit_with(0)
+
+    status('Test: master VM is created')
+    expect(result.stdout).to match(/master VM/)
+
+    status('Test: machine is a master VM clone')
+    expect(result.stdout).to match(/Cloning/)
+
+    status('Test: machine is available by ssh')
+    result = execute('vagrant', 'ssh', '-c', 'echo foo')
+    expect(result).to exit_with(0)
+    expect(result.stdout).to match(/foo\n$/)
+  end
+end

--- a/test/acceptance/skeletons/linked_clone/Vagrantfile
+++ b/test/acceptance/skeletons/linked_clone/Vagrantfile
@@ -1,0 +1,7 @@
+Vagrant.configure('2') do |config|
+  config.vm.box = 'basic'
+
+  config.vm.provider 'virtualbox' do |v|
+    v.linked_clone = true
+  end
+end


### PR DESCRIPTION
This is a port of the similar test for "parallels" provider: https://github.com/Parallels/vagrant-parallels/blob/master/test/acceptance/provider/linked_clone_spec.rb

It passes successfully:
```console
$ bundle exec vagrant-spec test --components=provider/virtualbox/linked_clone
#...

provider/virtualbox/linked_clone
  it should behave like provider/linked_clone
    creates machine as linked clone
      Execute: vagrant box add basic /path/to/box
      Test: machine is created successfully
      Execute: vagrant up --provider=virtualbox
      Test: master VM is created
      Test: machine is a master VM clone
      Test: machine is available by ssh
      Execute: vagrant ssh -c echo foo
      Execute: vagrant destroy --force
      creates machine as linked clone

Finished in 53.77 seconds
```