### PR TITLE
Fix for problem where the host_info.ps1 script returns a string instead of a list of IPs

### DIFF
--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -155,7 +155,12 @@ module VagrantPlugins
             stderr: r.stderr
         end
 
-        JSON.parse(r.stdout)["ip_addresses"]
+        res = JSON.parse(r.stdout)["ip_addresses"]
+        if res.instance_of? String
+          [ res ]
+        else
+          res
+        end
       end
     end
   end


### PR DESCRIPTION
This may have been due to a recent Windows Update? When doing a "vagrant up" on Windows 8.1, it was crashing due to the expected list of IPs returned from the host_info.ps1 script coming back as a string instead of a list.

