### PR TITLE
ansible_local: Skip config files detection on the guest system (by default)

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2147,6 +2147,15 @@ en:
         windows_not_supported_for_control_machine: |-
           Windows is not officially supported for the Ansible Control Machine.
           Please check https://docs.ansible.com/intro_installation.html#control-machine-requirements
+        warnings:
+          validate_guest_is_enabled: |-
+            Vagrant will try to detect the presence of some Ansible
+            configuration files on the guest system, but this action
+            is not supported by some providers (e.g. 'aws' and 'lxc').
+            If you encounter an application crash with errors like
+            'stack level too deep (SystemStackError)', setting the
+            `validate_guest` option to `false` will prevent this
+            problem from happening.
 
       docker:
         not_running: "Docker is not running on the guest VM."

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -79,6 +79,10 @@ This section lists the specific options for the Ansible Local provisioner. In ad
 
   The default value is `/tmp/vagrant-ansible`
 
+- `validate_guest` (boolean) - require Vagrant to verify the existence of some Ansible configuration files on the guest system (e.g. the playbook file). These checks are skipped when the machine is not ready for network communication.
+
+  The default value is `false` because this mechanism can crash with some machine provider implementations (e.g. [vagrant-aws](https://github.com/mitchellh/vagrant/issues/6984) or [vagrant-lxc](https://github.com/fgrehm/vagrant-lxc/issues/398)).
+
 - `version` (string) - The expected Ansible version.
 
   This option is disabled by default.


### PR DESCRIPTION
@sethvargo this is a possible way to fix #6984. An alternative to this, could be to totally give up with remote file checking by `ansible_local` provisioner. Please let me know your preference...