### PR TITLE
Fix Docker provisioning for Debian/Jessie box

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
           def self.docker_install(machine)
             machine.communicate.tap do |comm|
               comm.sudo("apt-get update -qq -y")
-              comm.sudo("apt-get install -qq -y --force-yes curl")
+              comm.sudo("apt-get install -qq -y --force-yes curl apt-transport-https")
               comm.sudo("apt-get purge -qq -y lxc-docker* || true")
               comm.sudo("curl -sSL https://get.docker.com/ | sh")
             end


### PR DESCRIPTION
Docker provisioning fails on Debian Jessie without the apt-transport-https package installed.