### PR TITLE
Identify and cleanup tempfiles and temporary directories

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -254,13 +254,14 @@ module Vagrant
     def with_isolated_gem
       raise Errors::BundlerDisabled if !@enabled
 
-      tmp_gemfile = Dir::Tmpname.create("vagrant-gemfile") {}
+      tmp_gemfile = tempfile("vagrant-gemfile")
+      tmp_gemfile.close
 
       # Remove bundler settings so that Bundler isn't loaded when building
       # native extensions because it causes all sorts of problems.
       old_rubyopt = ENV["RUBYOPT"]
       old_gemfile = ENV["BUNDLE_GEMFILE"]
-      ENV["BUNDLE_GEMFILE"] = tmp_gemfile
+      ENV["BUNDLE_GEMFILE"] = tmp_gemfile.path
       ENV["RUBYOPT"] = (ENV["RUBYOPT"] || "").gsub(/-rbundler\/setup\s*/, "")
 
       # Set the GEM_HOME so gems are installed only to our local gem dir
@@ -290,7 +291,7 @@ module Vagrant
         return yield
       end
     ensure
-      File.unlink(tmp_gemfile) if File.file?(tmp_gemfile)
+      tmp_gemfile.unlink rescue nil
 
       ENV["BUNDLE_GEMFILE"] = old_gemfile
       ENV["GEM_HOME"] = @gem_home

--- a/lib/vagrant/util.rb
+++ b/lib/vagrant/util.rb
@@ -9,6 +9,7 @@ module Vagrant
     autoload :SafeExec,                  'vagrant/util/safe_exec'
     autoload :StackedProcRunner,         'vagrant/util/stacked_proc_runner'
     autoload :TemplateRenderer,          'vagrant/util/template_renderer'
+    autoload :Tempfile,                  'vagrant/util/tempfile'
     autoload :Subprocess,                'vagrant/util/subprocess'
   end
 end

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -125,7 +125,7 @@ module Vagrant
         # directory runs a different filesystem than the root directory.
         # However, this works in many cases.
         def fs_case_sensitive?
-          Dir.mktmpdir("vagrant") do |tmp_dir|
+          Dir.mktmpdir("vagrant-fs-case-sensitive") do |tmp_dir|
             tmp_file = File.join(tmp_dir, "FILE")
             File.open(tmp_file, "w") do |f|
               f.write("foo")

--- a/lib/vagrant/util/tempfile.rb
+++ b/lib/vagrant/util/tempfile.rb
@@ -1,0 +1,58 @@
+require "tempfile"
+
+module Vagrant
+  module Util
+    class Tempfile
+      # Utility function for creating a temporary file that will persist for
+      # the duration of the block and then be removed after the block finishes.
+      #
+      # @example
+      #
+      #   Tempfile.create("arch-configure-networks") do |f|
+      #     f.write("network-1")
+      #     f.fsync
+      #     f.close
+      #     do_something_with_file(f.path)
+      #   end
+      #
+      # @example
+      #
+      #   Tempfile.create(["runner", "ps1"]) do |f|
+      #     # f will have a suffix of ".ps1"
+      #     # ...
+      #   end
+      #
+      # @param [String, Array] name the prefix of the tempfile to create
+      # @param [Hash] options a list of options
+      # @param [Proc] block the block to yield the file object to
+      #
+      # @yield [File]
+      def self.create(name, options = {})
+        raise "No block given!" if !block_given?
+
+        options = {
+          binmode: true
+        }.merge(options)
+
+        # The user can specify an array where the first parameter is the prefix
+        # and the last parameter is the file suffix. We want to prefix the
+        # "prefix" with `vagrant-`, and this does that
+        if name.is_a?(Array)
+          basename = ["vagrant-#{name[0]}", name[1]]
+        else
+          basename = "vagrant-#{name}"
+        end
+
+        Dir::Tmpname.create(basename) do |path|
+          begin
+            f = File.open(path, "w+")
+            f.binmode if options[:binmode]
+            yield f
+          ensure
+            File.unlink(f.path) if File.file?(f.path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-require "tempfile"
-
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestArch
@@ -10,23 +9,29 @@ module VagrantPlugins
         include Vagrant::Util
 
         def self.configure_networks(machine, networks)
-          interfaces = Array.new
+          tempfiles  = []
+          interfaces = []
+
           machine.communicate.sudo("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, result|
             interfaces = result.split("\n")
           end
 
-          networks.each do |network|
+          networks.each.with_index do |network, i|
             network[:device] = interfaces[network[:interface]]
 
-            entry = TemplateRenderer.render("guests/arch/network_#{network[:type]}", options: network)
+            entry = TemplateRenderer.render("guests/arch/network_#{network[:type]}",
+              options: network)
 
-            temp = Tempfile.new("vagrant")
-            temp.binmode
-            temp.write(entry)
-            temp.close
+            remote_path = "/tmp/vagrant-network-#{Time.now.to_i}-#{i}"
 
-            machine.communicate.upload(temp.path, "/tmp/vagrant_network")
-            machine.communicate.sudo("mv /tmp/vagrant_network /etc/netctl/#{network[:device]}")
+            Tempfile.create("arch-configure-networks") do |f|
+              f.write(entry)
+              f.fsync
+              f.close
+              machine.communicate.upload(f.path, remote_path)
+            end
+
+            machine.communicate.sudo("mv #{remote_path} /etc/netctl/#{network[:device]}")
             machine.communicate.sudo("ip link set #{network[:device]} down && netctl restart #{network[:device]} && netctl enable #{network[:device]}")
           end
         end

--- a/plugins/guests/coreos/cap/configure_networks.rb
+++ b/plugins/guests/coreos/cap/configure_networks.rb
@@ -1,6 +1,5 @@
-require "tempfile"
-
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestCoreOS
@@ -54,11 +53,11 @@ module VagrantPlugins
               })
             end
 
-            Tempfile.open("vagrant") do |temp|
-              temp.binmode
-              temp.write(entry)
-              temp.close
-              comm.upload(temp.path, "/tmp/etcd-cluster.service")
+            Tempfile.create("coreos-configure-networks") do |f|
+              f.write(entry)
+              f.fsync
+              f.close
+              comm.upload(f.path, "/tmp/etcd-cluster.service")
             end
 
             comm.sudo("mv /tmp/etcd-cluster.service /media/state/units/")

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -1,7 +1,7 @@
-require 'set'
-require 'tempfile'
+require "set"
 
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestDebian
@@ -29,14 +29,14 @@ module VagrantPlugins
               entries << entry
             end
 
-            # Perform the careful dance necessary to reconfigure
-            # the network interfaces
-            temp = Tempfile.new("vagrant")
-            temp.binmode
-            temp.write(entries.join("\n"))
-            temp.close
-
-            comm.upload(temp.path, "/tmp/vagrant-network-entry")
+            # Perform the careful dance necessary to reconfigure the network
+            # interfaces.
+            Tempfile.create("debian-configure-networks") do |f|
+              f.write(entries.join("\n"))
+              f.fsync
+              f.close
+              comm.upload(f.path, "/tmp/vagrant-network-entry")
+            end
 
             # Bring down all the interfaces we're reconfiguring. By bringing down
             # each specifically, we avoid reconfiguring eth0 (the NAT interface) so

--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 require "set"
-require "tempfile"
 
-require "vagrant/util/retryable"
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/retryable"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestFedora
@@ -96,12 +96,12 @@ module VagrantPlugins
             entry = TemplateRenderer.render("guests/fedora/network_#{network[:type]}",
                                             options: network)
 
-            temp = Tempfile.new("vagrant")
-            temp.binmode
-            temp.write(entry)
-            temp.close
-
-            machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry_#{interface}")
+            Tempfile.create("fedora-configure-networks") do |f|
+              f.write(entry)
+              f.fsync
+              f.close
+              machine.communicate.upload(f.path, "/tmp/vagrant-network-entry_#{interface}")
+            end
           end
 
           # Bring down all the interfaces we're reconfiguring. By bringing down

--- a/plugins/guests/gentoo/cap/configure_networks.rb
+++ b/plugins/guests/gentoo/cap/configure_networks.rb
@@ -1,6 +1,5 @@
-require "tempfile"
-
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestGentoo
@@ -21,12 +20,12 @@ module VagrantPlugins
                                               options: network)
 
               # Upload the entry to a temporary location
-              temp = Tempfile.new("vagrant")
-              temp.binmode
-              temp.write(entry)
-              temp.close
-
-              comm.upload(temp.path, "/tmp/vagrant-network-entry")
+              Tempfile.create("gentoo-configure-networks") do |f|
+                f.write(entry)
+                f.fsync
+                f.close
+                comm.upload(f.path, "/tmp/vagrant-network-entry")
+              end
 
               # Configure the interface
               comm.sudo("ln -fs /etc/init.d/net.lo /etc/init.d/net.eth#{network[:interface]}")

--- a/plugins/guests/nixos/cap/change_host_name.rb
+++ b/plugins/guests/nixos/cap/change_host_name.rb
@@ -1,6 +1,5 @@
-require 'tempfile'
-
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestNixos
@@ -16,13 +15,15 @@ module VagrantPlugins
 
         # Upload a file.
         def self.upload(machine, content, remote_path)
-          local_temp = Tempfile.new("vagrant-upload")
-          local_temp.binmode
-          local_temp.write(content)
-          local_temp.close
           remote_temp = mktemp(machine)
-          machine.communicate.upload(local_temp.path, "#{remote_temp}")
-          local_temp.delete
+
+          Tempfile.create("nixos-change-host-name") do |f|
+            f.write(content)
+            f.fsync
+            f.close
+            machine.communicate.upload(f.path, "#{remote_temp}")
+          end
+
           machine.communicate.sudo("mv #{remote_temp} #{remote_path}")
         end
 

--- a/plugins/guests/openbsd/cap/configure_networks.rb
+++ b/plugins/guests/openbsd/cap/configure_networks.rb
@@ -1,6 +1,5 @@
-require "tempfile"
-
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestOpenBSD
@@ -13,10 +12,12 @@ module VagrantPlugins
             entry = TemplateRenderer.render("guests/openbsd/network_#{network[:type]}",
                                             options: network)
 
-            temp = Tempfile.new("vagrant")
-            temp.binmode
-            temp.write(entry)
-            temp.close
+            Tempfile.create("openbsd-configure-networks") do |f|
+              f.write(entry)
+              f.fsync
+              f.close
+              machine.communicate.upload(f.path, "/tmp/vagrant-network-entry")
+            end
 
             # Determine the interface prefix...
             command = "ifconfig -a | grep -o ^[0-9a-z]*"
@@ -31,7 +32,6 @@ module VagrantPlugins
               end
             end
 
-            machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry")
             machine.communicate.sudo("mv /tmp/vagrant-network-entry /etc/hostname.#{ifname}")
 
             # remove old configurations

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 require "set"
-require "tempfile"
 
-require "vagrant/util/retryable"
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/retryable"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestRedHat
@@ -55,12 +55,12 @@ module VagrantPlugins
             entry = TemplateRenderer.render("guests/redhat/network_#{network[:type]}",
                                             options: network)
 
-            temp = Tempfile.new("vagrant")
-            temp.binmode
-            temp.write(entry)
-            temp.close
-
-            machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry_#{network[:interface]}")
+            Tempfile.create("red-hat-configure-networks") do |f|
+              f.write(entry)
+              f.fsync
+              f.close
+              machine.communicate.upload(f.path, "/tmp/vagrant-network-entry_#{network[:interface]}")
+            end
           end
 
           # Bring down all the interfaces we're reconfiguring. By bringing down

--- a/plugins/guests/suse/cap/configure_networks.rb
+++ b/plugins/guests/suse/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 require "set"
-require "tempfile"
 
-require "vagrant/util/retryable"
-require "vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/retryable"
+require_relative "../../../../lib/vagrant/util/template_renderer"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module GuestSUSE
@@ -33,12 +33,12 @@ module VagrantPlugins
             entry = TemplateRenderer.render("guests/suse/network_#{network[:type]}",
                                             options: network)
 
-            temp = Tempfile.new("vagrant")
-            temp.binmode
-            temp.write(entry)
-            temp.close
-
-            machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry_#{network[:interface]}")
+            Tempfile.create("suse-configure-networks") do |f|
+              f.write(entry)
+              f.fsync
+              f.close
+              machine.communicate.upload(f.path, "/tmp/vagrant-network-entry_#{network[:interface]}")
+            end
           end
 
           # Bring down all the interfaces we're reconfiguring. By bringing down

--- a/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
+++ b/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
@@ -16,8 +16,7 @@ module VagrantPlugins
         SHA256SUM = "62f933115498e51ddf5f2dab47dc1eebb42eb78ea1a7665cb91c53edacc847c6".freeze
 
         def self.provider_install_virtualbox(env)
-          tf = Tempfile.new("vagrant")
-          tf.close
+          path = Dir::Tmpname.create("vagrant-provider-install-virtualbox") {}
 
           # Prefixed UI for prettiness
           ui = Vagrant::UI::Prefixed.new(env.ui, "")
@@ -28,11 +27,11 @@ module VagrantPlugins
             version: VERSION))
           ui.detail(I18n.t(
             "vagrant.hosts.darwin.virtualbox_install_detail"))
-          dl = Vagrant::Util::Downloader.new(URL, tf.path, ui: ui)
+          dl = Vagrant::Util::Downloader.new(URL, path, ui: ui)
           dl.download!
 
           # Validate that the file checksum matches
-          actual = FileChecksum.new(tf.path, Digest::SHA2).checksum
+          actual = FileChecksum.new(path, Digest::SHA2).checksum
           if actual != SHA256SUM
             raise Vagrant::Errors::ProviderChecksumMismatch,
               provider: "virtualbox",
@@ -46,7 +45,7 @@ module VagrantPlugins
           ui.detail(I18n.t(
             "vagrant.hosts.darwin.virtualbox_install_install_detail"))
           script = File.expand_path("../../scripts/install_virtualbox.sh", __FILE__)
-          result = Vagrant::Util::Subprocess.execute("bash", script, tf.path)
+          result = Vagrant::Util::Subprocess.execute("bash", script, path)
           if result.exit_code != 0
             raise Vagrant::Errors::ProviderInstallFailed,
               provider: "virtualbox",

--- a/plugins/providers/virtualbox/action/package_setup_folders.rb
+++ b/plugins/providers/virtualbox/action/package_setup_folders.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
         def call(env)
           env["package.output"] ||= "package.box"
-          env["package.directory"] ||= Dir.mktmpdir("package-", env[:tmp_path])
+          env["package.directory"] ||= Dir.mktmpdir("vagrant-package-", env[:tmp_path])
 
           # Match up a couple environmental variables so that the other parts of
           # Vagrant will do the right thing.

--- a/plugins/provisioners/chef/provisioner/chef_apply.rb
+++ b/plugins/provisioners/chef/provisioner/chef_apply.rb
@@ -1,7 +1,7 @@
 require "digest/md5"
-require "tempfile"
 
 require_relative "base"
+require_relative "../../../../lib/vagrant/util/tempfile"
 
 module VagrantPlugins
   module Chef
@@ -54,17 +54,15 @@ module VagrantPlugins
         # Write the raw recipe contents to a tempfile and upload that to the
         # machine.
         def upload_recipe
-          # Write the raw recipe contents to a tempfile
-          file = Tempfile.new(["vagrant-chef-apply", ".rb"])
-          file.write(config.recipe)
-          file.rewind
+          # Write the raw recipe contents to a tempfile and upload
+          Tempfile.create(["chef-apply", ".rb"]) do |f|
+            f.write(config.recipe)
+            f.fsync
+            f.close
 
-          # Upload the tempfile to the guest
-          @machine.communicate.upload(file.path, target_recipe_path)
-        ensure
-          # Delete our template
-          file.close
-          file.unlink
+            # Upload the tempfile to the guest
+            @machine.communicate.upload(f.path, target_recipe_path)
+          end
         end
       end
     end

--- a/test/support/isolated_environment.rb
+++ b/test/support/isolated_environment.rb
@@ -28,7 +28,7 @@ class IsolatedEnvironment
     @logger = Log4r::Logger.new("test::isolated_environment")
 
     # Create a temporary directory for our work
-    @tempdir = Vagrant::Util::Platform.fs_real_path(Dir.mktmpdir("vagrant"))
+    @tempdir = Vagrant::Util::Platform.fs_real_path(Dir.mktmpdir("vagrant-iso-env"))
     @logger.info("Initialize isolated environment: #{@tempdir}")
 
     # Setup the home and working directories

--- a/test/unit/base.rb
+++ b/test/unit/base.rb
@@ -27,6 +27,10 @@ require "unit/support/shared/virtualbox_context"
 $stdout.sync = true
 $stderr.sync = true
 
+# Create a temporary directory where test vagrant will run. The reason we save
+# this to a constant is so we can clean it up later.
+VAGRANT_TEST_CWD = Dir.mktmpdir("vagrant-test-cwd")
+
 # Configure RSpec
 RSpec.configure do |c|
   c.treat_symbols_as_metadata_keys_with_true_values = true
@@ -36,11 +40,15 @@ RSpec.configure do |c|
   else
     c.filter_run_excluding :windows
   end
+
+  c.after(:suite) do
+    FileUtils.rm_rf(VAGRANT_TEST_CWD)
+  end
 end
 
 # Configure VAGRANT_CWD so that the tests never find an actual
 # Vagrantfile anywhere, or at least this minimizes those chances.
-ENV["VAGRANT_CWD"] = Dir.mktmpdir("vagrant")
+ENV["VAGRANT_CWD"] = VAGRANT_TEST_CWD
 
 # Set the dummy provider to the default for tests
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "dummy"

--- a/test/unit/plugins/commands/box/command/update_test.rb
+++ b/test/unit/plugins/commands/box/command/update_test.rb
@@ -35,7 +35,9 @@ describe VagrantPlugins::CommandBox::Command::Update do
     context "updating specific box" do
       let(:argv) { ["--box", "foo"] }
 
-      let(:metadata_url) { Pathname.new(Dir.mktmpdir).join("metadata.json") }
+      let(:scratch) { Dir.mktmpdir("vagrant-test-command-box-update-execute") }
+
+      let(:metadata_url) { Pathname.new(scratch).join("metadata.json") }
 
       before do
         metadata_url.open("w") do |f|
@@ -44,6 +46,10 @@ describe VagrantPlugins::CommandBox::Command::Update do
 
         test_iso_env.box3(
           "foo", "1.0", :virtualbox, metadata_url: metadata_url.to_s)
+      end
+
+      after do
+        FileUtils.rm_rf(scratch)
       end
 
       it "doesn't update if they're up to date" do

--- a/test/unit/plugins/guests/arch/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/arch/cap/change_host_name_test.rb
@@ -1,0 +1,37 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestArch::Cap::ChangeHostName" do
+  let(:described_class) do
+    VagrantPlugins::GuestArch::Plugin
+      .components
+      .guest_capabilities[:arch]
+      .get(:change_host_name)
+  end
+
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  after do
+    communicator.verify_expectations!
+  end
+
+  describe ".change_host_name" do
+    let(:hostname) { "example.com" }
+
+    it "sets the hostname" do
+      communicator.stub_command("sudo hostname | grep '#{hostname}'", exit_code: 1)
+      communicator.expect_command("hostnamectl set-hostname #{hostname}")
+      described_class.change_host_name(machine, hostname)
+    end
+
+    it "does not change the hostname if already set" do
+      communicator.stub_command("sudo hostname | grep '#{hostname}'", exit_code: 0)
+      described_class.change_host_name(machine, hostname)
+      expect(communicator.received_commands.size).to eq(1)
+    end
+  end
+end

--- a/test/unit/plugins/guests/arch/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/arch/cap/configure_networks_test.rb
@@ -1,0 +1,48 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestArch::Cap::ConfigureNetworks" do
+  let(:described_class) do
+    VagrantPlugins::GuestArch::Plugin
+      .components
+      .guest_capabilities[:arch]
+      .get(:configure_networks)
+  end
+
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    communicator.stub_command("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'",
+      stdout: "eth1\neth2")
+  end
+
+  after do
+    communicator.verify_expectations!
+  end
+
+  describe ".configure_networks" do
+    let(:network_1) do
+      {
+        interface: 0,
+        type: "dhcp",
+      }
+    end
+
+    let(:network_2) do
+      {
+        interface: 1,
+        type: "static",
+        ip: "33.33.33.10",
+        netmask: "255.255.0.0",
+        gateway: "33.33.0.1",
+      }
+    end
+
+    it "creates and starts the networks" do
+      communicator.expect_command("ip link set eth1 down && netctl restart eth1 && netctl enable eth1")
+      communicator.expect_command("ip link set eth2 down && netctl restart eth2 && netctl enable eth2")
+      described_class.configure_networks(machine, [network_1, network_2])
+    end
+  end
+end

--- a/test/unit/plugins/guests/coreos/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/coreos/cap/change_host_name_test.rb
@@ -1,0 +1,37 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestCoreOS::Cap::ChangeHostName" do
+  let(:described_class) do
+    VagrantPlugins::GuestCoreOS::Plugin
+      .components
+      .guest_capabilities[:coreos]
+      .get(:change_host_name)
+  end
+
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  after do
+    communicator.verify_expectations!
+  end
+
+  describe ".change_host_name" do
+    let(:hostname) { "example.com" }
+
+    it "sets the hostname" do
+      communicator.stub_command("sudo hostname --fqdn | grep '#{hostname}'", exit_code: 1)
+      communicator.expect_command("hostname example")
+      described_class.change_host_name(machine, hostname)
+    end
+
+    it "does not change the hostname if already set" do
+      communicator.stub_command("sudo hostname --fqdn | grep '#{hostname}'", exit_code: 0)
+      described_class.change_host_name(machine, hostname)
+      expect(communicator.received_commands.size).to eq(1)
+    end
+  end
+end

--- a/test/unit/plugins/guests/debian/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/debian/cap/change_host_name_test.rb
@@ -1,10 +1,14 @@
-require File.expand_path("../../../../../base", __FILE__)
-require File.expand_path("../../../support/shared/debian_like_host_name_examples", __FILE__)
+require_relative "../../../../base"
+require_relative "../../support/shared/debian_like_host_name_examples"
 
 describe "VagrantPlugins::GuestDebian::Cap::ChangeHostName" do
   let(:described_class) do
-    VagrantPlugins::GuestDebian::Plugin.components.guest_capabilities[:debian].get(:change_host_name)
+    VagrantPlugins::GuestDebian::Plugin
+      .components
+      .guest_capabilities[:debian]
+      .get(:change_host_name)
   end
+
   let(:machine) { double("machine") }
   let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
   let(:old_hostname) { 'oldhostname.olddomain.tld' }

--- a/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
@@ -1,0 +1,50 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
+  let(:described_class) do
+    VagrantPlugins::GuestDebian::Plugin
+      .components
+      .guest_capabilities[:debian]
+      .get(:configure_networks)
+  end
+
+  let(:machine) { double("machine") }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  after do
+    communicator.verify_expectations!
+  end
+
+  describe ".configure_networks" do
+    let(:network_0) do
+      {
+        interface: 0,
+        type: "dhcp",
+      }
+    end
+
+    let(:network_1) do
+      {
+        interface: 1,
+        type: "static",
+        ip: "33.33.33.10",
+        netmask: "255.255.0.0",
+        gateway: "33.33.0.1",
+      }
+    end
+
+    it "creates and starts the networks" do
+      communicator.expect_command("/sbin/ifdown eth0 2> /dev/null || true")
+      communicator.expect_command("/sbin/ip addr flush dev eth0 2> /dev/null")
+      communicator.expect_command("/sbin/ifdown eth1 2> /dev/null || true")
+      communicator.expect_command("/sbin/ip addr flush dev eth1 2> /dev/null")
+      communicator.expect_command("/sbin/ifup eth0")
+      communicator.expect_command("/sbin/ifup eth1")
+      described_class.configure_networks(machine, [network_0, network_1])
+    end
+  end
+end

--- a/test/unit/plugins/providers/docker/config_test.rb
+++ b/test/unit/plugins/providers/docker/config_test.rb
@@ -10,11 +10,15 @@ describe VagrantPlugins::DockerProvider::Config do
   let(:machine) { double("machine") }
 
   let(:build_dir) do
-    temporary_dir.tap do |dir|
-      dir.join("Dockerfile").open("w") do |f|
+    Dir.mktmpdir("vagrant-test-docker-provider-build-dir").tap do |dir|
+      File.open(File.join(dir, "Dockerfile"), "wb+") do |f|
         f.write("Hello")
       end
     end
+  end
+
+  after do
+    FileUtils.rm_rf(build_dir)
   end
 
   def assert_invalid

--- a/test/unit/plugins/pushes/atlas/push_test.rb
+++ b/test/unit/plugins/pushes/atlas/push_test.rb
@@ -125,6 +125,14 @@ describe VagrantPlugins::AtlasPush::Push do
   end
 
   describe "#uploader_path" do
+    let(:scratch) do
+      Pathname.new(Dir.mktmpdir("vagrant-test-atlas-push-upload-path"))
+    end
+
+    after do
+      FileUtils.rm_rf(scratch)
+    end
+
     it "should return the configured path if set" do
       config.uploader_path = "foo"
       expect(subject.uploader_path).to eq("foo")
@@ -141,12 +149,10 @@ describe VagrantPlugins::AtlasPush::Push do
     end
 
     it "should look up the uploader in the embedded dir if installer" do
-      dir = temporary_dir
-
       allow(Vagrant).to receive(:in_installer?).and_return(true)
-      allow(Vagrant).to receive(:installer_embedded_dir).and_return(dir.to_s)
+      allow(Vagrant).to receive(:installer_embedded_dir).and_return(scratch.to_s)
 
-      bin_path = dir.join("bin", bin)
+      bin_path = scratch.join("bin", bin)
       bin_path.dirname.mkpath
       bin_path.open("w+") { |f| f.write("hi") }
 
@@ -154,10 +160,8 @@ describe VagrantPlugins::AtlasPush::Push do
     end
 
     it "should look up the uploader in the PATH if not in the installer" do
-      dir = temporary_dir
-
       allow(Vagrant).to receive(:in_installer?).and_return(true)
-      allow(Vagrant).to receive(:installer_embedded_dir).and_return(dir.to_s)
+      allow(Vagrant).to receive(:installer_embedded_dir).and_return(scratch.to_s)
 
       expect(Vagrant::Util::Which).to receive(:which).
         with(described_class.const_get(:UPLOADER_BIN)).

--- a/test/unit/plugins/pushes/ftp/adapter_test.rb
+++ b/test/unit/plugins/pushes/ftp/adapter_test.rb
@@ -64,7 +64,7 @@ describe VagrantPlugins::FTPPush::FTPAdapter do
 
   describe "#upload" do
     before do
-      @dir = Dir.mktmpdir
+      @dir = Dir.mktmpdir("vagrant-ftp-push-adapter-upload")
       FileUtils.touch("#{@dir}/file")
     end
 

--- a/test/unit/plugins/pushes/ftp/push_test.rb
+++ b/test/unit/plugins/pushes/ftp/push_test.rb
@@ -109,7 +109,7 @@ describe VagrantPlugins::FTPPush::Push do
 
   describe "#all_files" do
     before(:all) do
-      @dir = Dir.mktmpdir
+      @dir = Dir.mktmpdir("vagrant-ftp-push-push-all-files")
 
       FileUtils.touch("#{@dir}/.hidden.rb")
       FileUtils.touch("#{@dir}/application.rb")
@@ -151,9 +151,9 @@ describe VagrantPlugins::FTPPush::Push do
     end
   end
 
-  describe "includes_files" do
+  describe "#includes_files" do
     before(:all) do
-      @dir = Dir.mktmpdir
+      @dir = Dir.mktmpdir("vagrant-ftp-push-includes-files")
 
       FileUtils.touch("#{@dir}/.hidden.rb")
       FileUtils.touch("#{@dir}/application.rb")

--- a/test/unit/plugins/pushes/ftp/push_test.rb
+++ b/test/unit/plugins/pushes/ftp/push_test.rb
@@ -41,7 +41,7 @@ describe VagrantPlugins::FTPPush::Push do
       end
       @server.start
 
-      @dir = temporary_dir
+      @dir = Dir.mktmpdir("vagrant-ftp-push")
       FileUtils.touch("#{@dir}/.hidden.rb")
       FileUtils.touch("#{@dir}/application.rb")
       FileUtils.touch("#{@dir}/config.rb")
@@ -51,6 +51,7 @@ describe VagrantPlugins::FTPPush::Push do
     end
 
     after(:all) do
+      FileUtils.rm_rf(@dir)
       @server.stop
     end
 

--- a/test/unit/support/isolated_environment.rb
+++ b/test/unit/support/isolated_environment.rb
@@ -132,8 +132,8 @@ module Unit
     # @return [Pathname] Path to the newly created box.
     def box1_file
       # Create a temporary directory to store our data we will tar up
-      td_source = Dir.mktmpdir
-      td_dest   = Dir.mktmpdir
+      td_source = Dir.mktmpdir("vagrant-box1-source")
+      td_dest   = Dir.mktmpdir("vagrant-box-1-dest")
 
       # Store the temporary directory so it is not deleted until
       # this instance is garbage collected.
@@ -177,8 +177,8 @@ module Unit
       }.merge(options[:metadata] || {})
 
       # Create a temporary directory to store our data we will tar up
-      td_source = Dir.mktmpdir
-      td_dest   = Dir.mktmpdir
+      td_source = Dir.mktmpdir("vagrant-box-2-source")
+      td_dest   = Dir.mktmpdir("vagrant-box-2-dest")
 
       # Store the temporary directory so it is not deleted until
       # this instance is garbage collected.

--- a/test/unit/support/shared/base_context.rb
+++ b/test/unit/support/shared/base_context.rb
@@ -73,19 +73,27 @@ shared_context "unit" do
   end
 
   # This creates a temporary directory and returns a {Pathname}
-  # pointing to it.
+  # pointing to it. If a block is given, the pathname is yielded and the
+  # temporary directory is removed at the end of the block.
   #
   # @return [Pathname]
   def temporary_dir
     # Create a temporary directory and append it to the instance
     # variabe so that it isn't garbage collected and deleted
-    d = Dir.mktmpdir("vagrant")
+    d = Dir.mktmpdir("vagrant-temporary-dir")
     @_temp_files ||= []
     @_temp_files << d
 
     # Return the pathname
     result = Pathname.new(Vagrant::Util::Platform.fs_real_path(d))
-    yield result if block_given?
+    if block_given?
+      begin
+        yield result
+      ensure
+        FileUtils.rm_rf(result)
+      end
+    end
+
     return result
   end
 

--- a/test/unit/vagrant/action/builtin/lock_test.rb
+++ b/test/unit/vagrant/action/builtin/lock_test.rb
@@ -4,8 +4,7 @@ describe Vagrant::Action::Builtin::Lock do
   let(:app) { lambda { |env| } }
   let(:env) { {} }
   let(:lock_path) do
-    @__lock_path = Tempfile.new("vagrant-test-lock")
-    @__lock_path.path.to_s
+    Dir::Tmpname.create("vagrant-test-lock") {}
   end
 
   let(:options) do
@@ -13,6 +12,10 @@ describe Vagrant::Action::Builtin::Lock do
       exception: Class.new(StandardError),
       path:      lock_path
     }
+  end
+
+  after do
+    File.unlink(lock_path) if File.file?(lock_path)
   end
 
   it "should require a path" do

--- a/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
@@ -13,9 +13,9 @@ describe Vagrant::Action::Builtin::MixinSyncedFolders do
     end
   end
 
-  let(:machine) do
-    data_dir = Pathname.new(Dir.mktmpdir)
+  let(:data_dir) { Pathname.new(Dir.mktmpdir("vagrant-test-mixin-synced-folders")) }
 
+  let(:machine) do
     double("machine").tap do |machine|
       allow(machine).to receive(:config).and_return(machine_config)
       allow(machine).to receive(:data_dir).and_return(data_dir)
@@ -29,6 +29,10 @@ describe Vagrant::Action::Builtin::MixinSyncedFolders do
   end
 
   let(:vm_config) { double("machine_vm_config", :allowed_synced_folder_types => nil) }
+
+  after do
+    FileUtils.rm_rf(data_dir)
+  end
 
   describe "default_synced_folder_type" do
     it "returns the usable implementation" do

--- a/test/unit/vagrant/action/builtin/synced_folder_cleanup_test.rb
+++ b/test/unit/vagrant/action/builtin/synced_folder_cleanup_test.rb
@@ -53,10 +53,14 @@ describe Vagrant::Action::Builtin::SyncedFolderCleanup do
       plugins[:nfs] = [impl(true, "nfs"), 5]
 
       env[:machine] = Object.new
-      env[:root_path] = Pathname.new(Dir.mktmpdir)
+      env[:root_path] = Pathname.new(Dir.mktmpdir("vagrant-test-synced-folder-cleanup-call"))
 
       subject.stub(plugins: plugins)
       subject.stub(synced_folders: synced_folders)
+    end
+
+    after do
+      FileUtils.rm_rf(env[:root_path])
     end
 
     it "should invoke cleanup" do

--- a/test/unit/vagrant/action/builtin/synced_folders_test.rb
+++ b/test/unit/vagrant/action/builtin/synced_folders_test.rb
@@ -41,10 +41,14 @@ describe Vagrant::Action::Builtin::SyncedFolders do
       plugins[:default] = [impl(true, "default"), 10]
       plugins[:nfs] = [impl(true, "nfs"), 5]
 
-      env[:root_path] = Pathname.new(Dir.mktmpdir)
+      env[:root_path] = Pathname.new(Dir.mktmpdir("vagrant-test-synced-folders-call"))
       subject.stub(plugins: plugins)
       subject.stub(synced_folders: synced_folders)
       allow(subject).to receive(:save_synced_folders)
+    end
+
+    after do
+      FileUtils.rm_rf(env[:root_path])
     end
 
     it "should create on the host if specified" do

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -39,8 +39,13 @@ describe Vagrant::BoxCollection, :skip_windows do
     end
 
     it 'does not raise an exception when a file appears in the boxes dir' do
-      Tempfile.new('a_file', environment.boxes_dir)
-      expect { subject.all }.to_not raise_error
+      t = Tempfile.new('a_file', environment.boxes_dir)
+      t.close
+      begin
+        expect { subject.all }.to_not raise_error
+      ensure
+        t.unlink
+      end
     end
   end
 

--- a/test/unit/vagrant/box_test.rb
+++ b/test/unit/vagrant/box_test.rb
@@ -227,7 +227,7 @@ describe Vagrant::Box, :skip_windows do
 
   context "#load_metadata" do
     let(:metadata_url) do
-      Tempfile.new("vagrant").tap do |f|
+      Tempfile.new("vagrant-test-box-test").tap do |f|
         f.write(<<-RAW)
         {
           "name": "foo",
@@ -242,6 +242,10 @@ describe Vagrant::Box, :skip_windows do
       described_class.new(
         name, provider, version, directory,
         metadata_url: metadata_url.path)
+    end
+
+    after do
+      metadata_url.unlink if metadata_url.file?
     end
 
     it "loads the url and returns the data" do

--- a/test/unit/vagrant/box_test.rb
+++ b/test/unit/vagrant/box_test.rb
@@ -290,6 +290,14 @@ describe Vagrant::Box, :skip_windows do
   end
 
   describe "repackaging" do
+    let(:scratch) { Dir.mktmpdir("vagrant-test-box-repackaging") }
+
+    let(:box_output_path) { File.join(scratch, "package.box") }
+
+    after do
+      FileUtils.rm_rf(scratch)
+    end
+
     it "should repackage the box" do
       test_file_contents = "hello, world!"
 
@@ -300,7 +308,6 @@ describe Vagrant::Box, :skip_windows do
       end
 
       # Repackage our box to some temporary directory
-      box_output_path = temporary_dir.join("package.box")
       expect(subject.repackage(box_output_path)).to be_true
 
       # Let's now add this box again under a different name, and then

--- a/test/unit/vagrant/box_test.rb
+++ b/test/unit/vagrant/box_test.rb
@@ -245,7 +245,7 @@ describe Vagrant::Box, :skip_windows do
     end
 
     after do
-      metadata_url.unlink if metadata_url.file?
+      metadata_url.unlink
     end
 
     it "loads the url and returns the data" do

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -69,14 +69,14 @@ describe Vagrant::Environment do
 
   describe "#home_path" do
     it "is set to the home path given" do
-      temporary_dir do |dir|
+      Dir.mktmpdir("vagrant-test-env-home-path-given") do |dir|
         instance = described_class.new(home_path: dir)
         expect(instance.home_path).to eq(Pathname.new(dir))
       end
     end
 
     it "is set to the environmental variable VAGRANT_HOME" do
-      temporary_dir do |dir|
+      Dir.mktmpdir("vagrant-test-env-home-env-var") do |dir|
         instance = with_temp_env("VAGRANT_HOME" => dir.to_s) do
           described_class.new
         end
@@ -99,7 +99,7 @@ describe Vagrant::Environment do
       end
 
       it "is okay if it has the current version" do
-        Dir.mktmpdir do |dir|
+        Dir.mktmpdir("vagrant-test-env-current-version") do |dir|
           Pathname.new(dir).join("setup_version").open("w") do |f|
             f.write(Vagrant::Environment::CURRENT_SETUP_VERSION)
           end
@@ -112,7 +112,7 @@ describe Vagrant::Environment do
       end
 
       it "raises an exception if the version is newer than ours" do
-        Dir.mktmpdir do |dir|
+        Dir.mktmpdir("vagrant-test-env-newer-version") do |dir|
           Pathname.new(dir).join("setup_version").open("w") do |f|
             f.write("100.5")
           end
@@ -123,7 +123,7 @@ describe Vagrant::Environment do
       end
 
       it "raises an exception if there is an unknown home directory version" do
-        Dir.mktmpdir do |dir|
+        Dir.mktmpdir("vagrant-test-env-unknown-home") do |dir|
           Pathname.new(dir).join("setup_version").open("w") do |f|
             f.write("0.7")
           end
@@ -645,7 +645,7 @@ VF
 
   describe "active machines" do
     it "should be empty if there is no root path" do
-      Dir.mktmpdir do |temp_dir|
+      Dir.mktmpdir("vagrant-test-env-no-root-path") do |temp_dir|
         instance = described_class.new(cwd: temp_dir)
         expect(instance.active_machines).to be_empty
       end
@@ -715,7 +715,7 @@ VF
 
   describe "current working directory" do
     it "is the cwd by default" do
-      Dir.mktmpdir do |temp_dir|
+      Dir.mktmpdir("vagrant-test-env-cwd-default") do |temp_dir|
         Dir.chdir(temp_dir) do
           with_temp_env("VAGRANT_CWD" => nil) do
             expect(described_class.new.cwd).to eq(Pathname.new(Dir.pwd))
@@ -725,14 +725,14 @@ VF
     end
 
     it "is set to the cwd given" do
-      Dir.mktmpdir do |directory|
+      Dir.mktmpdir("vagrant-test-env-set-cwd") do |directory|
         instance = described_class.new(cwd: directory)
         expect(instance.cwd).to eq(Pathname.new(directory))
       end
     end
 
     it "is set to the environmental variable VAGRANT_CWD" do
-      Dir.mktmpdir do |directory|
+      Dir.mktmpdir("vagrant-test-env-set-vagrant-cwd") do |directory|
         instance = with_temp_env("VAGRANT_CWD" => directory) do
           described_class.new
         end
@@ -905,7 +905,7 @@ VF
     end
 
     it "is expanded relative to the cwd" do
-      Dir.mktmpdir do |temp_dir|
+      Dir.mktmpdir("vagrant-test-env-relative-cwd") do |temp_dir|
         Dir.chdir(temp_dir) do
           instance = described_class.new(local_data_path: "foo")
           expect(instance.local_data_path).to eq(instance.cwd.join("foo"))
@@ -915,7 +915,7 @@ VF
     end
 
     it "is set to the given value" do
-      Dir.mktmpdir do |dir|
+      Dir.mktmpdir("vagrant-test-env-set-given") do |dir|
         instance = described_class.new(local_data_path: dir)
         expect(instance.local_data_path.to_s).to eq(dir)
       end
@@ -923,7 +923,7 @@ VF
 
     describe "upgrading V1 dotfiles" do
       let(:v1_dotfile_tempfile) do
-        Tempfile.new("vagrant").tap do |f|
+        Tempfile.new("vagrant-upgrade-dotfile").tap do |f|
           f.close
         end
       end
@@ -931,6 +931,10 @@ VF
       let(:v1_dotfile)          { Pathname.new(v1_dotfile_tempfile.path) }
       let(:local_data_path)     { v1_dotfile_tempfile.path }
       let(:instance) { described_class.new(local_data_path: local_data_path) }
+
+      after do
+        File.unlink(v1_dotfile_tempfile) if File.file?(v1_dotfile_template)
+      end
 
       it "should be fine if dotfile is empty" do
         v1_dotfile.open("w+") do |f|

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -933,7 +933,7 @@ VF
       let(:instance) { described_class.new(local_data_path: local_data_path) }
 
       after do
-        File.unlink(v1_dotfile) if File.file?(v1_dotfile)
+        FileUtils.rm_rf(local_data_path)
       end
 
       it "should be fine if dotfile is empty" do

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -933,7 +933,7 @@ VF
       let(:instance) { described_class.new(local_data_path: local_data_path) }
 
       after do
-        File.unlink(v1_dotfile_tempfile) if File.file?(v1_dotfile_template)
+        File.unlink(v1_dotfile) if File.file?(v1_dotfile)
       end
 
       it "should be fine if dotfile is empty" do

--- a/test/unit/vagrant/machine_index_test.rb
+++ b/test/unit/vagrant/machine_index_test.rb
@@ -9,7 +9,7 @@ require "vagrant/machine_index"
 describe Vagrant::MachineIndex do
   include_context "unit"
 
-  let(:data_dir) { temporary_dir }
+  let(:data_dir) { Dir.mktmpdir }
   let(:entry_klass) { Vagrant::MachineIndex::Entry }
 
   let(:new_entry) do
@@ -20,6 +20,10 @@ describe Vagrant::MachineIndex do
   end
 
   subject { described_class.new(data_dir) }
+
+  after do
+    FileUtils.rm_rf(data_dir)
+  end
 
   it "raises an exception if the data file is corrupt" do
     data_dir.join("index").open("w") do |f|

--- a/test/unit/vagrant/machine_index_test.rb
+++ b/test/unit/vagrant/machine_index_test.rb
@@ -9,7 +9,7 @@ require "vagrant/machine_index"
 describe Vagrant::MachineIndex do
   include_context "unit"
 
-  let(:data_dir) { Dir.mktmpdir }
+  let(:data_dir) { temporary_dir }
   let(:entry_klass) { Vagrant::MachineIndex::Entry }
 
   let(:new_entry) do

--- a/test/unit/vagrant/machine_index_test.rb
+++ b/test/unit/vagrant/machine_index_test.rb
@@ -9,7 +9,7 @@ require "vagrant/machine_index"
 describe Vagrant::MachineIndex do
   include_context "unit"
 
-  let(:data_dir) { temporary_dir }
+  let(:data_dir) { Pathname.new(Dir.mktmpdir("vagrant-test-machine-index-data-dir")) }
   let(:entry_klass) { Vagrant::MachineIndex::Entry }
 
   let(:new_entry) do

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -43,7 +43,7 @@ describe Vagrant::Machine do
   let(:instance) { new_instance }
 
   after do
-    FileUtils.rm_rf(data_dir)
+    FileUtils.rm_rf(data_dir) if data_dir
   end
 
   subject { instance }

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -28,7 +28,7 @@ describe Vagrant::Machine do
   end
 
   let(:config)   { env.vagrantfile.config }
-  let(:data_dir) { Pathname.new(Dir.mktmpdir("vagrant")) }
+  let(:data_dir) { Pathname.new(Dir.mktmpdir("vagrant-machine-data-dir")) }
   let(:env)      do
     # We need to create a Vagrantfile so that this test environment
     # has a proper root path
@@ -41,6 +41,10 @@ describe Vagrant::Machine do
   let(:test_env) { isolated_environment }
 
   let(:instance) { new_instance }
+
+  after do
+    FileUtils.rm_rf(data_dir)
+  end
 
   subject { instance }
 

--- a/test/unit/vagrant/plugin/manager_test.rb
+++ b/test/unit/vagrant/plugin/manager_test.rb
@@ -11,11 +11,7 @@ describe Vagrant::Plugin::Manager do
   include_context "unit"
 
   let(:path) do
-    f = Tempfile.new("vagrant")
-    p = f.path
-    f.close
-    f.unlink
-    Pathname.new(p)
+    Pathname.new(Dir::Tmpname.create("vagrant-test-plugin-manager") {})
   end
 
   let(:bundler) { double("bundler") }

--- a/test/unit/vagrant/plugin/state_file_test.rb
+++ b/test/unit/vagrant/plugin/state_file_test.rb
@@ -5,11 +5,7 @@ require File.expand_path("../../../base", __FILE__)
 
 describe Vagrant::Plugin::StateFile do
   let(:path) do
-    f = Tempfile.new("vagrant")
-    p = f.path
-    f.close
-    f.unlink
-    Pathname.new(p)
+    Pathname.new(Dir::Tmpname.create("vagrant-test-statefile") {})
   end
 
   after do

--- a/test/unit/vagrant/util/safe_chdir_test.rb
+++ b/test/unit/vagrant/util/safe_chdir_test.rb
@@ -5,10 +5,17 @@ require File.expand_path("../../../base", __FILE__)
 require 'vagrant/util/safe_chdir'
 
 describe Vagrant::Util::SafeChdir do
+  let(:temp_dir) { Dir.mktmpdir("vagrant-test-util-safe-chdir") }
+  let(:temp_dir2) { Dir.mktmpdir("vagrant-test-util-safe-chdir-2") }
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+    FileUtils.rm_rf(temp_dir2)
+  end
+
   it "should change directories" do
     expected = nil
     result   = nil
-    temp_dir = Dir.mktmpdir
 
     Dir.chdir(temp_dir) do
       expected = Dir.pwd
@@ -24,15 +31,14 @@ describe Vagrant::Util::SafeChdir do
   it "should allow recursive chdir" do
     expected  = nil
     result    = nil
-    temp_path = Dir.mktmpdir
 
-    Dir.chdir(temp_path) do
+    Dir.chdir(temp_dir) do
       expected = Dir.pwd
     end
 
     expect do
-      described_class.safe_chdir(Dir.mktmpdir) do
-        described_class.safe_chdir(temp_path) do
+      described_class.safe_chdir(temp_dir2) do
+        described_class.safe_chdir(temp_dir) do
           result = Dir.pwd
         end
       end

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -58,7 +58,7 @@ describe Vagrant::Vagrantfile do
 
   describe "#machine" do
     let(:boxes) { Vagrant::BoxCollection.new(iso_env.boxes_dir) }
-    let(:data_path) { Pathname.new(Dir.mktmpdir) }
+    let(:data_path) { Pathname.new(Dir.mktmpdir("vagrant-machine-data-path")) }
     let(:env)   { iso_env.create_vagrant_env }
     let(:iso_env) { isolated_environment }
     let(:vagrantfile) { described_class.new(loader, keys) }
@@ -84,6 +84,10 @@ describe Vagrant::Vagrantfile do
         config.ssh.port = 123
       end
       VF
+    end
+
+    after do
+      FileUtils.rm_rf(data_path.to_s)
     end
 
     describe '#data_dir' do


### PR DESCRIPTION
Individual commit messages have more detailed information, but as a high-level overview:

1. Uniquely name every tempfile and tempdir we create in Vagrant. This will help better identify leaks in the future.
1. Attempt to cleanup tempfiles and tempdirs (created a utility class to wrap this logic) - many leaks still exist in tests because of `isolated_environment` not having a cleanup hook
1. Use `Dir::Tmpname.create` when we just need a filepath instead of creating Tempfile that we immediately delete. Tempfile calls this function under the hood, and we save the additional overhead of writing and deleting a file.