### PR TITLE
Docker provisioning:  restart container if newer image build is available.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2015 Mitchell Hashimoto
+Copyright (c) 2010-2015 Mitchell Hashimoto, Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi,
I've noticed that the Docker provisioner does not check if a newer image is available when deciding whether to restart a container.
That is:
```ruby
config.vm.provision "docker" do |docker|
  docker.build_image "/vagrant/app", args: '-t "myapp" '
  docker.run 'myapp'
end
```
Will update the docker image when running `vagrant provision`, but the `run` command will do nothing.

This patch fixes that: it checks the image that the container is running and restarts the container if a newer image is available.
