### PR TITLE
[WIP] core: use environment variable for bundler retry #6705

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -45,7 +45,9 @@ module Vagrant
       end
 
       # Configure Bundler to retry
-      ::Bundler.settings[:retry] = 3
+      Util::SafeEnv.change_env do |env|
+        env["BUNDLE_RETRY"] = "3"
+      end
     end
 
     # Initializes Bundler and the various gem paths so that we can begin


### PR DESCRIPTION
(This attempts to address https://github.com/mitchellh/vagrant/issues/6705#issuecomment-166768147. It's marked WIP since it doesn't yet clean up the environment after itself. Also, I'm not sure if more tests are required, or if this is even the best way to approach the problem.)

This prevents a .bundle/config file from being written.

See 2ade664 for the original implementation.