### PR TITLE
compatibility fix for ubuntu/debian dash shell

### DIFF
--- a/plugins/guests/linux/cap/mount_nfs.rb
+++ b/plugins/guests/linux/cap/mount_nfs.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
 
             # Emit an upstart event if we can
             machine.communicate.sudo <<-SCRIPT
-if command -v /sbin/init &>/dev/null && /sbin/init --version | grep upstart &>/dev/null; then
+if command -v /sbin/init &>/dev/null && /sbin/init --version | grep -q upstart; then
   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT='#{expanded_guest_path}'
 fi
 SCRIPT

--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -94,7 +94,7 @@ SCRIPT
 
           # Emit an upstart event if we can
           machine.communicate.sudo <<-SCRIPT
-if command -v /sbin/init &>/dev/null && /sbin/init --version | grep upstart &>/dev/null; then
+if command -v /sbin/init &>/dev/null && /sbin/init --version | grep -q upstart; then
   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT='#{expanded_guest_path}'
 fi
 SCRIPT

--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -81,7 +81,7 @@ module VagrantPlugins
 
           # Emit an upstart event if we can
           machine.communicate.sudo <<-SCRIPT
-if command -v /sbin/init &>/dev/null && /sbin/init --version | grep upstart &>/dev/null; then
+if command -v /sbin/init &>/dev/null && /sbin/init --version | grep -q upstart; then
   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT='#{expanded_guest_path}'
 fi
 SCRIPT


### PR DESCRIPTION
Deploying Ubuntu 16.04 failed due to a script which doesn't work in Ubuntu sh, which is dash instead of bash.

```
Output:
==> ubuntu1604: Mounting shared folders...
    ubuntu1604: /vagrant => /home/brad/git/githome/mypacker
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

if command -v /sbin/init &>/dev/null && /sbin/init --version | grep upstart &>/dev/null; then
  /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT='/vagrant'
fi


Stdout from the command:

/sbin/init


Stderr from the command:

sh: 3: /sbin/initctl: not found
/sbin/init: unrecognized option '--version'
```
The code block works fine when I ssh in and run it under bash, but I noticed it didn't work with sh.  Sh is linked to dash instead of bash,  it ran the contained code despite failing the condition.  A shorter example of dash behavior:

$ sh -c '(echo one | grep two && echo ok)'
$ sh -c '(echo one | grep two &>/dev/null && echo ok)'
ok

So i removed the &>/dev/null and changed it to -q.  I successfully ran 14.04 and 16.04 with this.