### PR TITLE
Fixing second paragraph indentation and link.

### DIFF
--- a/website/source/docs/provisioning/chef_common.html.md
+++ b/website/source/docs/provisioning/chef_common.html.md
@@ -59,11 +59,11 @@ understand their purpose.
   requested version. If they match, no action is taken. If they do not match,
   the value specified in this attribute will be installed in favor of the
   existing version (a message will be displayed).
-
+  
   You can also specify "latest" (default), which will install the latest
   version of Chef on the system. In this case, Chef will use whatever
   version is on the system. To force the newest version of Chef to be
-  installed on every provision, set the {#install} option to "force".
+  installed on every provision, set the [`install`](#install) option to "force".
 
 
 ## Runner Chef Provisioners


### PR DESCRIPTION
Without the two spaces on line 62, the docs look like this:

![screenshot](https://i.imgur.com/24PYjFW.png)

This is confusing, because it looks like the second paragraph is wrapping up the "ALL CHEF PROVISIONERS" section. Instead, we should indent the second paragraph so it is clear it is talking about the `version` attribute.

I also fixed the broken `install` link.