### PR TITLE
hyperv differencing disk

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -18,11 +18,13 @@ module VagrantPlugins
           maxmemory = env[:machine].provider_config.maxmemory
           cpus = env[:machine].provider_config.cpus
           vmname = env[:machine].provider_config.vmname
+          differencing_disk = env[:machine].provider_config.differencing_disk
 
           env[:ui].output("Configured Dynamic memory allocation, maxmemory is #{maxmemory}") if maxmemory
           env[:ui].output("Configured startup memory is #{memory}") if memory
           env[:ui].output("Configured cpus number is #{cpus}") if cpus
           env[:ui].output("Configured vmname is #{vmname}") if vmname
+          env[:ui].output("Configured differencing disk instead of cloning") if differencing_disk
 
           if !vm_dir.directory? || !hd_dir.directory?
             raise Errors::BoxInvalid
@@ -95,7 +97,11 @@ module VagrantPlugins
           env[:ui].detail("Cloning virtual hard drive...")
           source_path = image_path.to_s
           dest_path   = env[:machine].data_dir.join("#{image_filename}#{image_ext}").to_s
-          FileUtils.cp(source_path, dest_path)
+          if differencing_disk
+            env[:machine].provider.driver.execute("clone_vhd.ps1", {Source: source_path, Destination: dest_path})
+          else
+            FileUtils.cp(source_path, dest_path)
+          end
           image_path = dest_path
 
           # We have to normalize the paths to be Windows paths since

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -3,7 +3,7 @@ require "vagrant"
 module VagrantPlugins
   module HyperV
     class Config < Vagrant.plugin("2", :config)
-      
+
       attr_accessor :ip_address_timeout # Time to wait for an IP address when booting, in seconds @return [Integer]
       attr_accessor :memory #  Memory size in mb @return [Integer]
       attr_accessor :maxmemory # Maximal memory size in mb enables dynamical memory allocation @return [Integer]
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :vmname # Name that will be shoen in Hyperv Manager @return [String]
       attr_accessor :vlan_id # VLAN ID for network interface for the virtual machine. @return [Integer]
       attr_accessor :mac # MAC address for network interface for the virtual machine. @return [String]
+      attr_accessor :differencing_disk # Create differencing disk instead of cloning whole VHD [Boolean]
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
@@ -20,6 +21,7 @@ module VagrantPlugins
         @vmname = UNSET_VALUE
         @vlan_id  = UNSET_VALUE
         @mac  = UNSET_VALUE
+        @differencing_disk = UNSET_VALUE
       end
 
       def finalize!
@@ -28,10 +30,11 @@ module VagrantPlugins
         end
         @memory = nil if @memory == UNSET_VALUE
         @maxmemory = nil if @maxmemory == UNSET_VALUE
-        @cpus = nil if @cpus == UNSET_VALUE 
+        @cpus = nil if @cpus == UNSET_VALUE
         @vmname = nil if @vmname == UNSET_VALUE
         @vlan_id = nil if @vlan_id == UNSET_VALUE
         @mac = nil if @mac == UNSET_VALUE
+        @differencing_disk = false if @differencing_disk == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/providers/hyperv/scripts/clone_vhd.ps1
+++ b/plugins/providers/hyperv/scripts/clone_vhd.ps1
@@ -1,0 +1,9 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$Source,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Destination
+)
+
+New-VHD -Path $Destination -ParentPath $Source -ErrorAction Stop

--- a/website/source/docs/hyperv/configuration.html.md
+++ b/website/source/docs/hyperv/configuration.html.md
@@ -28,3 +28,4 @@ you may set. A complete reference is shown below:
   * `ip_address_timeout` (integer) - The time in seconds to wait for the
     virtual machine to report an IP address. This defaults to 120 seconds.
     This may have to be increased if your VM takes longer to boot.
+  * `differencing_disk` (boolean) - Switch to use differencing disk intead of cloning whole VHD.


### PR DESCRIPTION
### Overview
Allow Hyper-V users use differencing disks instead of copying whole image each time to save space and time.

Creating differencing disk takes less than second and it does not matter how big is original disk

Added `differencing_disk` (Boolean) (optional, default is false) switch for hyperv.

Usage example:

```ruby
Vagrant.configure(2) do |config|
  config.vm.provider "hyperv"
  config.vm.box = "hashicorp/precise64"

  config.vm.provider :hyperv do |hv|
    hv.differencing_disk = true
  end
end
```


### References
- Fixes #7089
- References #7089

