### PR TITLE
Fixed an issue locating puppet binary. Issue-6876

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -154,9 +154,9 @@ module VagrantPlugins
           # This is very platform dependent.
           test_cmd = "sh -c 'command -v #{binary}'"
           if windows?
-            test_cmd = "where #{binary}"
+            test_cmd = "where.exe #{binary}"
             if @config.binary_path
-              test_cmd = "where \"#{@config.binary_path}:#{binary}\""
+              test_cmd = "where.exe \"#{@config.binary_path}:#{binary}\""
             end
           end
 


### PR DESCRIPTION
As explained here http://stackoverflow.com/questions/11009598/whats-the-cmd-powershell-equivalent-of-which-on-bash in PS may be necessary to use "where.exe" instead of "where" to avoid call "Where-Object"

The change is compatible with CMD also.