### PR TITLE
Salt: move masterless config to apply to all platforms

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -320,43 +320,38 @@ module VagrantPlugins
         end
       end
 
-      def call_masterless
-        @machine.env.ui.info "Calling state.highstate in local mode... (this may take a while)"
-        cmd = "salt-call state.highstate --local#{get_loglevel}#{get_colorize}#{get_pillar}"
-        if @config.minion_id
-          cmd += " --id #{@config.minion_id}"
-        end
-        @machine.communicate.sudo(cmd) do |type, data|
-          if @config.verbose
-            @machine.env.ui.info(data)
-          end
-        end
-      end
-
       def call_highstate
-        if @config.masterless
-          call_masterless
-        elsif @config.run_highstate
+        if @config.run_highstate
+          local=""
+          if @config.masterless
+            local=" --local"
+          end
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
-            @machine.communicate.sudo("salt '*' saltutil.sync_all")
-            @machine.communicate.sudo("salt '*' state.highstate --verbose#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
-              if @config.verbose
-                @machine.env.ui.info(data.rstrip)
-              end
+            unless @config.masterless?
+              @machine.communicate.sudo("salt '*' saltutil.sync_all")
             end
+            @machine.communicate.sudo("salt '*' state.highstate --verbose #{local}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+            if @config.verbose
+                @machine.env.ui.info(data.rstrip)
+            end
+          end
           else
             if @machine.config.vm.communicator == :winrm
               opts = { elevated: true }
-              @machine.communicate.execute("C:\\salt\\salt-call.bat saltutil.sync_all", opts)
-              @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate --retcode-passthrough #{get_loglevel}#{get_colorize}#{get_pillar}", opts) do |type, data|
+              unless @config.masterless?
+                @machine.communicate.execute("C:\\salt\\salt-call.bat saltutil.sync_all", opts)
+              end
+              @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate --retcode-passthrough #{local}#{get_loglevel}#{get_colorize}#{get_pillar}", opts) do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end
               end
             else
-              @machine.communicate.sudo("salt-call saltutil.sync_all")
-              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough #{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+              unless @config.masterless?
+                @machine.communicate.sudo("salt-call saltutil.sync_all")
+              end
+              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough #{local}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end


### PR DESCRIPTION
This makes the masterless config setting more integrated with the other highstate logic by making it control a string (--local) instead of a separate code block.  In doing so, it also avoids the masterless section overriding the highstate setting.

This was essential for fixing masterless configurations on Windows, because the separate code block for masterless config did not include Windows logic.

Closes #6924
Fixes #6915

If you can point me to tests, I'm happy to try to work some in with this PR.  I have to warn you, though, I'm a Python-head, and not very good with Ruby.