### PR TITLE
remove double sudo

### DIFF
--- a/plugins/provisioners/chef/omnibus.rb
+++ b/plugins/provisioners/chef/omnibus.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
       OMNITRUCK = "https://omnitruck.chef.io".freeze
 
       def sh_command(project, version, channel, options = {})
-        command =  "curl -sL #{OMNITRUCK}/install.sh | sudo bash"
+        command =  "curl -sL #{OMNITRUCK}/install.sh | bash"
         command << " -s -- -P \"#{project}\" -c \"#{channel}\""
 
         if version != :latest


### PR DESCRIPTION
The double sudo in `plugins/provisioners/chef/omnibus.rb:11` lost the env like proxy settings. All commands see (plugins/provisioners/chef/cap/*/chef_install.rb) have allready sudo so no need to pipe it to sudo.

See also #6804

