### PR TITLE
Adds instructions concerning Bundler versions

### DIFF
--- a/website/source/docs/plugins/development-basics.html.md
+++ b/website/source/docs/plugins/development-basics.html.md
@@ -67,20 +67,9 @@ your plugin works with another plugin.
 
 With this structure in place, your workflow should be like any other
 Ruby project, with one exception.  Because Vagrant uses the internal
-APIs of Bundler, the version of Bundler used for Vagrant development
-is pinned to a specific range defined in the
-[vagrant.gemspec](https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec)
-file.  If the upper bound version is `1.10.6`, then install the 
-required version of Bundler and Vagrant dependencies with the
-following commands:
-
-```
-gem install bundler --version '1.10.6' && \
-bundle _1.10.6_ install
-```
-
-*Be sure to check [vagrant.gemspec](https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec)
-and use the upper bound version of Bundler*
+APIs of Bundler, see [Installing Vagrant from Source](https://github.com/mitchellh/vagrant/wiki/Installing-Vagrant-from-Source)
+for tips for using the correct version of Bundler to install
+dependencies.
 
 When you want to manually test your plugin, use
 `bundle exec vagrant` in order to run Vagrant with your plugin

--- a/website/source/docs/plugins/development-basics.html.md
+++ b/website/source/docs/plugins/development-basics.html.md
@@ -66,7 +66,23 @@ allows you to add multiple plugins to Vagrant for development, if
 your plugin works with another plugin.
 
 With this structure in place, your workflow should be like any other
-Ruby project. When you want to manually test your plugin, use
+Ruby project, with one exception.  Because Vagrant uses the internal
+APIs of Bundler, the version of Bundler used for Vagrant development
+is pinned to a specific range defined in the
+[vagrant.gemspec](https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec)
+file.  If the upper bound version is `1.10.6`, then install the 
+required version of Bundler and Vagrant dependencies with the
+following commands:
+
+```
+gem install bundler --version '1.10.6' && \
+bundle _1.10.6_ install
+```
+
+*Be sure to check [vagrant.gemspec](https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec)
+and use the upper bound version of Bundler*
+
+When you want to manually test your plugin, use
 `bundle exec vagrant` in order to run Vagrant with your plugin
 loaded (as we specified in the Gemfile).
 

--- a/website/source/docs/plugins/development-basics.html.md
+++ b/website/source/docs/plugins/development-basics.html.md
@@ -68,7 +68,7 @@ your plugin works with another plugin.
 With this structure in place, your workflow should be like any other
 Ruby project, with one exception.  Because Vagrant uses the internal
 APIs of Bundler, see [Installing Vagrant from Source](https://github.com/mitchellh/vagrant/wiki/Installing-Vagrant-from-Source)
-for tips for using the correct version of Bundler to install
+for tips on using the correct version of Bundler to install
 dependencies.
 
 When you want to manually test your plugin, use


### PR DESCRIPTION
Because Vagrant requires certain versions of Bundler in order to work properly, the correct version of Bundler must be installed manually.  I gathered this information from a couple of sources.

It's handy to have this information in this specific guide :)