### PR TITLE
v.use_linked_clone should be v.linked_clone

### DIFF
--- a/website/docs/source/v2/virtualbox/configuration.html.md
+++ b/website/docs/source/v2/virtualbox/configuration.html.md
@@ -50,7 +50,7 @@ the master VM.
 
 ```ruby
 config.vm.provider "virtualbox" do |v|
-  v.use_linked_clone = true
+  v.linked_clone = true
 end
 ```
 


### PR DESCRIPTION
I'm assuming this got changed during development, but the documentation refers to an setting which doesn't work:

```
There are errors in the configuration of this machine. Please fix
the following errors and try again:

VirtualBox Provider:
* The following settings shouldn't exist: use_linked_clone
```