### PR TITLE
Authenticate metadata box urls

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -253,7 +253,7 @@ module Vagrant
           end
 
           provider_url = metadata_provider.url
-          if url != authenticated_url
+          if provider_url != authenticated_url
             # Authenticate the provider URL since we're using auth
             hook_env    = env[:hook].call(:authenticate_box_url, box_urls: [provider_url])
             authed_urls = hook_env[:box_urls]
@@ -261,7 +261,7 @@ module Vagrant
               raise "Bad box authentication hook, did not generate proper results."
             end
             provider_url = authed_urls[0]
-          end
+        end
 
           box_add(
             [[provider_url, metadata_provider.url]],


### PR DESCRIPTION
I'm going to do some more testing on this, but this should fix the issue where private boxes can be downloaded, but not updated. We previously were not adding the access token to the private box URLs during update, only during adding. This fixes that.

- Fixes #6776 

/cc @mitchellh @phinze @kikitux 