### PR TITLE
Added 'vagrant reload' info on collision_error

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1733,7 +1733,11 @@ en:
 
             Sometimes, Vagrant will attempt to auto-correct this for you. In this
             case, Vagrant was unable to. This is usually because the guest machine
-            is in a state which doesn't allow modifying port forwarding.
+            is in a state which doesn't allow modifying port forwarding. You could
+            try 'vagrant reload' (equivalent of running a halt followed by an up) 
+            so vagrant can attempt to auto-correct this upon booting. Be warned 
+            that any unsaved work might be lost.
+            
           fixed_collision: |-
             Fixed port collision for %{guest_port} => %{host_port}. Now on port %{new_port}.
           forwarding: Forwarding ports...


### PR DESCRIPTION
Although the current message does tell you that the forwarded port can't be auto corrected due to the current state of the machine, it does not provide a clear solution. This happens to me all the time and after changing my vagrant file I've found out that I could just do a `vagrant reload`! 

Could it be nice to add this do the docs? 