### PR TITLE
fixes #2270, support env variables in puppet apply run

### DIFF
--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -13,6 +13,7 @@ module VagrantPlugins
         attr_accessor :manifests_path
         attr_accessor :environment
         attr_accessor :environment_path
+        attr_accessor :environment_variables
         attr_accessor :module_path
         attr_accessor :options
         attr_accessor :synced_folder_type
@@ -23,18 +24,19 @@ module VagrantPlugins
         def initialize
           super
 
-          @binary_path        = UNSET_VALUE
-          @hiera_config_path  = UNSET_VALUE
-          @manifest_file      = UNSET_VALUE
-          @manifests_path     = UNSET_VALUE
-          @environment        = UNSET_VALUE
-          @environment_path   = UNSET_VALUE
-          @module_path        = UNSET_VALUE
-          @options            = []
-          @facter             = {}
-          @synced_folder_type = UNSET_VALUE
-          @temp_dir           = UNSET_VALUE
-          @working_directory  = UNSET_VALUE
+          @binary_path           = UNSET_VALUE
+          @hiera_config_path     = UNSET_VALUE
+          @manifest_file         = UNSET_VALUE
+          @manifests_path        = UNSET_VALUE
+          @environment           = UNSET_VALUE
+          @environment_path      = UNSET_VALUE
+          @environment_variables = UNSET_VALUE
+          @module_path           = UNSET_VALUE
+          @options               = []
+          @facter                = {}
+          @synced_folder_type    = UNSET_VALUE
+          @temp_dir              = UNSET_VALUE
+          @working_directory     = UNSET_VALUE
         end
 
         def nfs=(value)
@@ -84,6 +86,9 @@ module VagrantPlugins
             end
             if @manifest_file == UNSET_VALUE
               @manifest_file = nil
+            end
+            if @environment_variables == UNSET_VALUE
+              @environment_variables = nil
             end
           end
 

--- a/website/source/docs/provisioning/puppet_apply.html.md
+++ b/website/source/docs/provisioning/puppet_apply.html.md
@@ -52,6 +52,9 @@ available below this section.
 * `environment_path` (string) - Path to the directory that contains environment
   files on the host disk.
 
+* `environment_variables` (hash) - A hash of data to be set as environment
+  variables before the puppet apply run.
+
 * `options` (array of strings) - Additionally options to pass to the
   Puppet executable when running Puppet.
 


### PR DESCRIPTION
replaces PR #6688


for a config of:

```
   config.vm.provision :puppet do |puppet|
     puppet.environment_variables = { 'FOO' => 'BAR' }
   end

```

it provides 'FOO' in the same execution context as the puppet apply run:

```
\>VAGRANT_LOG=info bundle exec vagrant provision 2>&1 | grep 'puppet apply'
 INFO ssh: Execute: FOO='BAR'   puppet apply --color=false
 --detailed-exitcodes --manifestdir
 /tmp/vagrant-puppet/manifests-a11d1078b1b1f2e3bdea27312f6ba513
 /tmp/vagrant-puppet/manifests-a11d1078b1b1f2e3bdea27312f6ba513/default.pp
```

this should fix #2270