### PR TITLE
Fix issues with virtual interfaces

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
           end
 
           if virtual
-            machine.communicate.sudo("ls -v /sys/class/net | egrep -v lo\\|docker") do |_, result|
+            machine.communicate.sudo("find -L /sys/class/net -xtype l -name device -maxdepth 2 2> /dev/null | awk -F/ '{print \$5}'") do |_, result|
               interface_names = result.split("\n")
             end
 


### PR DESCRIPTION
This change fix this issue https://github.com/openshift/openshift-ansible/issues/1341

After provisioning vagrant configure private_network on interface eth0 instead eth1 because there are br0 in result of ls /sys/class/net | egrep -v lo\|docker