### PR TITLE
Plugin install do not highlight the fact we can refer to a gem file stored locally

### DIFF
--- a/website/source/docs/cli/plugin.html.md
+++ b/website/source/docs/cli/plugin.html.md
@@ -62,6 +62,19 @@ This command accepts optional command-line flags:
   to a more complex constraint by comma-separating multiple constraints:
   "> 1.0.2, < 1.1.0" (do not forget to quote these on the command-line).
 
+## Behind corporate firewalls
+
+### Offline package install
+
+Installing is done the same way, but can refer to a Gem file downloaded
+from [RubyGems.org](https://rubygems.org/) in a folder (e.g. `C:\somewhere`)
+
+In the folder, from the command prompt, execute the command:
+
+```
+C:\somewhere> vagrant plugin install vagrant-vbguest-0.10.0.gem
+```
+
 # Plugin License
 
 **Command: `vagrant plugin license <name> <license-file>`**


### PR DESCRIPTION
In some case, we may want to use Vagrant in networks that aren’t connected to the Internet.

This snippet shows how we can achieve this.

If it wasn’t for this [Stack Overflow response][superuser], I would still be working with this.

   [superuser]: https://superuser.com/questions/801745/cant-vagrant-install-a-plugin-gem-dependency-fails-despite-being-installed/899414#answer-899414