### PR TITLE
Do not ignore the sentinal file when running resume

### DIFF
--- a/plugins/commands/resume/command.rb
+++ b/plugins/commands/resume/command.rb
@@ -1,24 +1,38 @@
 require 'optparse'
 
+require Vagrant.source_root.join("plugins/commands/up/start_mixins")
+
 module VagrantPlugins
   module CommandResume
     class Command < Vagrant.plugin("2", :command)
+      # We assume that the `up` plugin exists and that we'll have access
+      # to this.
+      include VagrantPlugins::CommandUp::StartMixins
+
       def self.synopsis
         "resume a suspended vagrant machine"
       end
 
       def execute
+        options = {}
+        options[:provision_ignore_sentinel] = false
+
         opts = OptionParser.new do |o|
           o.banner = "Usage: vagrant resume [vm-name]"
+          o.separator ""
+          build_start_options(o, options)
         end
 
         # Parse the options
         argv = parse_options(opts)
         return if !argv
 
+        # Validate the provisioners
+        validate_provisioner_flags!(options, argv)
+
         @logger.debug("'resume' each target VM...")
         with_target_vms(argv) do |machine|
-          machine.action(:resume)
+          machine.action(:resume, options)
         end
 
         # Success, exit status 0

--- a/website/source/docs/cli/resume.html.md
+++ b/website/source/docs/cli/resume.html.md
@@ -14,3 +14,15 @@ description: |-
 
 This resumes a Vagrant managed machine that was previously suspended,
 perhaps with the [suspend command](/docs/cli/suspend.html).
+
+The configured provisioners will not run again, by default. You can force
+the provisioners to re-run by specifying the `--provision` flag.
+
+# Options
+
+* `--provision` - Force the provisioners to run.
+
+* `--provision-with x,y,z` - This will only run the given provisioners. For
+  example, if you have a `:shell` and `:chef_solo` provisioner and run
+  `vagrant provision --provision-with shell`, only the shell provisioner will
+  be run.


### PR DESCRIPTION
### Overview
Do not ignore the sentinal file when running resume and prevent running provisioners again.

### References
- Fixes #6787 

The sentinal file was always being ignored when running the resume command. This is fixed along with allowing provision options to be used with resume. The code added aligns with the implementation in the reload command.

BTW, I did a ```git bisect``` to track it back to issue #5815 and commit 6f3ed13f75a1be66ed22f9bdcaa262e8077e458e. In the case of a resume command there was no options array passed into the ```machine.action``` call which caused the ```env.key?(:provision_ignore_sentinel)``` check in lib/vagrant/action/builtin/provision.rb to fail and ```ignore_sentinal``` defaulted to true.