### PR TITLE
Use "stable" as the default Chef channel

### DIFF
--- a/plugins/provisioners/chef/config/base.rb
+++ b/plugins/provisioners/chef/config/base.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
         # The channel from which to download Chef. Currently known values are
         # "current" and "stable", but more may be added in the future. The
-        # default is "current".
+        # default is "stable".
         # @return [String]
         attr_accessor :channel
 
@@ -68,10 +68,9 @@ module VagrantPlugins
         def prerelease=(value)
           STDOUT.puts <<-EOH
 [DEPRECATED] The configuration `chef.prerelease' has been deprecated. Please use
-`chef.channel' instead. The default value for channel is "current", which
-includes prelease versions of Chef Client and the Chef Development Kit. You can
-probably just remove the `prerelease' setting from your Vagrantfile and things
-will continue working as expected.
+`chef.channel' instead. The default value for channel is "stable", which
+includes the latest published versions of the Chef Client. You can choose to use
+prerelease versions by setting the channel to "current".
 EOH
         end
 
@@ -94,7 +93,7 @@ EOH
           @product     = "chef"    if @product == UNSET_VALUE
           @install     = true      if @install == UNSET_VALUE
           @log_level   = :info     if @log_level == UNSET_VALUE
-          @channel     = "current" if @channel == UNSET_VALUE
+          @channel     = "stable"  if @channel == UNSET_VALUE
           @version     = :latest   if @version == UNSET_VALUE
           @installer_download_path = nil  if @installer_download_path == UNSET_VALUE
 

--- a/test/unit/plugins/provisioners/chef/config/base_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/base_test.rb
@@ -57,9 +57,9 @@ describe VagrantPlugins::Chef::Config::Base do
   end
 
   describe "#channel" do
-    it "defaults to \"current\"" do
+    it "defaults to \"stable\"" do
       subject.finalize!
-      expect(subject.channel).to eq("current")
+      expect(subject.channel).to eq("stable")
     end
   end
 

--- a/website/source/docs/provisioning/chef_common.html.md
+++ b/website/source/docs/provisioning/chef_common.html.md
@@ -43,14 +43,16 @@ understand their purpose.
 
 - `product` (string) - The name of the Chef product to install. The default
   value is "chef", which corresponds to the Chef Client. You can also specify
-  "chefdk", which will install the Chef Development Kit.
+  "chefdk", which will install the Chef Development Kit. At the time of this
+  writing, the ChefDK is only available through the "current" channel, so you
+  will need to update that value as well.
 
 - `channel` (string) - The release channel from which to pull the Chef Client
-  or the Chef Development Kit. The default value is `"current"` which will pull
-  ChefDK and the latest released version of Chef. For older versions, you may
-  need to change the channel to "stable". Because Chef Software floats the
-  versions that are contained in the channel, they may change and Vagrant is
-  unable to detect this.
+  or the Chef Development Kit. The default value is `"stable"` which will pull
+  the latest stable version of the Chef Client. For newer versions, or if you
+  wish to install the Chef Development Kit, you may need to change the channel
+  to "current". Because Chef Software floats the versions that are contained in
+  the channel, they may change and Vagrant is unable to detect this.
 
 - `version` (string) - The version of Chef to install on the guest. If Chef is
   already installed on the system, the installed version is compared with the


### PR DESCRIPTION
Previously the default channel was "current", but after discussion with
@coderanger on GH-6979, it seems like this was a poor design decision.
Instead, we should use the stable channel and allow users to opt-in to
prerelease versions.

Fixes GH-6979