### PR TITLE
Add snapshot support to Hyper-V provider

### DIFF
--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -207,6 +207,58 @@ module VagrantPlugins
         end
       end
 
+      def self.action_snapshot_delete
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t("vagrant_hyperv.message_not_created")
+              next
+            end
+
+            b2.use SnapshotDelete
+
+          end
+        end
+      end
+
+      def self.action_snapshot_restore
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t("vagrant_hyperv.message_not_created")
+              next
+            end
+
+            b2.use action_halt
+            b2.use SnapshotRestore
+
+            b2.use Call, IsEnvSet, :snapshot_delete do |env2, b3|
+              if env2[:result]
+                b3.use action_snapshot_delete
+              end
+            end
+
+            b2.use action_start
+
+          end
+        end
+      end
+
+      def self.action_snapshot_save
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t("vagrant_hyperv.message_not_created")
+              next
+            end
+            b2.use SnapshotSave
+          end
+        end
+      end
+
       # The autoload farm
       action_root = Pathname.new(File.expand_path("../action", __FILE__))
       autoload :CheckEnabled, action_root.join("check_enabled")
@@ -222,6 +274,9 @@ module VagrantPlugins
       autoload :NetSetVLan, action_root.join("net_set_vlan")
       autoload :NetSetMac, action_root.join("net_set_mac")
       autoload :MessageWillNotDestroy, action_root.join("message_will_not_destroy")
+      autoload :SnapshotDelete, action_root.join("snapshot_delete")
+      autoload :SnapshotRestore, action_root.join("snapshot_restore")
+      autoload :SnapshotSave, action_root.join("snapshot_save")
     end
   end
 end

--- a/plugins/providers/hyperv/action/snapshot_delete.rb
+++ b/plugins/providers/hyperv/action/snapshot_delete.rb
@@ -1,0 +1,27 @@
+module VagrantPlugins
+  module HyperV
+    module Action
+      class SnapshotDelete
+        def initialize(app, env)
+          @app    = app
+        end
+
+        def call(env)
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.deleting",
+            name: env[:snapshot_name]))
+
+          env[:machine].provider.driver.delete_snapshot(env[:snapshot_name])
+
+          env[:ui].success(I18n.t(
+            "vagrant.actions.vm.snapshot.deleted",
+            name: env[:snapshot_name]))
+
+          @app.call(env)
+
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/action/snapshot_restore.rb
+++ b/plugins/providers/hyperv/action/snapshot_restore.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module HyperV
+    module Action
+      class SnapshotRestore
+        def initialize(app, env)
+          @app    = app
+        end
+
+        def call(env)
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.restoring",
+            name: env[:snapshot_name]))
+
+          env[:machine].provider.driver.restore_snapshot(env[:snapshot_name])
+
+          @app.call(env)
+
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/action/snapshot_save.rb
+++ b/plugins/providers/hyperv/action/snapshot_save.rb
@@ -1,0 +1,27 @@
+module VagrantPlugins
+  module HyperV
+    module Action
+      class SnapshotSave
+        def initialize(app, env)
+          @app    = app
+        end
+
+        def call(env)
+
+          env[:ui].info(I18n.t(
+            "vagrant.actions.vm.snapshot.saving",
+            name: env[:snapshot_name]))
+
+          env[:machine].provider.driver.create_snapshot(env[:snapshot_name])
+
+          env[:ui].success(I18n.t(
+            "vagrant.actions.vm.snapshot.saved",
+            name: env[:snapshot_name]))
+
+          @app.call(env)
+
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/cap/snapshot_list.rb
+++ b/plugins/providers/hyperv/cap/snapshot_list.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module HyperV
+    module Cap
+      module SnapshotList
+        def self.snapshot_list(machine)
+          machine.provider.driver.list_snapshots
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -84,7 +84,24 @@ module VagrantPlugins
        def net_set_mac(mac_addr)
           execute("set_network_mac.ps1", { VmId: vm_id, Mac: mac_addr })
        end
-       
+
+       def create_snapshot(snapshot_name)
+          execute("create_snapshot.ps1", { VmId: vm_id, SnapName: (snapshot_name) } )
+       end
+
+       def restore_snapshot(snapshot_name)
+          execute("restore_snapshot.ps1", { VmId: vm_id,  SnapName: (snapshot_name) } )
+       end
+
+       def list_snapshots()
+          snaps = execute("list_snapshots.ps1", { VmID: vm_id } )
+          snaps.map { |s| s['Name'] }
+       end
+
+       def delete_snapshot(snapshot_name)
+          execute("delete_snapshot.ps1", {VmID: vm_id, SnapName: snapshot_name})
+       end
+
       protected
 
       def execute_powershell(path, options, &block)

--- a/plugins/providers/hyperv/plugin.rb
+++ b/plugins/providers/hyperv/plugin.rb
@@ -27,6 +27,11 @@ module VagrantPlugins
         Cap::PublicAddress
       end
 
+      provider_capability("hyperv", "snapshot_list") do
+        require_relative "cap/snapshot_list"
+        Cap::SnapshotList
+      end
+
       protected
 
       def self.init!

--- a/plugins/providers/hyperv/scripts/create_snapshot.ps1
+++ b/plugins/providers/hyperv/scripts/create_snapshot.ps1
@@ -1,0 +1,8 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$VmId,
+    [string]$SnapName
+)
+
+$VM = Get-VM -Id $VmId -ErrorAction "Stop"
+Checkpoint-VM $VM -SnapshotName $SnapName 

--- a/plugins/providers/hyperv/scripts/delete_snapshot.ps1
+++ b/plugins/providers/hyperv/scripts/delete_snapshot.ps1
@@ -1,0 +1,8 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$VmId,
+    [string]$SnapName
+)
+
+$VM = Get-VM -Id $VmId -ErrorAction "Stop"
+Remove-VMSnapshot $VM -Name $SnapName 

--- a/plugins/providers/hyperv/scripts/list_snapshots.ps1
+++ b/plugins/providers/hyperv/scripts/list_snapshots.ps1
@@ -1,0 +1,12 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$VmId
+)
+
+$VM = Get-VM -Id $VmId -ErrorAction "Stop"
+$Snapshots = @(Get-VMSnapshot $VM | Select-Object Name)
+$result = ConvertTo-json $Snapshots
+
+Write-Host "===Begin-Output==="
+Write-Host $result
+Write-Host "===End-Output==="

--- a/plugins/providers/hyperv/scripts/restore_snapshot.ps1
+++ b/plugins/providers/hyperv/scripts/restore_snapshot.ps1
@@ -1,0 +1,8 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$VmId,
+    [string]$SnapName
+)
+
+$VM = Get-VM -Id $VmId -ErrorAction "Stop"
+Restore-VMSnapshot $VM -Name $SnapName -Confirm:$false

--- a/website/source/docs/hyperv/limitations.html.md
+++ b/website/source/docs/hyperv/limitations.html.md
@@ -33,3 +33,11 @@ a host only network.
 Vagrant does not implement the `vagrant package` command for Hyper-V
 yet, though this should be fairly straightforward to add in a Vagrant
 release in the near future.
+
+## Snapshots
+
+Restoring snapshot VMs using `vagrant snapshot pop` or 
+`vagrant snapshot restore` will sometimes raise errors when mounting
+SMB shared folders, however these mounts will still work inside the guest.
+
+


### PR DESCRIPTION
### Overview
This PR is a port of the Hyper-V snapshot support from https://github.com/scalefactory/vagrant-multiprovider-snap into Vagrant core.  It supports all of the snapshot behaviour supplied by the Virtualbox and VMWare providers.

### Known Bugs
Restored VMs using SMB shared folders may error as they boot, during the mounting of those shared folders, though in the cases I've observed, the pre-snapshot mounts are still functional inside the guest.  

Presumably this is down to the filesystem and network state in the guest taking a trip back in time, but the host not going along for the ride.

I believe this to be bug-compatible with the other providers, and with my original implementation, but this may be a concern here since the default folder sharing mechanism on Hyper-V hosts is SMB.

### References
- Fixes GH-7109

