### PR TITLE
Update nfs docs

### DIFF
--- a/website/docs/source/v2/synced-folders/nfs.html.md
+++ b/website/docs/source/v2/synced-folders/nfs.html.md
@@ -138,6 +138,8 @@ Below, we have a couple example sudoers entries. Note that you may
 have to modify them _slightly_ on certain hosts because the way Vagrant
 modifies `/etc/exports` changes a bit from OS to OS.
 
+For *nix users, make sure to edit your `/etc/sudoers` file with `visudo`. It protects you against syntax errors which could leave you without the ability to gain elevated privileges.
+
 All of the snippets below require Vagrant version 1.7.3 or higher.
 
 For OS X, sudoers should have this entry:

--- a/website/docs/source/v2/synced-folders/nfs.html.md
+++ b/website/docs/source/v2/synced-folders/nfs.html.md
@@ -138,7 +138,7 @@ Below, we have a couple example sudoers entries. Note that you may
 have to modify them _slightly_ on certain hosts because the way Vagrant
 modifies `/etc/exports` changes a bit from OS to OS.
 
-For *nix users, make sure to edit your `/etc/sudoers` file with `visudo`. It protects you against syntax errors which could leave you without the ability to gain elevated privileges.
+For \*nix users, make sure to edit your `/etc/sudoers` file with `visudo`. It protects you against syntax errors which could leave you without the ability to gain elevated privileges.
 
 All of the snippets below require Vagrant version 1.7.3 or higher.
 


### PR DESCRIPTION
Closes #6872

Adds a warning to the [synced folders docs](https://docs.vagrantup.com/v2/synced-folders/nfs.html) about using `visudo` vs any other editor as syntax errors can leave you stuck without privileges.
