### PR TITLE
website: add a page to send folks to get to a signup link for atlas

### DIFF
--- a/website/source/docs/boxes/base.html.md
+++ b/website/source/docs/boxes/base.html.md
@@ -67,7 +67,7 @@ Provider-specific guides are linked below:
 
 We strongly recommend using [Packer](https://www.packer.io) to create reproducible
 builds for your base boxes, as well as automating the builds with
-[Atlas](https://atlas.hashicorp.com). Read more about
+[Atlas](/docs/other/atlas.html). Read more about
 [Creating Vagrant Boxes with Packer](https://atlas.hashicorp.com/help/packer/artifacts/creating-vagrant-boxes)
 in the Atlas documentation.
 
@@ -262,7 +262,7 @@ provider-specific guides are linked to towards the top of this page.
 You can distribute the box file however you would like. However, if you want
 to support versioning, putting multiple providers at a single URL, pushing
 updates, analytics, and more, we recommend you add the box to
-[HashiCorp's Atlas](https://atlas.hashicorp.com).
+[HashiCorp's Atlas](/docs/other/atlas.html).
 
 You can upload both public and private boxes to this service.
 

--- a/website/source/docs/boxes/format.html.md
+++ b/website/source/docs/boxes/format.html.md
@@ -27,7 +27,7 @@ Today, there are two different components:
   box file and so on.
 
 * Box Catalog Metadata - This is a JSON document (typically exchanged
-  during interactions with [HashiCorp's Atlas](https://atlas.hashicorp.com))
+  during interactions with [HashiCorp's Atlas](/docs/other/atlas.html))
   that specifies the name of the box, a description, available
   versions, available providers, and URLs to the actual box files
   (next component) for each provider and version. If this catalog

--- a/website/source/docs/boxes/format.html.md
+++ b/website/source/docs/boxes/format.html.md
@@ -82,7 +82,7 @@ providers from a single file, and more.
 
 <div class="alert alert-block alert-info">
   <strong>You do not need to manually make the metadata.</strong> If you
-  have an account with <a href="https://atlas.hashicorp.com">HashiCorp's Atlas</a>, you
+  have an account with <a href="/docs/other/atlas.html">HashiCorp's Atlas</a>, you
   can create boxes there, and HashiCorp's Atlas automatically creates
   the metadata for you. The format is still documented here.
 </div>

--- a/website/source/docs/boxes/versioning.html.md
+++ b/website/source/docs/boxes/versioning.html.md
@@ -30,7 +30,7 @@ to update your own custom boxes with versions. That is covered in
 
 `vagrant box list` only shows _installed_ versions of boxes. If you want
 to see all available versions of a box, you will have to find the box
-on [HashiCorp's Atlas](https://atlas.hashicorp.com). An easy way to find a box
+on [HashiCorp's Atlas](/docs/other/atlas.html). An easy way to find a box
 is to use the url `https://atlas.hashicorp.com/$USER/$BOX`. For example, for
 the `hashicorp/precise64` box, you can find information about it at
 `https://atlas.hashicorp.com/hashicorp/precise64`.

--- a/website/source/docs/cli/login.html.md
+++ b/website/source/docs/cli/login.html.md
@@ -12,7 +12,7 @@ description: |-
 **Command: `vagrant login`**
 
 The login command is used to authenticate with the
-[HashiCorp's Atlas](https://atlas.hashicorp.com) server. Logging is only
+[HashiCorp's Atlas](/docs/other/atlas.html) server. Logging is only
 necessary if you are accessing protected boxes or using
 [Vagrant Share](/docs/share/).
 

--- a/website/source/docs/getting-started/share.html.md
+++ b/website/source/docs/getting-started/share.html.md
@@ -26,7 +26,7 @@ connected to the Internet.
 ## Login to HashiCorp's Atlas
 
 Before being able to share your Vagrant environment, you will need an account on
-[HashiCorp's Atlas](https://atlas.hashicorp.com). Do not worry, it is free.
+[HashiCorp's Atlas](/docs/other/atlas.html). Do not worry, it is free.
 
 Once you have an account, log in using `vagrant login`:
 

--- a/website/source/docs/other/atlas.html.md
+++ b/website/source/docs/other/atlas.html.md
@@ -1,0 +1,23 @@
+---
+layout: "docs"
+page_title: "Atlas and Vagrant"
+sidebar_current: "other-atlas"
+description: |-
+  A brief description of how to use, sign up for and access the
+  Vagrant features in Atlas.
+---
+
+# Atlas and Vagrant
+
+Atlas is the HashiCorp Suite for the Enterprise,
+but also provides features for the community. It hosts
+a <a href="https://atlas.hashicorp.com/boxes/search">public registry of Vagrant boxes</a>
+as well as powers the Vagrant share features.
+
+Vagrant Enteprise is provided via Atlas and allows
+for private boxes to be hosted and distributed to
+your team.
+
+## Signing up for Atlas
+
+You can signup for a free Atlas account <a href="https://atlas.hashicorp.com/account/new">here</a>.

--- a/website/source/docs/other/atlas.html.md
+++ b/website/source/docs/other/atlas.html.md
@@ -14,7 +14,7 @@ but also provides features for the community. It hosts
 a <a href="https://atlas.hashicorp.com/boxes/search">public registry of Vagrant boxes</a>
 as well as powers the Vagrant share features.
 
-Vagrant Enteprise is provided via Atlas and allows
+Vagrant Enterprise is provided via Atlas and allows
 for private boxes to be hosted and distributed to
 your team.
 

--- a/website/source/docs/other/index.html.md
+++ b/website/source/docs/other/index.html.md
@@ -12,5 +12,6 @@ description: |-
 This section covers other information that does not quite fit under the
 other categories.
 
+- [Atlas](/docs/other/atlas.html)
 - [Debugging](/docs/other/debugging.html)
 - [Environment Variables](/docs/other/environmental-variables.html)

--- a/website/source/docs/push/atlas.html.md
+++ b/website/source/docs/push/atlas.html.md
@@ -65,4 +65,4 @@ And then push the application to Atlas:
 $ vagrant push
 ```
 
-[Atlas]: https://atlas.hashicorp.com/  "HashiCorp's Atlas Service"
+[Atlas]: /docs/other/atlas.html "HashiCorp's Atlas Service"

--- a/website/source/docs/share/index.html.md
+++ b/website/source/docs/share/index.html.md
@@ -39,4 +39,4 @@ to the left. We also have a section where we go into detail about the
 security implications of this feature.
 
 Vagrant Share requires an account with
-[HashiCorp's Atlas](https://atlas.hashicorp.com) to be used.
+[HashiCorp's Atlas](/docs/other/atlas.html) to be used.

--- a/website/source/docs/vagrantfile/machine_settings.html.md
+++ b/website/source/docs/vagrantfile/machine_settings.html.md
@@ -24,7 +24,7 @@ for the machine to boot and be accessible. By default this is 300 seconds.
 `config.vm.box` - This configures what [box](/docs/boxes.html) the
 machine will be brought up against. The value here should be the name
 of an installed box or a shorthand name of a box in
-[HashiCorp's Atlas](https://atlas.hashicorp.com).
+[HashiCorp's Atlas](/docs/other/atlas.html).
 
 This option requires Vagrant 1.5 or higher. You can download the latest version
 of Vagrant from the [Vagrant installers page](/downloads.html).
@@ -35,7 +35,7 @@ of Vagrant from the [Vagrant installers page](/downloads.html).
 the configured box on every `vagrant up`. If an update is found, Vagrant
 will tell the user. By default this is true. Updates will only be checked
 for boxes that properly support updates (boxes from
-[HashiCorp's Atlas](https://atlas.hashicorp.com)
+[HashiCorp's Atlas](/docs/other/atlas.html)
 or some other versioned box).
 
 <hr>
@@ -88,7 +88,7 @@ all subsequent redirects. By default, redirect locations are untrusted so creden
 <hr>
 
 `config.vm.box_url` - The URL that the configured box can be found at.
-If `config.vm.box` is a shorthand to a box in [HashiCorp's Atlas](https://atlas.hashicorp.com)
+If `config.vm.box` is a shorthand to a box in [HashiCorp's Atlas](/docs/other/atlas.html)
 then this value does not need to be specified. Otherwise, it should
 point to the proper place where the box can be found if it is not
 installed.


### PR DESCRIPTION
This adds a page to describe Atlas as Atlas no longer has an easy to understand homepage.