### PR TITLE
Documentation for synced_folder's 'id' argument

### DIFF
--- a/website/source/docs/synced-folders/basic_usage.html.md
+++ b/website/source/docs/synced-folders/basic_usage.html.md
@@ -64,6 +64,9 @@ in other pages available in the navigation for these docs.
   Vagrant will automatically choose the best synced folder option for your
   environment. Otherwise, you can specify a specific type such as "nfs".
 
+* `id` (string) - The name for the mount point of this synced folder in the
+  guest machine. This shows up when you run `mount` in the guest machine.
+
 ## Enabling
 
 Synced folders are automatically setup during `vagrant up` and


### PR DESCRIPTION
For issue https://github.com/mitchellh/vagrant/issues/7343

For what it's worth, `man mount` mentions that `mount` is only maintained for backward compatibility. The  recommended alternative `findmnt` doesn't seem to list the `id` value.
