### PR TITLE
Add trisquel guest plugin as derivative of ubuntu - Issue #6842

### DIFF
--- a/plugins/guests/trisquel/guest.rb
+++ b/plugins/guests/trisquel/guest.rb
@@ -1,0 +1,11 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestTrisquel
+    class Guest < Vagrant.plugin("2", :guest)
+      def detect?(machine)
+        machine.communicate.test("[ -x /usr/bin/lsb_release ] && /usr/bin/lsb_release -i 2>/dev/null | grep Trisquel")
+      end
+    end
+  end
+end

--- a/plugins/guests/trisquel/plugin.rb
+++ b/plugins/guests/trisquel/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestTrisquel
+    class Plugin < Vagrant.plugin("2")
+      name "Trisquel guest"
+      description "Trisquel guest support."
+
+      guest("trisquel", "ubuntu") do
+        require File.expand_path("../guest", __FILE__)
+        Guest
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since Trisquel is a direct derivative of Ubuntu the only thing needed to change is the distribution detection. The rest of the capabilities should work with no issue through normal inheritance.