### PR TITLE
Ansible parallel race

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -109,6 +109,7 @@ module Vagrant
       @provider_options = provider_options
       @ui              = Vagrant::UI::Prefixed.new(@env.ui, @name)
       @ui_mutex        = Mutex.new
+      @state_mutex     = Mutex.new
 
       # Read the ID, which is usually in local storage
       @id = nil
@@ -505,11 +506,17 @@ module Vagrant
       # master index.
       uuid = index_uuid
       if uuid
-        entry = @env.machine_index.get(uuid)
-        if entry
-          entry.state = result.short_description
-          @env.machine_index.set(entry)
-          @env.machine_index.release(entry)
+        # active_machines provides access to query this info on each machine
+        # from a different thread, ensure multiple machines do not access
+        # the locked entry simultaneously as this triggers a locked machine
+        # exception.
+        @state_mutex.synchronize do
+          entry = @env.machine_index.get(uuid)
+          if entry
+            entry.state = result.short_description
+            @env.machine_index.set(entry)
+            @env.machine_index.release(entry)
+          end
         end
       end
 

--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -132,8 +132,15 @@ module VagrantPlugins
           inventory_file = Pathname.new(File.join(inventory_path, 'vagrant_ansible_inventory'))
           @@lock.synchronize do
             if !File.exists?(inventory_file) or inventory_content != File.read(inventory_file)
-              inventory_file.open('w') do |file|
-                file.write(inventory_content)
+              begin
+                # ansible dir inventory will ignore files starting with '.'
+                inventory_tmpfile = Tempfile.new('.vagrant_ansible_inventory', inventory_path)
+                inventory_tmpfile.write(inventory_content)
+                inventory_tmpfile.close
+                File.rename(inventory_tmpfile.path, inventory_file)
+              ensure
+                inventory_tmpfile.close
+                inventory_tmpfile.unlink
               end
             end
           end


### PR DESCRIPTION
Combined, these two changes should reduce the number of race issues when bringing up multiple machines in parallel and using the ansible provisioner to configure each guest.

The state lock is required any time active_machines is used and anything that can trigger a state check on the other machines occurs. Currently the machine index assumes that it will only be updated by itself, however if you skip syncing of the current directory to the machine, it's possible to get to the ansible provisioner checking all the other machines for ssh_info while they are in the process of changing state, which will trigger a Locked Machine exception.

The use of a temp file to write out the inventory and then replace should ensure that if the contents have changed that ansible will only ever see the old or new contents, and never the truncated file contents that is caused by opening with the 'w' mode.

Ansible ignores files starting with '.' since version 1.2, so using the same directory to ensure we are on filesystem to use rename instead of a move should be safe. Anyone using ansible < 1.2 should really upgrade.

These should fix #6526 for most use cases where the provisioner is only running against the current machine. Handling the provisioner configured to run against all other machines using parallel up without random failures due to some machines still coming up, will require some form of waiting till all running machines are ready.

This has mostly been developed against the vagrant-libvirt provider, which triggers this due to needing to wait to get the SSH information from the machine after it has booted.