### PR TITLE
prepare_nfs_settings: Try harder to get all machine IPs.

### DIFF
--- a/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
+++ b/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
@@ -36,8 +36,19 @@ module VagrantPlugins
         #
         # The ! indicates that this method modifies its argument.
         def add_ips_to_env!(env)
-          adapter, host_ip = find_host_only_adapter
-          machine_ip       = read_static_machine_ips || read_dynamic_machine_ip(adapter)
+          adapter, host_ip   = find_host_only_adapter
+          machine_ip         = read_static_machine_ips
+          dynamic_machine_ip = read_dynamic_machine_ip(adapter)
+
+          if machine_ip.nil?
+            # If there were no static IPs, attempt to use the dynamic IP
+            # instead.
+            machine_ip = dynamic_machine_ip
+          else
+            # If we did get some static machine IPs, add the dynamic IPs to
+            # that list too.
+            machine_ip.push(dynamic_machine_ip) unless dynamic_machine_ip.nil?
+          end
 
           raise Vagrant::Errors::NFSNoHostonlyNetwork if !host_ip || !machine_ip
 

--- a/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
+++ b/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
@@ -36,18 +36,27 @@ module VagrantPlugins
         #
         # The ! indicates that this method modifies its argument.
         def add_ips_to_env!(env)
-          adapter, host_ip   = find_host_only_adapter
-          machine_ip         = read_static_machine_ips
-          dynamic_machine_ip = read_dynamic_machine_ip(adapter)
+          adapter, host_ip = find_host_only_adapter
+          machine_ip       = read_static_machine_ips
 
-          if machine_ip.nil?
-            # If there were no static IPs, attempt to use the dynamic IP
-            # instead.
-            machine_ip = dynamic_machine_ip
+          if !machine_ip
+            # No static IP, attempt to use the dynamic IP.
+            machine_ip = read_dynamic_machine_ip(adapter)
           else
-            # If we did get some static machine IPs, add the dynamic IPs to
-            # that list too.
-            machine_ip.push(dynamic_machine_ip) unless dynamic_machine_ip.nil?
+            # We have static IPs, also attempt to read any dynamic IPs.
+            # If there is no dynamic IP on the adapter, it doesn't matter. We
+            # already have a static IP.
+            begin
+              dynamic_ip = read_dynamic_machine_ip(adapter)
+            rescue Vagrant::Errors::NFSNoGuestIP
+              dynamic_ip = nil
+            end
+
+            # If we found a dynamic IP and we didn't include it in the
+            # machine_ip array yet, do so.
+            if dynamic_ip && !machine_ip.include?(dynamic_ip)
+              machine_ip.push(dynamic_ip)
+            end
           end
 
           raise Vagrant::Errors::NFSNoHostonlyNetwork if !host_ip || !machine_ip

--- a/test/unit/plugins/providers/virtualbox/action/prepare_nfs_settings_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/prepare_nfs_settings_test.rb
@@ -116,5 +116,14 @@ describe VagrantPlugins::ProviderVirtualBox::Action::PrepareNFSSettings do
       expect(env[:nfs_host_ip]).to    eq("1.2.3.4")
       expect(env[:nfs_machine_ip]).to eq(["11.12.13.14"])
     end
+
+    it "allows statically configured guest IPs to co-exist with dynamic host only IPs for NFS" do
+      env[:machine].config.vm.network :private_network, ip: "11.12.13.14"
+
+      subject.call(env)
+
+      expect(env[:nfs_host_ip]).to    eq("1.2.3.4")
+      expect(env[:nfs_machine_ip]).to eq(["11.12.13.14", "2.3.4.5"])
+    end
   end
 end


### PR DESCRIPTION
Vagrant was not behaving correctly in configurations where there was
a static IP on a VirtualBox `intnet` interface and a DHCP `:hostonly`
interface configured.

Since `machine_ip` attempted to get static addresses `||` dynamic
addresses, it would simply use the static machine address and
continue.

This commit corrects this behaviour by collecting all static and
dynamic addresses into the `machine_ip` array instead of just one or
the other.

The result of this is a correctly generated `/etc/exports` on the
host machine, allowing NFS mounts to work correctly in this type of
environment.

### References
- GH-7289