### PR TITLE
Allow overriding the inferred name from `config.vm.synced_folder`

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -198,6 +198,7 @@ module VagrantPlugins
       #   folder.
       # @param [Hash] options Additional options.
       def synced_folder(hostpath, guestpath, options=nil)
+        name = (options && options.delete(:name)) || guestpath
         if Vagrant::Util::Platform.windows?
           # On Windows, Ruby just uses normal '/' for path seps, so
           # just replace normal Windows style seps with Unix ones.
@@ -214,7 +215,7 @@ module VagrantPlugins
         # Make sure the type is a symbol
         options[:type] = options[:type].to_sym if options[:type]
 
-        @__synced_folders[options[:guestpath]] = options
+        @__synced_folders[name] = options
       end
 
       # Define a way to access the machine via a network. This exposes a
@@ -617,7 +618,7 @@ module VagrantPlugins
           # If the shared folder is disabled then don't worry about validating it
           next if options[:disabled]
 
-          guestpath = Pathname.new(options[:guestpath])
+          guestpath = Pathname.new(options[:guestpath]) if options[:guestpath]
           hostpath  = Pathname.new(options[:hostpath]).expand_path(machine.env.root_path)
 
           if guestpath.to_s != ""


### PR DESCRIPTION
If a `name` is specified as an option, it will be used as the id instead
of inferring it from the `guestpath`. If `guestpath` is nil, the `name`
needs to be specified so the folder can be mounted with a name.

This also fixes the synced folder code to allow `guestpath` to be nil.
It was allowed in a previous version for the purpose of preventing a
directory from being auto mounted (#936), but seems to have become an
error at some point after that.

An example of modifying the default /vagrant folder so it doesn't
auto-mount anymore:

```
config.vm.synced_folder ".", nil, name: "/vagrant"
```

An example of sharing another folder, but not auto-mounting it:

```
config.vm.synced_folder ".", nil, name: "foobar"
```

Fixes #6835.
