### PR TITLE
Pass through retcode of masterless Salt provisioner

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -322,7 +322,7 @@ module VagrantPlugins
 
       def call_masterless
         @machine.env.ui.info "Calling state.highstate in local mode... (this may take a while)"
-        cmd = "salt-call state.highstate --local#{get_loglevel}#{get_colorize}#{get_pillar}"
+        cmd = "salt-call state.highstate --retcode-passthrough --local#{get_loglevel}#{get_colorize}#{get_pillar}"
         if @config.minion_id
           cmd += " --id #{@config.minion_id}"
         end


### PR DESCRIPTION
### Overview
Pass through the return status of the Salt provisioner when run in masterless mode.

### References
- References GH-4304

The other calls to state.highstate all had this option added by commit
1cc78dc224677b9f2bf3a273199b53258722852e, but the masterless option
did not yet exist.