### PR TITLE
#7084 - fixes-7084-notrunc-command-is-wrong-in-client.rb : corrected …

### DIFF
--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -128,7 +128,7 @@ module VagrantPlugins
           # recent versions use the full container ID
           # See https://github.com/dotcloud/docker/pull/2140 for more information
           return comm.test("#{docker_ps} | grep -wFq #{id}") ||
-            comm.test("#{docker_ps} -notrunc | grep -wFq #{id}")
+            comm.test("#{docker_ps} --no-trunc | grep -wFq #{id}")
         end
       end
 


### PR DESCRIPTION
### Overview
Fixes the misspelled command docker ps -notrunc which should be --no-trunc inside of plugins/provisioners/docker/client.rb

-Fixes #7084 
