### PR TITLE
Remove sysvinit else clauses in NFS for Arch Linux

### DIFF
--- a/plugins/hosts/arch/cap/nfs.rb
+++ b/plugins/hosts/arch/cap/nfs.rb
@@ -3,31 +3,17 @@ module VagrantPlugins
     module Cap
       class NFS
         def self.nfs_check_command(env)
-          if systemd?
             return "/usr/sbin/systemctl status nfs-server.service"
-          else
-            return "/etc/rc.d/nfs-server status"
           end
         end
 
         def self.nfs_start_command(env)
-          if systemd?
             return "/usr/sbin/systemctl start nfs-server.service"
-          else
-            return "sh -c 'for s in {rpcbind,nfs-common,nfs-server}; do /etc/rc.d/$s start; done'"
           end
         end
 
         def self.nfs_installed(environment)
-          Kernel.system("grep -Fq nfs /proc/filesystems")
-        end
-
-        protected
-
-        # This tests to see if systemd is used on the system. This is used
-        # in newer versions of Arch, and requires a change in behavior.
-        def self.systemd?
-          `ps -o comm= 1`.chomp == 'systemd'
+          Kernel.system("grep -Fq nfsd /proc/filesystems")
         end
       end
     end


### PR DESCRIPTION
Currently the code tries to detect if Arch uses systemd via checking
comm= of PID 1. As access to proc filesystem might be restricted due to
hideproc set and systemd is default for all Arch Linux installations
since October 2012, let's just ditch that check.