### PR TITLE
Update nfs sudo configuration for Fedora

### DIFF
--- a/website/source/docs/synced-folders/nfs.html.md
+++ b/website/source/docs/synced-folders/nfs.html.md
@@ -176,7 +176,7 @@ Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
 Cmnd_Alias VAGRANT_NFSD_CHECK = /usr/bin/systemctl status nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_START = /usr/bin/systemctl start nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
-Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /bin/sed -r -e * d -ibak /etc/exports
+Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /bin/sed -r -e * d -ibak /tmp/exports
 %vagrant ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY, VAGRANT_EXPORTS_REMOVE
 ```
 


### PR DESCRIPTION
Copied the configuration to my own machine and noticed I was still getting prompted for my password. Looking at the command, I realize that sed is called on /tmp/exports, not /etc. Quick change, and everything is automatic as expected!

Updating the documentation so others don't have the same hassle. :)