### PR TITLE
Add missing features to snapshot restore/pop

### DIFF
--- a/plugins/commands/snapshot/command/pop.rb
+++ b/plugins/commands/snapshot/command/pop.rb
@@ -10,17 +10,22 @@ module VagrantPlugins
         include PushShared
 
         def execute
+          options = {}
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant snapshot pop [options] [vm-name]"
             o.separator ""
             o.separator "Restore state that was pushed with `vagrant snapshot push`."
+
+            o.on("--no-delete", "Don't delete the snapshot after the restore") do
+                options[:no_delete] = true
+            end
           end
 
           # Parse the options
           argv = parse_options(opts)
           return if !argv
 
-          return shared_exec(argv, method(:pop))
+          return shared_exec(argv, method(:pop), options)
         end
       end
     end

--- a/plugins/commands/snapshot/command/pop.rb
+++ b/plugins/commands/snapshot/command/pop.rb
@@ -1,6 +1,10 @@
 require 'json'
 require 'optparse'
 
+require 'vagrant'
+
+require Vagrant.source_root.join("plugins/commands/up/start_mixins")
+
 require_relative "push_shared"
 
 module VagrantPlugins
@@ -8,22 +12,28 @@ module VagrantPlugins
     module Command
       class Pop < Vagrant.plugin("2", :command)
         include PushShared
+        include VagrantPlugins::CommandUp::StartMixins
 
         def execute
           options = {}
+          options[:snapshot_delete] = true
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant snapshot pop [options] [vm-name]"
             o.separator ""
+            build_start_options(o, options)
             o.separator "Restore state that was pushed with `vagrant snapshot push`."
 
             o.on("--no-delete", "Don't delete the snapshot after the restore") do
-                options[:no_delete] = true
+                options[:snapshot_delete] = false
             end
           end
 
           # Parse the options
           argv = parse_options(opts)
           return if !argv
+
+          # Validate the provisioners
+          validate_provisioner_flags!(options, argv)
 
           return shared_exec(argv, method(:pop), options)
         end

--- a/plugins/commands/snapshot/command/push_shared.rb
+++ b/plugins/commands/snapshot/command/push_shared.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module CommandSnapshot
     module Command
       module PushShared
-        def shared_exec(argv, m)
+        def shared_exec(argv, m, opts={})
           with_target_vms(argv) do |vm|
             if !vm.id
               vm.ui.info("Not created. Cannot push snapshot state.")
@@ -12,7 +12,7 @@ module VagrantPlugins
             end
 
             vm.env.lock("machine-snapshot-stack") do
-              m.call(vm)
+              m.call(vm,opts)
             end
           end
 
@@ -20,14 +20,14 @@ module VagrantPlugins
           0
         end
 
-        def push(machine)
+        def push(machine,opts={})
           snapshot_name = "push_#{Time.now.to_i}_#{rand(10000)}"
 
           # Save the snapshot. This will raise an exception if it fails.
           machine.action(:snapshot_save, snapshot_name: snapshot_name)
         end
 
-        def pop(machine)
+        def pop(machine,opts={})
           # By reverse sorting, we should be able to find the first
           # pushed snapshot.
           name = nil
@@ -45,11 +45,16 @@ module VagrantPlugins
             return
           end
 
-          # Restore the snapshot and tell the provider to delete it as well.
+          snapshot_delete = true
+          if opts.key?(:no_delete)
+              snapshot_delete = false
+          end
+
+          # Restore the snapshot and tell the provider to delete it, if required
           machine.action(
             :snapshot_restore,
             snapshot_name: name,
-            snapshot_delete: true)
+            snapshot_delete: snapshot_delete)
         end
       end
     end

--- a/plugins/commands/snapshot/command/push_shared.rb
+++ b/plugins/commands/snapshot/command/push_shared.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
             end
 
             vm.env.lock("machine-snapshot-stack") do
-              m.call(vm,opts)
+              m.call(vm, opts)
             end
           end
 
@@ -20,14 +20,14 @@ module VagrantPlugins
           0
         end
 
-        def push(machine,opts={})
+        def push(machine, opts={})
           snapshot_name = "push_#{Time.now.to_i}_#{rand(10000)}"
 
           # Save the snapshot. This will raise an exception if it fails.
           machine.action(:snapshot_save, snapshot_name: snapshot_name)
         end
 
-        def pop(machine,opts={})
+        def pop(machine, opts={})
           # By reverse sorting, we should be able to find the first
           # pushed snapshot.
           name = nil

--- a/plugins/commands/snapshot/command/push_shared.rb
+++ b/plugins/commands/snapshot/command/push_shared.rb
@@ -45,16 +45,9 @@ module VagrantPlugins
             return
           end
 
-          snapshot_delete = true
-          if opts.key?(:no_delete)
-              snapshot_delete = false
-          end
-
           # Restore the snapshot and tell the provider to delete it, if required
-          machine.action(
-            :snapshot_restore,
-            snapshot_name: name,
-            snapshot_delete: snapshot_delete)
+          opts[:snapshot_name] = name
+          machine.action(:snapshot_restore, opts)
         end
       end
     end


### PR DESCRIPTION
In our test environments, it's good to be able to roll back to the same,
anonymous, snapshot repeatedly.  This patch adds a `--no-delete` option
to the `snapshot pop` command allowing this.

This makes the new core snapshot behaviour more consistent with what we
were doing with [vagrant-multiprovider-snap](https://github.com/scalefactory/vagrant-multiprovider-snap) which I intend to deprecate eventually.