### PR TITLE
set longer timeout for net::ssh

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -339,7 +339,7 @@ module VagrantPlugins
           paranoid:              false,
           password:              ssh_info[:password],
           port:                  ssh_info[:port],
-          timeout:               15,
+          timeout:               30,
           user_known_hosts_file: [],
           verbose:               :debug,
         }


### PR DESCRIPTION
timeout is set from 15 sec to 30 sec. it will fix some timeout error
like "timeout during server version negotiating" for some guest setting