### PR TITLE
Bump box resume delay to 24h

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -18,6 +18,10 @@ module Vagrant
         # to NOT be metadata.
         METADATA_SIZE_LIMIT = 20971520
 
+        # This is the amount of time to "resume" downloads if a partial box
+        # file already exists.
+        RESUME_DELAY = 24 * 60 * 60
+
         def initialize(app, env)
           @app    = app
           @logger = Log4r::Logger.new("vagrant::action::builtin::box_add")
@@ -393,7 +397,7 @@ module Vagrant
             if env[:box_clean]
               @logger.info("Cleaning existing temp box file.")
               delete = true
-            elsif temp_path.mtime.to_i < (Time.now.to_i - 6 * 60 * 60)
+            elsif temp_path.mtime.to_i < (Time.now.to_i - RESUME_DELAY)
               @logger.info("Existing temp file is too old. Removing.")
               delete = true
             end

--- a/website/source/docs/cli/box.html.md
+++ b/website/source/docs/cli/box.html.md
@@ -43,7 +43,7 @@ variables are respected. HTTPS is also supported.
 
 If an error occurs during the download or the download is interrupted with
 a Ctrl-C, then Vagrant will attempt to resume the download the next time it
-is requested. Vagrant will only attempt to resume a download for six hours
+is requested. Vagrant will only attempt to resume a download for 24 hours
 after the initial download.
 
 ## Options


### PR DESCRIPTION
This commit bumps the box resume delay time to 24h and makes it a constant because I had a bugger of a time actually finding this in the code :frowny:.

Fixes GH-7272