### PR TITLE
fixing incorrect missing ansible error

### DIFF
--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
 
           # Check that ansible binaries are well installed on the guest,
           @machine.communicate.execute(
-            "ansible-galaxy --help && ansible-playbook --help",
+            "ansible-galaxy info --help && ansible-playbook --help",
             :error_class => Ansible::Errors::AnsibleNotFoundOnGuest,
             :error_key => :ansible_not_found_on_guest)
 


### PR DESCRIPTION
At least for ansible 2.0.0.1 the command `ansible-galaxy --help` is inappropriate for testing if ansible is installed, as it yields an error:

```
vagrant@vagrant-ubuntu-trusty-64:~$ ansible-galaxy --help && echo "OK"          
Usage: ansible-galaxy [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...

Options:
  -h, --help     show this help message and exit
  -v, --verbose  verbose mode (-vvv for more, -vvvv to enable connection
                 debugging)
  --version      show program's version number and exit
ERROR! Missing required action
```