### PR TITLE
Fix #6828 regression with broken regexp support on 'vagrant up /test*/'

### DIFF
--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -146,7 +146,7 @@ module VagrantPlugins
           p = provider
           p = entry.provider.to_sym if !p && entry
           p = @env.default_provider(
-            machine: machine.name.to_sym, check_usable: false) if !p
+            machine: machine.name.to_sym, check_usable: false) if !p && entry
 
           # Add it to the set
           providers.add(p)


### PR DESCRIPTION
The fix resolves an issue #6828 for me. Please consider to include in Vagrant 1.8.2
Thank you!