### PR TITLE
Fix/master/tinycore nfs mount

### DIFF
--- a/plugins/guests/tinycore/cap/mount_nfs.rb
+++ b/plugins/guests/tinycore/cap/mount_nfs.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
               mount_opts = opts[:mount_options].dup
             end
 
-            mount_command = "mount -o '#{mount_opts.join(",")}' #{ip}:'#{hostpath}' #{expanded_guest_path}"
+            mount_command = "mount.nfs -o '#{mount_opts.join(",")}' #{ip}:'#{hostpath}' #{expanded_guest_path}"
             retryable(on: Vagrant::Errors::LinuxNFSMountFailed, tries: 8, sleep: 3) do
               machine.communicate.sudo(mount_command,
                                        error_class: Vagrant::Errors::LinuxNFSMountFailed)

--- a/plugins/guests/tinycore/cap/mount_nfs.rb
+++ b/plugins/guests/tinycore/cap/mount_nfs.rb
@@ -1,0 +1,46 @@
+require "vagrant/util/retryable"
+
+module VagrantPlugins
+  module GuestLinux
+    module Cap
+      class MountNFS
+        extend Vagrant::Util::Retryable
+
+        def self.mount_nfs_folder(machine, ip, folders)
+          folders.each do |name, opts|
+            # Expand the guest path so we can handle things like "~/vagrant"
+            expanded_guest_path = machine.guest.capability(
+              :shell_expand_guest_path, opts[:guestpath])
+
+            # Do the actual creating and mounting
+            machine.communicate.sudo("mkdir -p #{expanded_guest_path}")
+
+            # Mount
+            hostpath = opts[:hostpath].dup
+            hostpath.gsub!("'", "'\\\\''")
+
+            # Figure out any options
+            mount_opts = ["vers=#{opts[:nfs_version]}"]
+            mount_opts << "udp" if opts[:nfs_udp]
+            if opts[:mount_options]
+              mount_opts = opts[:mount_options].dup
+            end
+
+            mount_command = "mount -o '#{mount_opts.join(",")}' #{ip}:'#{hostpath}' #{expanded_guest_path}"
+            retryable(on: Vagrant::Errors::LinuxNFSMountFailed, tries: 8, sleep: 3) do
+              machine.communicate.sudo(mount_command,
+                                       error_class: Vagrant::Errors::LinuxNFSMountFailed)
+            end
+
+            # Emit an upstart event if we can
+            machine.communicate.sudo <<-SCRIPT
+if command -v /sbin/init &>/dev/null && /sbin/init --version | grep upstart &>/dev/null; then
+  /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT='#{expanded_guest_path}'
+fi
+SCRIPT
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/tinycore/cap/mount_nfs.rb
+++ b/plugins/guests/tinycore/cap/mount_nfs.rb
@@ -1,7 +1,7 @@
 require "vagrant/util/retryable"
 
 module VagrantPlugins
-  module GuestLinux
+  module GuestTinyCore
     module Cap
       class MountNFS
         extend Vagrant::Util::Retryable

--- a/plugins/guests/tinycore/plugin.rb
+++ b/plugins/guests/tinycore/plugin.rb
@@ -30,6 +30,11 @@ module VagrantPlugins
         require_relative "cap/rsync"
         Cap::RSync
       end
+
+      guest_capability("linux", "mount_nfs_folder") do
+        require_relative "cap/mount_nfs"
+        Cap::MountNFS
+      end
     end
   end
 end

--- a/plugins/guests/tinycore/plugin.rb
+++ b/plugins/guests/tinycore/plugin.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
         Cap::RSync
       end
 
-      guest_capability("linux", "mount_nfs_folder") do
+      guest_capability("tinycore", "mount_nfs_folder") do
         require_relative "cap/mount_nfs"
         Cap::MountNFS
       end


### PR DESCRIPTION
The hashicorp/boot2docker box used the linux mount_nfs.rb which fails with TinyCore.
Currently NFSv4 works, and NFSv3 needs the additional `nolock` option.

Fixes #6968
