### PR TITLE
Change to use pkgng

### DIFF
--- a/plugins/guests/freebsd/cap/rsync.rb
+++ b/plugins/guests/freebsd/cap/rsync.rb
@@ -8,10 +8,7 @@ module VagrantPlugins
             version = result.split('.')[0].to_i if type == :stdout
           end
 
-          pkg_cmd = "pkg_add -r"
-          if version && version >= 10
-            pkg_cmd = "pkg install -y"
-          end
+          pkg_cmd = "pkg install -y"
 
           machine.communicate.sudo("#{pkg_cmd} rsync")
         end


### PR DESCRIPTION
Old pkg_* is now EOL: https://lists.freebsd.org/pipermail/freebsd-ports-announce/2014-February/000077.html