### PR TITLE
Support Chef Solo local + legacy modes

### DIFF
--- a/plugins/provisioners/chef/command_builder.rb
+++ b/plugins/provisioners/chef/command_builder.rb
@@ -47,6 +47,7 @@ module VagrantPlugins
         args << " --config #{provisioning_path("#{type}.rb")}"
         args << " --json-attributes #{provisioning_path("dna.json")}"
         args << " --local-mode" if options[:local_mode]
+        args << " --legacy-mode" if options[:legacy_mode]
         args << " --log_level #{config.log_level}" if config.log_level
         args << " --no-color" if !options[:colored]
 

--- a/plugins/provisioners/chef/config/chef_solo.rb
+++ b/plugins/provisioners/chef/config/chef_solo.rb
@@ -33,6 +33,10 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :recipe_url
 
+        # Enable chef-solo legacy mode rather than local mode.
+        # @return [true, false]
+        attr_accessor :legacy_mode
+
         # The path where roles are stored on disk.
         # @return [String]
         attr_accessor :roles_path
@@ -49,6 +53,7 @@ module VagrantPlugins
           @environments_path   = UNSET_VALUE
           @nodes_path          = UNSET_VALUE
           @recipe_url          = UNSET_VALUE
+          @legacy_mode         = UNSET_VALUE
           @roles_path          = UNSET_VALUE
           @synced_folder_type  = UNSET_VALUE
         end
@@ -62,6 +67,7 @@ module VagrantPlugins
 
           @recipe_url = nil if @recipe_url == UNSET_VALUE
           @synced_folder_type = nil if @synced_folder_type == UNSET_VALUE
+          @legacy_mode = false if @legacy_mode == UNSET_VALUE
 
           if @cookbooks_path == UNSET_VALUE
             @cookbooks_path = []

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -182,6 +182,7 @@ module VagrantPlugins
           command = CommandBuilder.command(:solo, @config,
             windows: windows?,
             colored: @machine.env.ui.color?,
+            legacy_mode: @config.legacy_mode
           )
 
           @config.attempts.times do |attempt|

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -4,15 +4,15 @@ node_name "<%= node_name %>"
 file_cache_path    "<%= file_cache_path %>"
 file_backup_path   "<%= file_backup_path %>"
 cookbook_path <%= cookbooks_path.inspect %>
-<% if roles_path %>
+<% if roles_path && !roles_path.empty? -%>
 role_path <%= roles_path.size == 1 ? roles_path.first.inspect : roles_path.inspect %>
-<% end %>
+<% end -%>
 log_level <%= log_level.inspect %>
 verbose_logging <%= verbose_logging.inspect %>
 
 encrypted_data_bag_secret <%= encrypted_data_bag_secret.inspect %>
 
-<% if data_bags_path -%>
+<% if data_bags_path && !data_bags_path.empty? -%>
 data_bag_path <%= data_bags_path.size == 1 ? data_bags_path.first.inspect : data_bags_path.inspect %>
 <% end %>
 
@@ -20,18 +20,18 @@ data_bag_path <%= data_bags_path.size == 1 ? data_bags_path.first.inspect : data
 recipe_url "<%= recipe_url %>"
 <% end -%>
 
-<% if environments_path %>
+<% if environments_path && !environments_path.empty? -%>
 environment_path <%= environments_path.inspect %>
 <% end -%>
 
-<% if environment %>
+<% if environment -%>
 environment "<%= environment %>"
 <% end -%>
 
 <% if local_mode -%>
 local_mode true
 <% end -%>
-<% if nodes_path -%>
+<% if nodes_path && !nodes_path.empty? -%>
 node_path <%= nodes_path.inspect %>
 <% end -%>
 
@@ -43,7 +43,7 @@ https_proxy_user <%= https_proxy_user.inspect %>
 https_proxy_pass <%= https_proxy_pass.inspect %>
 no_proxy <%= no_proxy.inspect %>
 
-<% if formatter %>
+<% if formatter -%>
 add_formatter "<%= formatter %>"
 <% end %>
 


### PR DESCRIPTION
Chef Solo by default will be using the same code path as chef-client in local mode, and we're adding a legacy mode to retain the previous behavior.

This PR adds support for legacy mode, and also fixes a bug where the node_path was getting set to an empty array, rather than simply being unset - which caused solo-in-local-mode to break.

Fixes: chef/chef#4948 cc @sethvargo