### PR TITLE
use SafeExec to capture history via up/down keys in powershell command

### DIFF
--- a/plugins/hosts/windows/cap/ps.rb
+++ b/plugins/hosts/windows/cap/ps.rb
@@ -1,7 +1,7 @@
 require "pathname"
 require "tmpdir"
 
-require "vagrant/util/subprocess"
+require "vagrant/util/safe_exec"
 
 module VagrantPlugins
   module HostWindows
@@ -34,7 +34,7 @@ module VagrantPlugins
           end
 
           # Launch it
-          Vagrant::Util::Subprocess.execute("powershell", *args)
+          Vagrant::Util::SafeExec.exec("powershell", *args)
         end
       end
     end


### PR DESCRIPTION
`Subprocess` sets up the process in such a way that pressing the up/down arrows does not cycle through command history in the `powershell` command. Using `SafeExec` instead as the `ssh` command does seems to fix this.