### PR TITLE
fix login behind proxy (#6898)

### DIFF
--- a/plugins/commands/login/client.rb
+++ b/plugins/commands/login/client.rb
@@ -50,6 +50,7 @@ module VagrantPlugins
           proxy   = nil
           proxy ||= ENV["HTTPS_PROXY"] || ENV["https_proxy"]
           proxy ||= ENV["HTTP_PROXY"]  || ENV["http_proxy"]
+	  RestClient.proxy = proxy
 
           response = RestClient::Request.execute(
             method: :post,


### PR DESCRIPTION
we're using rest_client 1.6.9, which doesn't use proxy passed in
to the RestClient::Request.execute.  Must set RestClient.proxy
instead

Fixes #6898