### PR TITLE
communicators/winrm return false on ready? failure

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -107,9 +107,9 @@ module VagrantPlugins
 
         @logger.info("WinRM is ready!")
         return true
-      rescue Errors::TransientError => e
-        # We catch a `TransientError` which would signal that something went
-        # that might work if we wait and retry.
+      rescue Vagrant::Errors::VagrantError => e
+        # We catch a `VagrantError` which would signal that something went
+        # wrong expectedly in the `connect`, which means we didn't connect.
         @logger.info("WinRM not up: #{e.inspect}")
 
         # We reset the shell to trigger calling of winrm_finder again.

--- a/test/unit/plugins/communicators/winrm/communicator_test.rb
+++ b/test/unit/plugins/communicators/winrm/communicator_test.rb
@@ -66,9 +66,9 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
       expect(subject.ready?).to be_false
     end
 
-    it "raises an error if hostname command fails with an unknown error" do
+    it "returns false if hostname command fails" do
       expect(shell).to receive(:powershell).with("hostname").and_raise(Vagrant::Errors::VagrantError)
-      expect { subject.ready? }.to raise_error(Vagrant::Errors::VagrantError)
+      expect(subject.ready?).to be_false
     end
 
     it "raises timeout error when hostname command takes longer then winrm timeout" do


### PR DESCRIPTION
Prior to this patch, the WinRM `.ready?` method raised an error if there was
a communication failure. This behavior differs from the SSH communicator which
returns `false` from `ready?` if a communication failure occurs. The difference
in behavior makes it difficult to write code that works with both types of
communicators.

This patch changes the WinRM `.ready?` method to return false if an error of
type `Vagrant::Errors::VagrantError` occurs, which matches the behavior of the
SSH communicator.

Fixes mitchellh/vagrant#6356.