### PR TITLE
remove call to deprecated toggle_nori_type_casting in winrm

### DIFF
--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -170,7 +170,6 @@ module VagrantPlugins
 
         client = ::WinRM::WinRMWebService.new(endpoint, @config.transport.to_sym, endpoint_options)
         client.set_timeout(@config.timeout)
-        client.toggle_nori_type_casting(:off) #we don't want coersion of types
         client
       end
 


### PR DESCRIPTION
Removing call to method deprecated in v1.3. This will also prevent v1.5+ from leaking deprecation warning.

cc @sneal 