### PR TITLE
Use <prefix>::1 as the IPv6 adapter IP.

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -290,8 +290,8 @@ module VagrantPlugins
             # Default subnet prefix length
             options[:netmask] ||= 64
 
-            # IPv6 we just mask the address and use that as the adapter
-            options[:adapter_ip] ||= ip.mask(options[:netmask].to_i).to_s
+            # Set adapter IP to <prefix>::1
+            options[:adapter_ip] ||= (ip.mask(options[:netmask].to_i) | 1).to_s
 
             # Append a 6 to the end of the type
             options[:type] = "#{options[:type]}6".to_sym

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -42,6 +42,34 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
     expect(called).to eq(true)
   end
 
+  it "creates a host-only interface with an IPv6 address <prefix>:1" do
+    guest = double("guest")
+    machine.config.vm.network 'private_network', { type: :static, ip: 'dead:beef::100' }
+    #allow(driver).to receive(:read_bridged_interfaces) { [] }
+    allow(driver).to receive(:read_host_only_interfaces) { [] }
+    #allow(driver).to receive(:read_dhcp_servers) { [] }
+    allow(machine).to receive(:guest) { guest }
+    allow(driver).to receive(:create_host_only_network) {{ name: 'vboxnet0' }}
+    allow(guest).to receive(:capability)
+    interface_ip = 'dead:beef::1'
+
+    subject.call(env)
+
+    expect(driver).to have_received(:create_host_only_network).with({
+      adapter_ip: interface_ip,
+      netmask: 64,
+    })
+
+    expect(guest).to have_received(:capability).with(:configure_networks, [{
+      type: :static6,
+      adapter_ip: 'dead:beef::1',
+      ip: 'dead:beef::100',
+      netmask: 64,
+      auto_config: true,
+      interface: nil
+    }])
+  end
+
   context "with a dhcp private network" do
     let(:bridgedifs)  { [] }
     let(:hostonlyifs) { [] }


### PR DESCRIPTION
Set the IPv6 adapter IP to be <prefix>::1. Otherwise, guest to host
communication over IPv6 is not routed correctly. This means that
consumers should not specify <prefix>::1 IP addresses to VirtualBox,
which should be a reasonable restriction.

Fixes #6658