### PR TITLE
Properly namespace the FileChecksum class

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -521,7 +521,7 @@ module Vagrant
           @logger.info("Validating checksum with #{checksum_klass}")
           @logger.info("Expected checksum: #{checksum}")
 
-          actual = FileChecksum.new(path, checksum_klass).checksum
+          actual = Vagrant::Util::FileChecksum.new(path, checksum_klass).checksum
           if actual.casecmp(checksum) != 0
             raise Errors::BoxChecksumMismatch,
               actual: actual,

--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -7,39 +7,43 @@ class DigestClass
   def hexdigest; end
 end
 
-class FileChecksum
-  BUFFER_SIZE = 1024 * 8
+module Vagrant
+  module Util
+    class FileChecksum
+      BUFFER_SIZE = 1024 * 8
 
-  # Initializes an object to calculate the checksum of a file. The given
-  # ``digest_klass`` should implement the ``DigestClass`` interface. Note
-  # that the built-in Ruby digest classes duck type this properly:
-  # Digest::MD5, Digest::SHA1, etc.
-  def initialize(path, digest_klass)
-    @digest_klass = digest_klass
-    @path         = path
-  end
+      # Initializes an object to calculate the checksum of a file. The given
+      # ``digest_klass`` should implement the ``DigestClass`` interface. Note
+      # that the built-in Ruby digest classes duck type this properly:
+      # Digest::MD5, Digest::SHA1, etc.
+      def initialize(path, digest_klass)
+        @digest_klass = digest_klass
+        @path         = path
+      end
 
-  # This calculates the checksum of the file and returns it as a
-  # string.
-  #
-  # @return [String]
-  def checksum
-    digest = @digest_klass.new
-    buf = ''
+      # This calculates the checksum of the file and returns it as a
+      # string.
+      #
+      # @return [String]
+      def checksum
+        digest = @digest_klass.new
+        buf = ''
 
-    File.open(@path, "rb") do |f|
-      while !f.eof
-        begin
-          f.readpartial(BUFFER_SIZE, buf)
-          digest.update(buf)
-        rescue EOFError
-          # Although we check for EOF earlier, this seems to happen
-          # sometimes anyways [GH-2716].
-          break
+        File.open(@path, "rb") do |f|
+          while !f.eof
+            begin
+              f.readpartial(BUFFER_SIZE, buf)
+              digest.update(buf)
+            rescue EOFError
+              # Although we check for EOF earlier, this seems to happen
+              # sometimes anyways [GH-2716].
+              break
+            end
+          end
         end
+
+        return digest.hexdigest
       end
     end
-
-    return digest.hexdigest
   end
 end

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -33,7 +33,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows do
 
   # Helper to quickly SHA1 checksum a path
   def checksum(path)
-    FileChecksum.new(path, Digest::SHA1).checksum
+    Vagrant::Util::FileChecksum.new(path, Digest::SHA1).checksum
   end
 
   def with_ftp_server(path, **opts)

--- a/test/unit/vagrant/util/file_checksum_test.rb
+++ b/test/unit/vagrant/util/file_checksum_test.rb
@@ -4,7 +4,7 @@ require 'digest/sha1'
 
 require 'vagrant/util/file_checksum'
 
-describe FileChecksum do
+describe Vagrant::Util::FileChecksum do
   include_context "unit"
 
   let(:environment) { isolated_environment }


### PR DESCRIPTION
Use Vagrant::Util::FileChecksum everywhere.

Fixes #6713.