### PR TITLE
Fixes bug report #7073 with RubyGems later than 2.4.6.

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -265,7 +265,7 @@ module Vagrant
 
       # Reset the all specs override that Bundler does
       old_all = Gem::Specification._all
-      Gem::Specification.all = nil
+      begin Gem::Specification.all = nil; rescue; end
 
       # /etc/gemrc and so on.
       old_config = nil


### PR DESCRIPTION
### Overview
RubyGems later than version 2.4.6 introduced a change which prevented Vagrant from functioning, due to `NilClass:#group_by` method missing.

### References
- Fixes GH-7073
- References rubygems/rubygems@044b0e2685e4b219b013f1067d670918a48c1f62