### PR TITLE
Fix `uninitialized constant` error in `vagrant powershell` command

### DIFF
--- a/plugins/commands/powershell/command.rb
+++ b/plugins/commands/powershell/command.rb
@@ -1,5 +1,6 @@
 require "optparse"
 
+require "vagrant/util/powershell"
 require_relative "../../communicators/winrm/helper"
 
 module VagrantPlugins


### PR DESCRIPTION
This is a fix for `vagrant powershell` command, with fails with such exception:
```
C:\Users\michael.kuzmin\Projects\forks\vagrant>bundle exec vagrant powershell
DL is deprecated, please use Fiddle
Vagrant appears to be running in a Bundler environment. Your
existing Gemfile will be used. Vagrant will not auto-load any plugins
installed with `vagrant plugin`. Vagrant will autoload any plugins in
the 'plugins' group in your Gemfile. You can force Vagrant to take over
with VAGRANT_FORCE_BUNDLER.

You appear to be running Vagrant outside of the official installers.
Note that the installers are what ensure that Vagrant has all required
dependencies, and Vagrant assumes that these dependencies exist. By
running outside of the installer environment, Vagrant may not function
properly. To remove this warning, install Vagrant using one of the
official packages from vagrantup.com.

==> teamcity: Detecting if a remote PowerShell connection can be made with the guest...
C:/Users/michael.kuzmin/Projects/forks/vagrant/plugins/commands/powershell/command.rb:92:in `ready_ps_remoting_for': uninitialized constant Vagrant::Util::PowerShell (NameError)
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/plugins/commands/powershell/command.rb:68:in `block in execute'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/lib/vagrant/plugin/v2/command.rb:235:in `block in with_target_vms'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/lib/vagrant/plugin/v2/command.rb:229:in `each'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/lib/vagrant/plugin/v2/command.rb:229:in `with_target_vms'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/plugins/commands/powershell/command.rb:43:in `execute'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/lib/vagrant/cli.rb:42:in `execute'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/lib/vagrant/environment.rb:302:in `cli'
        from C:/Users/michael.kuzmin/Projects/forks/vagrant/bin/vagrant:174:in `<top (required)>'
        from c:/Ruby/lib/ruby/gems/2.1.0/bin/vagrant:23:in `load'
        from c:/Ruby/lib/ruby/gems/2.1.0/bin/vagrant:23:in `<main>'
```