### PR TITLE
Restart network after reconfiguration

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
 
             machine.communicate.upload(temp.path, "/tmp/vagrant_network")
             machine.communicate.sudo("mv /tmp/vagrant_network /etc/netctl/#{network[:device]}")
-            machine.communicate.sudo("ip link set #{network[:device]} down && netctl start #{network[:device]} && netctl enable #{network[:device]}")
+            machine.communicate.sudo("ip link set #{network[:device]} down && netctl restart #{network[:device]} && netctl enable #{network[:device]}")
           end
         end
       end


### PR DESCRIPTION
### Overview
Restart network device on arch linux after reconfiguration (and to ensure that the device is actually up).

### References
- Fixes GH-7119
- References GH-5737
