### PR TITLE
Fixed linked clone failure when master VM is missing

### DIFF
--- a/plugins/providers/virtualbox/action/import_master.rb
+++ b/plugins/providers/virtualbox/action/import_master.rb
@@ -51,6 +51,8 @@ module VagrantPlugins
               "Master VM for '#{env[:machine].box.name}' already exists " +
               " (id=#{env[:clone_id]}) - skipping import step.")
             return
+          else
+            env.delete(:clone_id)
           end
 
           env[:ui].info(I18n.t("vagrant.actions.vm.clone.setup_master"))


### PR DESCRIPTION
### Overview
When using linked_clones, If the master VM is manually removed from VirtualBox a user will get a Box with UUID xxx-xxx-xxx Not Found error when trying to run `vagrant up` on a new machine.

This is because the master_id file exists `action/import_master.rb` sets ` env[:clone_id] = master_id_file.read.chomp if master_id_file.file?`

The `action/import.rb` code assumes if `env[:clone_id]` is set then it does not need to import the box, it can just clone it.  This is not true when the master VM has manually been removed.

The `action/import_master.rb` code  seemed to be setup to handle this situation with a nice `if` statement.  All the if statement did though was log a message.
```
          if env[:clone_id] && env[:machine].provider.driver.vm_exists?(env[:clone_id])
            @logger.info(
              "Master VM for '#{env[:machine].box.name}' already exists " +
              " (id=#{env[:clone_id]}) - skipping import step.")
            return
          end
```

This pull request just adds an `else` to this `if` statement to remove the `env[:clone_id]` setting so that when `action/import.rb` is called it knows it needs to first import the master, then clone.

Fixes #6742 
