### PR TITLE
#7074 - fixes does not allow provisioning when container name is specified

### DIFF
--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -126,9 +126,8 @@ module VagrantPlugins
         @machine.communicate.tap do |comm|
           # Docker < 0.7.0 stores container IDs using its short version while
           # recent versions use the full container ID
-          # See https://github.com/dotcloud/docker/pull/2140 for more information
-          return comm.test("#{docker_ps} | grep -wFq #{id}") ||
-            comm.test("#{docker_ps} --no-trunc | grep -wFq #{id}")
+          # using full container ID from now on.
+          return comm.test("#{docker_ps} --no-trunc | grep -wFq #{id}")
         end
       end
 


### PR DESCRIPTION
#7074 - Docker provisioner doesn't allow provisioning when container name is specified

We will be using the full container ID from now on since the Docker version is newer than 0.7.0

#7085 is partly fixing the grep issue with the -notrunc comand which was failing here.