### PR TITLE
Set max_network_adapters to 36 for Virtualbox

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -178,7 +178,7 @@ module VagrantPlugins
 
         # Returns the maximum number of network adapters.
         def max_network_adapters
-          8
+          36
         end
 
         # Returns a list of forwarded ports for a VM.

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1364,7 +1364,7 @@ en:
         There is no available slots on the VirtualBox VM for the configured
         high-level network interfaces. "private_network" and "public_network"
         network configurations consume a single network adapter slot on the
-        VirtualBox VM. VirtualBox limits the number of slots to 8, and it
+        VirtualBox VM. VirtualBox limits the number of slots to 36, and it
         appears that every slot is in use. Please lower the number of used
         network adapters.
       virtualbox_not_detected: |-


### PR DESCRIPTION
Updated ./plugins/providers/virtualbox/driver/base.rb file, set max_network_adapters to 36 for Virtualbox so all 36 adapters are cleared prior to programming interfaces. This fix is per issue 7286 --> https://github.com/mitchellh/vagrant/issues/7286

## Limited Testing
Performed limited testing on the provided vagrantfile in issue 7286. To compare performance timing before and after the change. No Difference.
Performed Vagrant up on leaf1 5 times in a row and averaged the completion times using the following commands.

## Test Commands
time vagrant up leaf1
vagrant destroy -f leaf1
time vagrant up leaf1
vagrant destroy -f leaf1
time vagrant up leaf1
vagrant destroy -f leaf1
time vagrant up leaf1
vagrant destroy -f leaf1
time vagrant up leaf1
vagrant destroy -f leaf

## Set to 8 Max Adapters
Vagrant up 1: 39.073 sec
Vagrant up 2: 37.678 sec
Vagrant up 3: 37.069 sec
Vagrant up 4: 37.629 sec
Vagrant up 5: 37.737 sec
Average: 37.837 sec

## Set to 36 Max Adapters
Vagrant up 1: 37.613 sec
Vagrant up 2: 37.041 sec
Vagrant up 3: 37.095 sec
Vagrant up 4: 37.056 sec
Vagrant up 5: 37.483 sec
Average: 37.257 sec