### PR TITLE
Fix berks

### DIFF
--- a/lib/vagrant/util/env.rb
+++ b/lib/vagrant/util/env.rb
@@ -9,7 +9,7 @@ module Vagrant
         if Vagrant.original_env.any?
           ENV.replace(proxy_env)
         elsif defined?(::Bundler::ORIGINAL_ENV)
-          #ENV.replace(::Bundler::ORIGINAL_ENV)
+          ENV.replace(::Bundler::ORIGINAL_ENV)
         end
         yield
       ensure

--- a/lib/vagrant/util/env.rb
+++ b/lib/vagrant/util/env.rb
@@ -7,7 +7,6 @@ module Vagrant
         original_env = ENV.to_hash
         proxy_env = Vagrant.original_env
         if Vagrant.original_env.any?
-          puts 'heloooooooooooooooo'
           ENV.replace(proxy_env)
         elsif defined?(::Bundler::ORIGINAL_ENV)
           #ENV.replace(::Bundler::ORIGINAL_ENV)

--- a/lib/vagrant/util/env.rb
+++ b/lib/vagrant/util/env.rb
@@ -5,8 +5,13 @@ module Vagrant
     class Env
       def self.with_original_env
         original_env = ENV.to_hash
-        ENV.replace(::Bundler::ORIGINAL_ENV) if defined?(::Bundler::ORIGINAL_ENV)
-        ENV.update(Vagrant.original_env)
+        proxy_env = Vagrant.original_env
+        if Vagrant.original_env.any?
+          puts 'heloooooooooooooooo'
+          ENV.replace(proxy_env)
+        elsif defined?(::Bundler::ORIGINAL_ENV)
+          #ENV.replace(::Bundler::ORIGINAL_ENV)
+        end
         yield
       ensure
         ENV.replace(original_env.to_hash)

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -37,9 +37,7 @@ module Vagrant
 
       def execute
         process=nil
-        puts "before #{ENV['VAGRANT_OLD_ENV_XAUTHORITY']}"
         Vagrant::Util::Env.with_original_env do
-        puts "after #{ENV['VAGRANT_OLD_ENV_XAUTHORITY']}"
         # Get the timeout, if we have one
         timeout = @options[:timeout]
 
@@ -67,7 +65,6 @@ module Vagrant
         # Build the ChildProcess
         @logger.info("Starting process: #{@command.inspect}")
         process = nil
-          puts "HOHOHOHOO #{ENV['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
           process = ChildProcess.build(*@command)
 
         # Create the pipes so we can read the output in real time as
@@ -126,8 +123,6 @@ module Vagrant
         begin
           SafeChdir.safe_chdir(workdir) do
             Vagrant::Util::Env.with_original_env do
-              puts "HIHIHIHIHI #{ENV['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
-              puts "HIHIHIHIHI #{process.environment['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
               process.start
             end
           end
@@ -315,7 +310,6 @@ module Vagrant
           env["RUBYOPT"] = ENV["RUBYOPT"].sub("-rbundler/setup", "")
         end
 
-        puts "ISNI #{env['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
         nil
       end
     end

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -36,6 +36,10 @@ module Vagrant
       end
 
       def execute
+        process=nil
+        puts "before #{ENV['VAGRANT_OLD_ENV_XAUTHORITY']}"
+        Vagrant::Util::Env.with_original_env do
+        puts "after #{ENV['VAGRANT_OLD_ENV_XAUTHORITY']}"
         # Get the timeout, if we have one
         timeout = @options[:timeout]
 
@@ -62,7 +66,9 @@ module Vagrant
 
         # Build the ChildProcess
         @logger.info("Starting process: #{@command.inspect}")
-        process = ChildProcess.build(*@command)
+        process = nil
+          puts "HOHOHOHOO #{ENV['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
+          process = ChildProcess.build(*@command)
 
         # Create the pipes so we can read the output in real time as
         # we execute the command.
@@ -119,7 +125,11 @@ module Vagrant
         # Start the process
         begin
           SafeChdir.safe_chdir(workdir) do
-            process.start
+            Vagrant::Util::Env.with_original_env do
+              puts "HIHIHIHIHI #{ENV['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
+              puts "HIHIHIHIHI #{process.environment['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
+              process.start
+            end
           end
         rescue ChildProcess::LaunchError => ex
           # Raise our own version of the error so that users of the class
@@ -222,6 +232,7 @@ module Vagrant
 
         # Return an exit status container
         return Result.new(process.exit_code, io_data[:stdout], io_data[:stderr])
+        end
       ensure
         if process && process.alive?
           # Make sure no matter what happens, the process exits
@@ -290,9 +301,6 @@ module Vagrant
       def jailbreak(env = {})
         return if ENV.key?("VAGRANT_SKIP_SUBPROCESS_JAILBREAK")
 
-        env.replace(::Bundler::ORIGINAL_ENV) if defined?(::Bundler::ORIGINAL_ENV)
-        env.merge!(Vagrant.original_env)
-
         # Bundler does this, so I guess we should as well, since I think it
         # other subprocesses that use Bundler will reload it
         env["MANPATH"] = ENV["BUNDLE_ORIG_MANPATH"]
@@ -307,6 +315,7 @@ module Vagrant
           env["RUBYOPT"] = ENV["RUBYOPT"].sub("-rbundler/setup", "")
         end
 
+        puts "ISNI #{env['VAGRANT_OLD_ENV_UPSTART_INSTANCE']}"
         nil
       end
     end

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -36,8 +36,6 @@ module Vagrant
       end
 
       def execute
-        process=nil
-        Vagrant::Util::Env.with_original_env do
         # Get the timeout, if we have one
         timeout = @options[:timeout]
 
@@ -64,8 +62,7 @@ module Vagrant
 
         # Build the ChildProcess
         @logger.info("Starting process: #{@command.inspect}")
-        process = nil
-          process = ChildProcess.build(*@command)
+        process = ChildProcess.build(*@command)
 
         # Create the pipes so we can read the output in real time as
         # we execute the command.
@@ -227,7 +224,6 @@ module Vagrant
 
         # Return an exit status container
         return Result.new(process.exit_code, io_data[:stdout], io_data[:stderr])
-        end
       ensure
         if process && process.alive?
           # Make sure no matter what happens, the process exits


### PR DESCRIPTION
Firstly, I want to squash before merging  

This change restores the original environment for processes run by `Vagrant::Util::Subprocess`. This is something that a lot of methods in the Vagrant codebase are supposed to be doing, but eventually didn't.  
The basic issue was that Bundler was double-executed (in addition to the env variable modification in the Vagrant Golang launcher), so it didn't restore the original Ruby variables properly.

After applying this, Vagrant successfully runs non-ChefDK Berkshelf properly (the ChefDK Berkshelf always works because it's ignoring Ruby environment variables like `GEM_PATH`.

I might have not understood the way `jailbreak` is supposed to work. It might need to run under the original env contex as well. I'll be happy to get guidance for testing it
