### PR TITLE
Salt provisioner: respect run_highstate setting in masterless mode

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -321,15 +321,19 @@ module VagrantPlugins
       end
 
       def call_masterless
-        @machine.env.ui.info "Calling state.highstate in local mode... (this may take a while)"
-        cmd = "salt-call state.highstate --local#{get_loglevel}#{get_colorize}#{get_pillar}"
-        if @config.minion_id
-          cmd += " --id #{@config.minion_id}"
-        end
-        @machine.communicate.sudo(cmd) do |type, data|
-          if @config.verbose
-            @machine.env.ui.info(data)
+        if @config.run_highstate
+          @machine.env.ui.info "Calling state.highstate in local mode... (this may take a while)"
+          cmd = "salt-call state.highstate --local#{get_loglevel}#{get_colorize}#{get_pillar}"
+          if @config.minion_id
+            cmd += " --id #{@config.minion_id}"
           end
+          @machine.communicate.sudo(cmd) do |type, data|
+            if @config.verbose
+              @machine.env.ui.info(data)
+            end
+          end
+        else
+          @machine.env.ui.info "run_highstate set to false. Not running state.highstate"
         end
       end
 


### PR DESCRIPTION
Ensure that the run_highstate setting for the salt provisioner is respected when bringing up a masterless minion. See my original [issue](https://github.com/mitchellh/vagrant/issues/6915) for more infos.

Fixes #6915.