### PR TITLE
HyperV: Reinstate compatibility with PowerShell 4

### DIFF
--- a/plugins/providers/hyperv/scripts/get_vm_status.ps1
+++ b/plugins/providers/hyperv/scripts/get_vm_status.ps1
@@ -7,12 +7,18 @@ Param(
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-# Get the VM with the given name
+
+if($PSVersionTable.PSVersion.Major -le 4) {
+  $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationOperationFailedException]
+} else {
+  $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationException]
+}
+
 try {
     $VM = Get-VM -Id $VmId -ErrorAction "Stop"
     $State = $VM.state
     $Status = $VM.status
-} catch [Microsoft.HyperV.PowerShell.VirtualizationException] {
+} catch $ExceptionType {
     $State = "not_created"
     $Status = $State
 }


### PR DESCRIPTION
### Overview
On `vagrant status` for HyperV users, we catch an exception to determine the status of the machine.  This changed in order to support Windows 10, but this broke compatibility with powershell 4. This PR makes the exception we're looking for conditional on PS version.

### References
A comment on https://github.com/mitchellh/vagrant/commit/587c88e65ae294c4f2939937c2079c545efd17cb shows that this commit broke back-compat with PowerShell 4.  