### PR TITLE
redhat/nfs_client: Ignore systemctl nfs return code

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
 
         def self.restart_nfs(machine)
           if systemd?(machine)
-            machine.communicate.sudo("/bin/systemctl restart rpcbind nfs")
+            machine.communicate.sudo("/bin/systemctl restart rpcbind nfs || :")
           else
             machine.communicate.sudo("/etc/init.d/rpcbind restart; /etc/init.d/nfs restart")
           end


### PR DESCRIPTION
By default there are no exports defined inside the Fedora guest,
because of this the nfs service fails to restart.
Let's ignore the returncode, because it's not to critical.