### PR TITLE
fix setting hostname for Debian guests

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -33,7 +33,10 @@ module VagrantPlugins
 
         def get_current_hostname
           hostname = ""
-          sudo "hostname -f" do |type, data|
+          execute "hostname -f", error_check: false do |type, data|
+            hostname = data.chomp if type == :stdout && hostname.empty?
+          end
+          execute "hostname" do |type, data|
             hostname = data.chomp if type == :stdout && hostname.empty?
           end
 

--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -82,8 +82,12 @@ module VagrantPlugins
           new_hostname.split('.').first
         end
 
-        def sudo(cmd, &block)
-          machine.communicate.sudo(cmd, &block)
+        def execute(cmd, opts=nil, &block)
+          machine.communicate.execute(cmd, opts, &block)
+        end
+
+        def sudo(cmd, opts=nil, &block)
+          machine.communicate.sudo(cmd, opts, &block)
         end
 
         def test(cmd)

--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
             hostname = data.chomp if type == :stdout && hostname.empty?
           end
 
-          hostname
+          /localhost(\..*)?/.match(hostname) ? '' : hostname
         end
 
         def update_etc_hostname

--- a/test/unit/plugins/guests/support/shared/debian_like_host_name_examples.rb
+++ b/test/unit/plugins/guests/support/shared/debian_like_host_name_examples.rb
@@ -11,7 +11,7 @@ shared_examples "a debian-like host name change" do
 
   it "does nothing when the provided hostname is not different" do
     described_class.change_host_name(machine, 'oldhostname.olddomain.tld')
-    expect(communicator.received_commands).to eq(['hostname -f'])
+    expect(communicator.received_commands).to eq(['hostname -f', 'hostname'])
   end
 
   describe "flipping out the old hostname in /etc/hosts" do


### PR DESCRIPTION
Without that setting `config.vm.hostname` for `debian/jessie64` and similar boxes will fail:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

hostname -f

Stdout from the command:



Stderr from the command:

sudo: unable to resolve host jessie.raw
stdin: is not a tty
hostname: Name or service not known
```

While this should also be fixed in the box itself, the Debian guests plugin should be more tolerant to badly set-up machines.

While at it:
* don't use `sudo` for just calling `hostname`
* don't consider `localhost` a valid hostname