### PR TITLE
Fix for #4608: Support for port forwarding in an IP aliased environment

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -244,9 +244,11 @@ module VagrantPlugins
           default_id = nil
 
           if type == :forwarded_port
-            # For forwarded ports, set the default ID to the
-            # host port so that host ports overwrite each other.
-            default_id = "#{options[:protocol]}#{options[:host]}"
+            # For forwarded ports, set the default ID to be the
+            # concat of host_ip, proto and host_port. This would ensure Vagrant
+            # caters for port forwarding in an IP aliased environment where
+            # different host IP addresses are to be listened on the same port.
+            default_id = "#{options[:host_ip]}#{options[:protocol]}#{options[:host]}"
           end
 
           options[:id] = default_id || SecureRandom.uuid
@@ -676,7 +678,7 @@ module VagrantPlugins
             end
 
             if options[:host]
-              key = "#{options[:protocol]}#{options[:host]}"
+              key = "#{options[:host_ip]}#{options[:protocol]}#{options[:host]}"
               if fp_used.include?(key)
                 errors << I18n.t("vagrant.config.vm.network_fp_host_not_unique",
                                 host: options[:host].to_s,

--- a/plugins/providers/virtualbox/util/compile_forwarded_ports.rb
+++ b/plugins/providers/virtualbox/util/compile_forwarded_ports.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
             if type == :forwarded_port
               guest_port = options[:guest]
               host_port  = options[:host]
+              host_ip    = options[:host_ip]
               protocol   = options[:protocol] || "tcp"
               options    = scoped_hash_override(options, :virtualbox)
               id         = options[:id]
@@ -22,7 +23,8 @@ module VagrantPlugins
               # If the forwarded port was marked as disabled, ignore.
               next if options[:disabled]
 
-              mappings[host_port.to_s + protocol.to_s] =
+              key = "#{host_ip}#{protocol}#{host_port}"
+              mappings[key] =
                 Model::ForwardedPort.new(id, host_port, guest_port, options)
             end
           end


### PR DESCRIPTION
Added support for Port forwarding in an IP aliased environment where the **same host port but different host IP addresses** are used. The change makes the following forwarding rule(s) possible.

Ex: `eth0` on the host is ip aliased to have a range of IP addresses `10.20.30.0/24.`

In the Vagrant file, we can now have an entry like the following and
it will just work! Note the host port `8081` is same for both .1 and .2.

```
 Vagrant.configure("2") do |config|
    config.vm.network "forwarded_port", guest: 80, host: 8080
    config.vm.network "forwarded_port", guest: 81, host: 8081, host_ip: 10.20.30.1
    config.vm.network "forwarded_port", guest: 82, host: 8081, host_ip: 10.20.30.2
  end
```
