### PR TITLE
Fixes 7073 specification.rb undefined method group by for nilclass

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -265,7 +265,7 @@ module Vagrant
 
       # Reset the all specs override that Bundler does
       old_all = Gem::Specification._all
-      Gem::Specification.all = nil
+      Gem::Specification.reset
 
       # /etc/gemrc and so on.
       old_config = nil


### PR DESCRIPTION
Adding PR for #7073 - As discussed in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818237 and suggested by @babilen ... 

 my bundle exec rake tests are failing locally however I am adding this as a PR to have the Travis CI tests run to make sure whether everything is fine or not. Feel free to close it or merge it depending on the output of the tests.

