### PR TITLE
FreeBSD: Use quotes around hostname in rc.conf

### DIFF
--- a/plugins/guests/freebsd/cap/change_host_name.rb
+++ b/plugins/guests/freebsd/cap/change_host_name.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class ChangeHostName
         def self.change_host_name(machine, name)
           if !machine.communicate.test("hostname -f | grep '^#{name}$' || hostname -s | grep '^#{name}$'", {shell: "sh"})
-            machine.communicate.sudo("sed -i '' 's/^hostname=.*$/hostname=#{name}/' /etc/rc.conf", {shell: "sh"})
+            machine.communicate.sudo("sed -i '' 's/^hostname=.*$/hostname=\"#{name}\"/' /etc/rc.conf", {shell: "sh"})
             machine.communicate.sudo("hostname #{name}", {shell: "sh"})
           end
         end


### PR DESCRIPTION
Use double quotes around the `hostname` value in `/etc/rc.conf`