### PR TITLE
Attempt to do the right thing if new hostname is in /etc/hosts

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -56,6 +56,14 @@ module VagrantPlugins
             expression = ['s', search, replace, 'g'].join('@')
 
             sudo("sed -ri '#{expression}' /etc/hosts")
+          elsif test("grep '#{short_hostname}' /etc/hosts")
+            # New hostname entry is in /etc/hosts
+            ip_address = '([0-9]{1,3}\.){3}[0-9]{1,3}'
+            search     = "^(#{ip_address})\\s+#{Regexp.escape(short_hostname)}(\\s.*)?$"
+            replace    = "\\1 #{fqdn} #{short_hostname}"
+            expression = ['s', search, replace, 'g'].join('@')
+
+            sudo("sed -ri '#{expression}' /etc/hosts")
           else
             # Current hostname entry isn't in /etc/hosts, just append it
             sudo("echo '127.0.1.1 #{fqdn} #{short_hostname}' >>/etc/hosts")


### PR DESCRIPTION
After creating vagrant box files using packer with /etc/hosts already populated, Vagrant was creating duplicate /etc/host entry pointing to 127.0.1.1 this checks for an existing host file entry.