### PR TITLE
Add debugging log docs.

### DIFF
--- a/website/source/docs/other/debugging.html.md
+++ b/website/source/docs/other/debugging.html.md
@@ -57,3 +57,9 @@ option. For example:
 ```
 $ vagrant up --debug
 ```
+
+Redirect the log output using `&>` to capture both stdout and stderr:
+
+```
+$ vagrant up --provision --debug &> vagrant.log
+```


### PR DESCRIPTION
During dev I needed to get the detailed logs into a file.  The debug info goes to stderr, my redirect was only catching stdout. Quick fix to the docs, and per http://unix.stackexchange.com/questions/244343/where-is-vagrants-log-file I may not be the only one who questioned this in the past.

The `--debug` option could be added to the CLI.  That was the first place I looked, and not seeing anything I googled. If I can get a quick pointer where to look in the code, I'll submit another small PR so ppl are aware of this option.