### PR TITLE
fix path in OSX vagrant uninstallation steps

### DIFF
--- a/website/source/docs/installation/uninstallation.html.md
+++ b/website/source/docs/installation/uninstallation.html.md
@@ -29,7 +29,7 @@ On **Mac OS X**:
 
 ```sh
 rm -rf /Applications/Vagrant
-rm -f /usr/bin/vagrant
+rm -f /usr/local/bin/vagrant
 sudo pkgutil --forget com.vagrant.vagrant
 ```
 


### PR DESCRIPTION
Uninstall steps refer to `/usr/bin/vagrant` rather than `/usr/local/bin/vagrant`.

Fixes #7205

Do we need to include both potential paths to support removal of old versions?