### PR TITLE
Add --box-version to `vagrant init`

### DIFF
--- a/plugins/commands/init/command.rb
+++ b/plugins/commands/init/command.rb
@@ -22,6 +22,10 @@ module VagrantPlugins
           o.separator "Options:"
           o.separator ""
 
+          o.on("--box-version VERSION", "Version of the box to add") do |f|
+            options[:box_version] = f
+          end
+
           o.on("-f", "--force", "Overwrite existing Vagrantfile") do |f|
             options[:force] = f
           end
@@ -54,8 +58,10 @@ module VagrantPlugins
 
         template_path = ::Vagrant.source_root.join(template)
         contents = Vagrant::Util::TemplateRenderer.render(template_path,
-                                                          box_name: argv[0] || "base",
-                                                          box_url: argv[1])
+          box_name: argv[0] || "base",
+          box_url: argv[1],
+          box_version: options[:box_version],
+        )
 
         if save_path
           # Write out the contents

--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -13,6 +13,9 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "<%= box_name %>"
+  <% if box_version -%>
+  config.vm.box_version = "<%= box_version %>"
+  <% end -%>
 
   <% if box_url -%>
   # The url from where the 'config.vm.box' box will be fetched if it

--- a/test/unit/plugins/commands/init/command_test.rb
+++ b/test/unit/plugins/commands/init/command_test.rb
@@ -1,0 +1,86 @@
+require_relative "../../../base"
+require_relative "../../../../../plugins/commands/init/command"
+
+describe VagrantPlugins::CommandInit::Command do
+  include_context "unit"
+  include_context "command plugin helpers"
+
+  let(:iso_env) do
+    isolated_environment
+  end
+
+  let(:env) do
+    iso_env.create_vagrant_env
+  end
+
+  let(:vagrantfile_path) { File.join(env.cwd, "Vagrantfile") }
+
+  before do
+    Vagrant.plugin("2").manager.stub(commands: {})
+  end
+
+  after do
+    iso_env.close
+  end
+
+  describe "#execute" do
+    it "creates a Vagrantfile with no args" do
+      described_class.new([], env).execute
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.box = "base"/)
+    end
+
+    it "creates a minimal Vagrantfile" do
+      described_class.new(["-m"], env).execute
+      contents = File.read(vagrantfile_path)
+      expect(contents).to_not match(/#/)
+      expect(contents).to_not match(/provision/)
+    end
+
+    it "does not overwrite an existing Vagrantfile" do
+      # Create an existing Vagrantfile
+      File.open(File.join(env.cwd, "Vagrantfile"), "w+") { |f| f.write("") }
+
+      expect {
+        described_class.new([], env).execute
+      }.to raise_error(Vagrant::Errors::VagrantfileExistsError)
+    end
+
+    it "overwrites an existing Vagrantfile with force" do
+      # Create an existing Vagrantfile
+      File.open(File.join(env.cwd, "Vagrantfile"), "w+") { |f| f.write("") }
+
+      expect {
+        described_class.new(["-f"], env).execute
+      }.to_not raise_error
+
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.box = "base"/)
+    end
+
+    it "creates a Vagrantfile with a box" do
+      described_class.new(["hashicorp/precise64"], env).execute
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.box = "hashicorp\/precise64"/)
+    end
+
+    it "creates a Vagrantfile with a box and box_url" do
+      described_class.new(["hashicorp/precise64", "http://mybox.com"], env).execute
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.box = "hashicorp\/precise64"/)
+      expect(contents).to match(/config.vm.box_url = "http:\/\/mybox.com"/)
+    end
+
+    it "creates a Vagrantfile with a box and box version" do
+      described_class.new(["--box-version", "1.2.3", "hashicorp/precise64"], env).execute
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.box = "hashicorp\/precise64"/)
+      expect(contents).to match(/config.vm.box_version = "1.2.3"/)
+    end
+
+    it "creates a Vagrantfile at a custom path" do
+      described_class.new(["--output", "vf.rb"], env).execute
+      expect(File.exist?(File.join(env.cwd, "vf.rb"))).to be(true)
+    end
+  end
+end

--- a/website/source/docs/cli/init.html.md
+++ b/website/source/docs/cli/init.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # Init
 
-**Command: `vagrant init [box-name] [box-url]`**
+**Command: `vagrant init [name [url]]`**
 
 This initializes the current directory to be a Vagrant environment
 by creating an initial [Vagrantfile](/docs/vagrantfile/) if
@@ -23,6 +23,9 @@ setting in the created Vagrantfile.
 
 ## Options
 
+* `--box-version` - (Optional) The box version or box version constraint to add
+  to the `Vagrantfile`.
+
 * `--force` - If specified, this command will overwite any existing
   `Vagrantfile`.
 
@@ -32,3 +35,35 @@ setting in the created Vagrantfile.
 
 * `--output FILE` - This will output the Vagrantfile to the given file.
   If this is "-", the Vagrantfile will be sent to stdout.
+
+## Examples
+
+Create a base Vagrantfile:
+
+```sh
+$ vagrant init hashicorp/precise64
+```
+
+Create a minimal Vagrantfile (no comments or helpers):
+
+```sh
+$ vagrant init -m hashicorp/precise64
+```
+
+Create a new Vagrantfile, overwriting the one at the current path:
+
+```sh
+$ vagrant init -f hashicorp/precise64
+```
+
+Create a Vagrantfile with the specific box, from the specific box URL:
+
+```sh
+$ vagrant init my-company-box https://boxes.company.com/my-company.box
+```
+
+Create a Vagrantfile, locking the box to a version constraint:
+
+```sh
+$ vagrant init --box-version '> 0.1.5' hashcorp/precise64
+```


### PR DESCRIPTION
This also adds a test suite for that particular command, updates the documentation, and adds some examples.

Fixes GH-5004