### PR TITLE
Fix file leaking in bundler

### DIFF
--- a/plugins/commands/ssh/command.rb
+++ b/plugins/commands/ssh/command.rb
@@ -55,6 +55,7 @@ module VagrantPlugins
             exit_status = env[:ssh_run_exit_status] || 0
             return exit_status
           else
+            Vagrant::Bundler.instance.deinit
             @logger.debug("Invoking `ssh` action on machine")
             vm.action(:ssh, ssh_opts: ssh_opts)
 


### PR DESCRIPTION
This fixes a leak that occurs when interacting with Vagrant's bundler instance. Each call to Tempfile creates and generates a tempfile, but they are not cleaned up unless GC runs. Additionally, we were not deleting a few of the files.

This adds a new helper that creates a tmp path using `Dir::Tmpname`, and then returns a new open file handle for that path.

- Fixes #6301 
- Fixes #3469
- Fixes #6231