### PR TITLE
Correctly detect chefdk install

### DIFF
--- a/plugins/provisioners/chef/cap/linux/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/linux/chef_installed.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
         module ChefInstalled
           # Check if Chef is installed at the given version.
           # @return [true, false]
-          def self.chef_installed(machine, version)
-            knife = "/opt/chef/bin/knife"
+          def self.chef_installed(machine, product, version)
+            knife = "/opt/#{product}/bin/knife"
             command = "test -x #{knife}"
 
             if version != :latest

--- a/plugins/provisioners/chef/cap/omnios/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_installed.rb
@@ -6,10 +6,10 @@ module VagrantPlugins
           # TODO: this is the same code as cap/linux/chef_installed, consider merging
           # Check if Chef is installed at the given version.
           # @return [true, false]
-          def self.chef_installed(machine, version)
-            knife = "/opt/chef/bin/knife"
+          def self.chef_installed(machine, product, version)
+            knife = "/opt/#{product}/bin/knife"
             command = "test -x #{knife}"
-            
+
             if version != :latest
               command << "&& #{knife} --version | grep 'Chef: #{version}'"
             end

--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         module ChefInstalled
           # Check if Chef is installed at the given version.
           # @return [true, false]
-          def self.chef_installed(machine, version)
+          def self.chef_installed(machine, product, version)
             if version != :latest
               command = 'if ((&knife --version) -Match "Chef: ' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else

--- a/plugins/provisioners/chef/installer.rb
+++ b/plugins/provisioners/chef/installer.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
           version: @version.to_s))
         @machine.guest.capability(:chef_install, @product, @version, @channel, @options)
 
-        if !@machine.guest.capability(:chef_installed, @version)
+        if !@machine.guest.capability(:chef_installed, @product, @version)
           raise Provisioner::Base::ChefError, :install_failed
         end
       end
@@ -40,7 +40,7 @@ module VagrantPlugins
       # option is given or if the guest does not have Chef installed at the
       # proper version.
       def should_install_chef?
-        @force || !@machine.guest.capability(:chef_installed, @version)
+        @force || !@machine.guest.capability(:chef_installed, @product, @version)
       end
     end
   end


### PR DESCRIPTION
### Overview
Currently if one sets `chef.product = 'chefdk'`, it gets successfully installed but then exits out with `Vagrant could not detect Chef on the guest! Even after Vagrant
attempted to install Chef, it could still not find Chef on the system.`

With this fix, chef runs

