### PR TITLE
[#7202] Always forward SSH on Windows

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -425,7 +425,9 @@ module VagrantPlugins
               id: "winrm-ssl",
               auto_correct: true
           end
-        elsif !@__networks["forwarded_port-ssh"]
+        end
+        # forward SSH ports regardless of communicator
+        if !@__networks["forwarded_port-ssh"]
           network :forwarded_port,
             guest: 22,
             host: 2222,

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -173,7 +173,7 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       subject.communicator = "winrm"
       subject.finalize!
       n = subject.networks
-      expect(n.length).to eq(2)
+      expect(n.length).to eq(3)
 
       expect(n[0][0]).to eq(:forwarded_port)
       expect(n[0][1][:guest]).to eq(5985)
@@ -186,6 +186,32 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       expect(n[1][1][:host]).to eq(55986)
       expect(n[1][1][:host_ip]).to eq("127.0.0.1")
       expect(n[1][1][:id]).to eq("winrm-ssl")
+    end
+
+    it "forwards ssh even if the communicator is winrm" do
+      subject.communicator = "winrm"
+      subject.finalize!
+      n = subject.networks
+      expect(n.length).to eq(3)
+
+      expect(n[0][0]).to eq(:forwarded_port)
+      expect(n[0][1][:guest]).to eq(5985)
+      expect(n[0][1][:host]).to eq(55985)
+      expect(n[0][1][:host_ip]).to eq("127.0.0.1")
+      expect(n[0][1][:id]).to eq("winrm")
+
+      expect(n[1][0]).to eq(:forwarded_port)
+      expect(n[1][1][:guest]).to eq(5986)
+      expect(n[1][1][:host]).to eq(55986)
+      expect(n[1][1][:host_ip]).to eq("127.0.0.1")
+      expect(n[1][1][:id]).to eq("winrm-ssl")
+
+      expect(n[2][0]).to eq(:forwarded_port)
+      expect(n[2][1][:guest]).to eq(22)
+      expect(n[2][1][:host]).to eq(2222)
+      expect(n[2][1][:host_ip]).to eq("127.0.0.1")
+      expect(n[2][1][:id]).to eq("ssh")
+
     end
 
     it "allows overriding SSH" do


### PR DESCRIPTION
As per the details in #7202 this has been fixed before by @mitchellh in 8655d21 but was regressed in 3e8fdc0.

This re-implements the changes, and adds a test that explicitly defines this behaviour.

All the unit tests still pass, and I have tested creating a Windows vagrant box with this change