### PR TITLE
Do not let NFS systemctl status use a pager

### DIFF
--- a/contrib/sudoers/linux-fedora
+++ b/contrib/sudoers/linux-fedora
@@ -1,5 +1,5 @@
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
-Cmnd_Alias VAGRANT_NFSD_CHECK = /usr/bin/systemctl status nfs-server.service
+Cmnd_Alias VAGRANT_NFSD_CHECK = /usr/bin/systemctl status --no-pager nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_START = /usr/bin/systemctl start nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /bin/sed -r -e * d -ibak /*/exports

--- a/plugins/hosts/arch/cap/nfs.rb
+++ b/plugins/hosts/arch/cap/nfs.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class NFS
         def self.nfs_check_command(env)
           if systemd?
-            return "/usr/sbin/systemctl status nfs-server.service"
+            return "/usr/sbin/systemctl status --no-pager nfs-server.service"
           else
             return "/etc/rc.d/nfs-server status"
           end

--- a/plugins/hosts/gentoo/cap/nfs.rb
+++ b/plugins/hosts/gentoo/cap/nfs.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
       class NFS
         def self.nfs_check_command(env)
           if systemd?
-            return "#{systemctl_path} status nfs-server.service"
+            return "#{systemctl_path} status --no-pager nfs-server.service"
           else
             return "/etc/init.d/nfs status"
           end


### PR DESCRIPTION
Call it with "--no-pager"
Without it, if the user has a pager (more/less/etc.) configured and
call vagrant up with NFS shares, systemctl would use the pager, and
that would probably require an unnecessary key press from the user.