### PR TITLE
linked_clone if Vagrant::VERSION =~ /^1.8/

### DIFF
--- a/website/docs/source/v2/virtualbox/configuration.html.md
+++ b/website/docs/source/v2/virtualbox/configuration.html.md
@@ -54,6 +54,14 @@ config.vm.provider "virtualbox" do |v|
 end
 ```
 
+To have backward compatibility:
+
+```ruby
+config.vm.provider 'virtualbox' do |v|
+  v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+end
+```
+
 <div class="alert alert-info">
 	<strong>Note:</strong> the generated master VMs are currently not removed
 	automatically by Vagrant. This has to be done manually. However, a master


### PR DESCRIPTION
To void this message on pre Vagrant 1.8

```bash
There are errors in the configuration of this machine. Please fix
the following errors and try again:

VirtualBox Provider:
* The following settings shouldn't exist: linked_clone
```