### PR TITLE
Add checksum validation for the VirtualBox installs on Windows and OS X

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -524,6 +524,10 @@ module Vagrant
       error_key(:provider_cant_install)
     end
 
+    class ProviderChecksumMismatch < VagrantError
+      error_key(:provider_checksum_mismatch)
+    end
+
     class ProviderInstallFailed < VagrantError
       error_key(:provider_install_failed)
     end

--- a/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
+++ b/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
@@ -2,6 +2,7 @@ require "pathname"
 require "tempfile"
 
 require "vagrant/util/downloader"
+require "vagrant/util/file_checksum"
 require "vagrant/util/subprocess"
 
 module VagrantPlugins
@@ -12,6 +13,7 @@ module VagrantPlugins
         # known-good version to download.
         URL = "http://download.virtualbox.org/virtualbox/5.0.10/VirtualBox-5.0.10-104061-OSX.dmg".freeze
         VERSION = "5.0.10".freeze
+        SHA256SUM = "62f933115498e51ddf5f2dab47dc1eebb42eb78ea1a7665cb91c53edacc847c6".freeze
 
         def self.provider_install_virtualbox(env)
           tf = Tempfile.new("vagrant")
@@ -28,6 +30,15 @@ module VagrantPlugins
             "vagrant.hosts.darwin.virtualbox_install_detail"))
           dl = Vagrant::Util::Downloader.new(URL, tf.path, ui: ui)
           dl.download!
+
+          # Validate that the file checksum matches
+          actual = Vagrant::Util::FileChecksum.new(tf.path, Digest::SHA2).checksum
+          if actual != SHA256SUM
+            raise Vagrant::Errors::ProviderChecksumMismatch,
+              provider: "virtualbox",
+              actual: actual,
+              expected: SHA256SUM
+          end
 
           # Launch it
           ui.output(I18n.t(

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1015,6 +1015,13 @@ en:
         This is a limitation of this provider. Please report this as a feature
         request to the provider in question. To install this provider, you'll
         have to do so manually.
+      provider_checksum_mismatch: |-
+        The checksum of the downloaded provider '%{provider}' did not match the
+        expected value. If the problem persists, please install the provider
+        manually.
+
+        Expected: %{expected}
+        Received: %{actual}
       provider_install_failed: |-
         Installation of the provider '%{provider}' failed! The stdout
         and stderr are shown below. Please read the error output, resolve it,


### PR DESCRIPTION
Use Vagrant::Util::FileChecksum to validate the downloaded VirtualBox
installers.

SHA-256 checksums for VirtualBox files are available at
https://www.virtualbox.org/download/hashes/5.0.10/SHA256SUMS.

Fixes #6611.