### PR TITLE
update help message on --provision-with to add by provisioner name

### DIFF
--- a/plugins/commands/provision/command.rb
+++ b/plugins/commands/provision/command.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
           o.banner = "Usage: vagrant provision [vm-name] [--provision-with x,y,z]"
 
           o.on("--provision-with x,y,z", Array,
-                    "Enable only certain provisioners, by type.") do |list|
+                    "Enable only certain provisioners, by type or by name.") do |list|
             options[:provision_types] = list.map { |type| type.to_sym }
           end
         end

--- a/plugins/commands/up/start_mixins.rb
+++ b/plugins/commands/up/start_mixins.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
         end
 
         parser.on("--provision-with x,y,z", Array,
-                "Enable only certain provisioners, by type.") do |list|
+                "Enable only certain provisioners, by type or by name.") do |list|
           options[:provision_types] = list.map { |type| type.to_sym }
           options[:provision_enabled] = true
           options[:provision_ignore_sentinel] = true


### PR DESCRIPTION
Just a quick fix to issue #6512
working on `vagrant provision --help` and `vagrant up --help`
