### PR TITLE
Fix Subprocess problem with closure of stdin by caller

### DIFF
--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -146,7 +146,7 @@ module Vagrant
 
         @logger.debug("Selecting on IO")
         while true
-          writers = notify_stdin ? [process.io.stdin] : []
+          writers = notify_stdin && !process.io.stdin.closed? ? [process.io.stdin] : []
           results = ::IO.select([stdout, stderr], writers, nil, 0.1)
           results ||= []
           readers = results[0]


### PR DESCRIPTION
Hello,

I've been writing a plugin or two for Vagrant and encountered an issue with the Subprocess utility. If you call it with a block and request notification of stdin, that's great so you can feed in data as and when it's ready for it. However, if you then close the stdin because you've finished sending data (which you have to or it will busy loop your block) you get the following exception and it crashes:

    E, [2016-03-31T19:52:09.690798 #24234] ERROR -- : exception while processing events: closed stream

This PR fixes the issue by only scheduling stdin for IO::Select if it's requested AND if it's open.