### PR TITLE
Add quoting for ansible's `extra_vars`

### DIFF
--- a/plugins/provisioners/ansible/helpers.rb
+++ b/plugins/provisioners/ansible/helpers.rb
@@ -15,8 +15,8 @@ module VagrantPlugins
 
         shell_arg = []
         command.each do |arg|
-          if arg =~ /(--start-at-task|--limit)=(.+)/
-            shell_arg << "#{$1}='#{$2}'"
+          if arg =~ /(--start-at-task|--limit|--extra-vars)=(.+)/
+            shell_arg << "%s='%s'" % [$1, $2.gsub("'", %q(\\\'))]
           else
             shell_arg << arg
           end

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -741,7 +741,7 @@ VF
         ssh_info[:private_key_path] = ['/my/key1', '/my/key2']
 
         # command line arguments
-        config.extra_vars = "@#{existing_file}"
+        config.extra_vars = {test: "string with 'apostrophes' and ="}
         config.sudo = true
         config.sudo_user = 'deployer'
         config.verbose = "vvv"
@@ -761,7 +761,7 @@ VF
 
       it_should_set_arguments_and_environment_variables 20, 4, true
       it_should_explicitly_enable_ansible_ssh_control_persist_defaults
-      it_should_set_optional_arguments({  "extra_vars"          => "--extra-vars=@#{File.expand_path(__FILE__)}",
+      it_should_set_optional_arguments({  "extra_vars"          => "--extra-vars={\"test\":\"string with 'apostrophes' and =\"}",
                                           "sudo"                => "--sudo",
                                           "sudo_user"           => "--sudo-user=deployer",
                                           "verbose"             => "-vvv",
@@ -786,7 +786,7 @@ VF
 
       it "shows the ansible-playbook command, with additional quotes when required" do
         expect(machine.env.ui).to receive(:detail).with { |full_command|
-          expect(full_command).to eq("PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=true ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes -i '/my/key1' -i '/my/key2' -o ForwardAgent=yes -o ControlMaster=no -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --ask-sudo-pass --ask-vault-pass --limit='machine*:&vagrant:!that_one' --inventory-file=#{generated_inventory_dir} --extra-vars=@#{File.expand_path(__FILE__)} --sudo --sudo-user=deployer -vvv --vault-password-file=#{File.expand_path(__FILE__)} --tags=db,www --skip-tags=foo,bar --start-at-task='an awesome task' --why-not --su-user=foot --ask-su-pass --limit='all' --private-key=./myself.key playbook.yml")
+          expect(full_command).to eq("PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=true ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes -i '/my/key1' -i '/my/key2' -o ForwardAgent=yes -o ControlMaster=no -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --ask-sudo-pass --ask-vault-pass --limit='machine*:&vagrant:!that_one' --inventory-file=#{generated_inventory_dir} --extra-vars='{\"test\":\"string with \\'apostrophes\\' and =\"}' --sudo --sudo-user=deployer -vvv --vault-password-file=#{File.expand_path(__FILE__)} --tags=db,www --skip-tags=foo,bar --start-at-task='an awesome task' --why-not --su-user=foot --ask-su-pass --limit='all' --private-key=./myself.key playbook.yml")
         }
       end
     end


### PR DESCRIPTION
`--start-at-task` and `--limit` are quoted, so is `extra_vars` as of the commit referenced below.

This seems to fix #6726 
I know absolutely no ruby, but hope that things I ended up with after some googling are not too scary.
I also modified a test that checked quoting to expect `extra-vars` quoted as well (and made `extra-vars` contain a hashtable as checking just a filename seemed pretty useless to me). I also supported nested single quotes for all 3 options that are quoted now.

This fix is checked with `ansible` provisioner (as it might have appeared broken because of the suggested fix). I'm happy to report that `ansible` did very same job as `ansible-local`  provisioning my guest machine.