### PR TITLE
vagrant box add fails when box version has dashes (1.8.1)

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -78,6 +78,8 @@ module Vagrant
       providers = Array(providers) if providers
       provider = nil
 
+      version = Gem::Version.new(version).to_s
+
       # A helper to check if a box exists. We store this in a variable
       # since we call it multiple times.
       check_box_exists = lambda do |box_formats|

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -233,6 +233,19 @@ describe Vagrant::BoxCollection, :skip_windows do
       expect(subject.find("foo/bar", :virtualbox, "1.0")).to_not be_nil
     end
 
+    it "should add a box with a version with '-' in it" do
+      box_path = environment.box2_file(:virtualbox)
+
+      # Add the box
+      box = subject.add(box_path, "foo", "1.0.1-1")
+      expect(box).to be_kind_of(box_class)
+      expect(box.name).to eq("foo")
+      expect(box.provider).to eq(:virtualbox)
+
+      # Verify we can find it as well
+      expect(subject.find("foo", :virtualbox, "1.0.1-1")).to_not be_nil
+    end
+
     it "should add a box without specifying a provider" do
       box_path = environment.box2_file(:vmware)
 


### PR DESCRIPTION
Vagrant version 1.8.1

Stack trace:

```
$ vagrant box add box.json
...
/opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/box_add.rb:361:in `box_add': undefined method `name' for nil:NilClass (NoMethodError)
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/box_add.rb:266:in `add_from_metadata'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/box_add.rb:104:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/handle_box.rb:82:in `handle_box'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/handle_box.rb:42:in `block in call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/handle_box.rb:36:in `synchronize'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/handle_box.rb:36:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/call.rb:53:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:224:in `action_raw'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:199:in `block in action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/environment.rb:561:in `lock'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:185:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:185:in `action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
```

box.json:

```
{
    "description": "...", 
    "name": "...", 
    "versions": [
        {
            "version": "8.00.00-16-g28b33ec", 
            "providers": [
                {
                    "url": "...", 
                    "checksum": "...", 
                    "name": "virtualbox", 
                    "checksum_type": "sha256"
                }
            ]
        }
    ]
}
```

A version string like this can be produced with `git describe --tags`.



The reason this failure occurs is because in `BoxCollection::add`, the version directory that is created is named exactly the same as the version. However, the last statement in `add` is to call `find`. In this method, the version that is passed in is first processed by `Gem::Version`, and then converted to a string, resulting in a slight but significant modification: `8.00.00.pre.16.pre.g28b33ec`. That directory does not exist, resulting in `add` returning `nil` and raising the above error.

The box is still added but listing and removing is no longer possible:

```
/opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/list.rb:55:in `block in list_boxes': undefined method `directory' for nil:NilClass (NoMethodError)
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/list.rb:47:in `each'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/list.rb:47:in `list_boxes'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/list.rb:30:in `execute'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/root.rb:61:in `execute'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/cli.rb:42:in `execute'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/environment.rb:302:in `cli'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/bin/vagrant:174:in `<main>'
```

```
/opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/box_remove.rb:84:in `block in call': undefined method `in_use?' for nil:NilClass (NoMethodError)
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/box_remove.rb:76:in `each'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/box_remove.rb:76:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/remove.rb:52:in `execute'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/box/command/root.rb:61:in `execute'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/cli.rb:42:in `execute'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/environment.rb:302:in `cli'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/bin/vagrant:174:in `<main>'
```

Each of these calls fail because `BoxCollection::find` is returning `nil`.

This can be resolved manually by renaming the version directory to match the result of `Gem::Version('...').to_s`. 

One option for solving this problem is to update `BoxCollection::add` to convert the version with `Gem::Version` before doing anything with it. 