### PR TITLE
only specify Hyper-V generation if the parameter is supported

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -107,12 +107,16 @@ $secure_boot_enabled = (Select-Xml -xml $vmconfig -XPath "//secure_boot_enabled"
 
 $vm_params = @{
     Name = $vm_name
-    Generation = $generation
     NoVHD = $True
     MemoryStartupBytes = $MemoryStartupBytes
     SwitchName = $switchname
     BootDevice = $bootdevice
     ErrorAction = "Stop"
+}
+
+# Generation parameter was added in ps v4
+if((get-command New-VM).Parameters.Keys.Contains("generation")) {
+    $vm_params.Generation = $generation
 }
 
 # Create the VM using the values in the hash map


### PR DESCRIPTION
### Overview
The Hyper-V `New-VM` cmdlet on powershell version 3 (v8/2012) and lower do not support the `Generation` parameter. This detects if the parameter is supported and only specifies the generation if it is.

### References
- Fixes GH-7098
