### PR TITLE
Take into account machine index and forced provider for provider install

### DIFF
--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -129,7 +129,17 @@ module VagrantPlugins
         # Most likely this will be a set of one.
         providers = Set.new
         names.each do |name|
-          providers.add(@env.default_provider(machine: name.to_sym, check_usable: false))
+          # Check if we have this machine in the index
+          entry    = @env.machine_index.get(name.to_s)
+
+          # Get the provider for this machine
+          provider = nil
+          provider = entry.provider.to_sym if entry
+          provider = @env.default_provider(
+            machine: name.to_sym, check_usable: false) if !provider
+
+          # Add it to the set
+          providers.add(provider)
         end
 
         # Go through and determine if we can install the providers

--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -82,7 +82,7 @@ module VagrantPlugins
           # parallelize this step because it is likely the same provider
           # anyways.
           if options[:install_provider]
-            install_providers(names)
+            install_providers(names, provider: options[:provider])
           end
 
           @env.batch(options[:parallel]) do |batch|
@@ -124,7 +124,7 @@ module VagrantPlugins
 
       protected
 
-      def install_providers(names)
+      def install_providers(names, provider: nil)
         # First create a set of all the providers we need to check for.
         # Most likely this will be a set of one.
         providers = Set.new
@@ -132,14 +132,24 @@ module VagrantPlugins
           # Check if we have this machine in the index
           entry    = @env.machine_index.get(name.to_s)
 
-          # Get the provider for this machine
-          provider = nil
-          provider = entry.provider.to_sym if entry
-          provider = @env.default_provider(
-            machine: name.to_sym, check_usable: false) if !provider
+          # Get the provider for this machine. This logic isn't completely
+          # straightforward. If we have a forced provider, we always use
+          # that no matter what. If we have an entry in the index (meaning
+          # the machine may be created), we use that provider no matter
+          # what since that will be used by the core. If we have none, then
+          # we ask the Vagrant env what the default provider would be and use
+          # that.
+          #
+          # Note that this logic is a bit redundant if we have "provider"
+          # set but I think its probably cleaner to put this logic in one
+          # place.
+          p = provider
+          p = entry.provider.to_sym if !p && entry
+          p = @env.default_provider(
+            machine: name.to_sym, check_usable: false) if !p
 
           # Add it to the set
-          providers.add(provider)
+          providers.add(p)
         end
 
         # Go through and determine if we can install the providers


### PR DESCRIPTION
Fixes #6708 

This takes into account the forced provider (`--provider`) as well as the machine index (already created machines' provider) into what provider to install instead of always installing the default.