### PR TITLE
Vagrant Issue #6608

### DIFF
--- a/plugins/guests/coreos/cap/configure_networks.rb
+++ b/plugins/guests/coreos/cap/configure_networks.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
 
             # Read network interface names
             interfaces = []
-            comm.sudo("ifconfig | grep 'enp0\\|ens' | cut -f1 -d:") do |_, result|
+            comm.sudo("ifconfig | grep '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?' | cut -f1 -d:") do |_, result|
               interfaces = result.split("\n")
             end
 


### PR DESCRIPTION
# Summary
Re-factor and repair regular expression attempting to match present interfaces.
The re-factored regular expression will match on enp* ens* eth* variants.

#### Referenced Issue
Vagrant Cannot Detect CoreOS interface names #6608 