### PR TITLE
Make virtualbox vm_exists? more resilient to VirtualBox transient failures

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -661,9 +661,9 @@ module VagrantPlugins
             result = raw("showvminfo", uuid)
             return true if result.exit_code == 0
 
-            # GH-2479: Sometimes this happens. In this case, retry. If
-            # we don't see this text, the VM really probably doesn't exist.
-            return false if !result.stderr.include?("CO_E_SERVER_EXEC_FAILURE")
+            # If vboxmanage returned VBOX_E_OBJECT_NOT_FOUND,
+            # then the vm truly does not exist. Any other error might be transient
+            return false if result.stderr.include?("VBOX_E_OBJECT_NOT_FOUND")
 
             # Sleep a bit though to give VirtualBox time to fix itself
             sleep 2

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -594,9 +594,9 @@ module VagrantPlugins
             result = raw("showvminfo", uuid)
             return true if result.exit_code == 0
 
-            # GH-2479: Sometimes this happens. In this case, retry. If
-            # we don't see this text, the VM really probably doesn't exist.
-            return false if !result.stderr.include?("CO_E_SERVER_EXEC_FAILURE")
+            # If vboxmanage returned VBOX_E_OBJECT_NOT_FOUND,
+            # then the vm truly does not exist. Any other error might be transient
+            return false if result.stderr.include?("VBOX_E_OBJECT_NOT_FOUND")
 
             # Sleep a bit though to give VirtualBox time to fix itself
             sleep 2

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -701,9 +701,9 @@ module VagrantPlugins
             result = raw("showvminfo", uuid)
             return true if result.exit_code == 0
 
-            # GH-2479: Sometimes this happens. In this case, retry. If
-            # we don't see this text, the VM really probably doesn't exist.
-            return false if !result.stderr.include?("CO_E_SERVER_EXEC_FAILURE")
+            # If vboxmanage returned VBOX_E_OBJECT_NOT_FOUND,
+            # then the vm truly does not exist. Any other error might be transient
+            return false if result.stderr.include?("VBOX_E_OBJECT_NOT_FOUND")
 
             # Sleep a bit though to give VirtualBox time to fix itself
             sleep 2

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -702,9 +702,9 @@ module VagrantPlugins
             result = raw("showvminfo", uuid)
             return true if result.exit_code == 0
 
-            # GH-2479: Sometimes this happens. In this case, retry. If
-            # we don't see this text, the VM really probably doesn't exist.
-            return false if !result.stderr.include?("CO_E_SERVER_EXEC_FAILURE")
+            # If vboxmanage returned VBOX_E_OBJECT_NOT_FOUND,
+            # then the vm truly does not exist. Any other error might be transient
+            return false if result.stderr.include?("VBOX_E_OBJECT_NOT_FOUND")
 
             # Sleep a bit though to give VirtualBox time to fix itself
             sleep 2


### PR DESCRIPTION
It seems that multiple parallel calls to `vboxmanage showvminfo` for the same VM can cause VBoxManage to fail with this type of error:
```
VBoxManage.exe: error: The object is not ready
VBoxManage.exe: error: Details: code E_ACCESSDENIED (0x80070005), component SessionMachine, interface IMachine, callee IUnknown
VBoxManage.exe: error: Context: "get_Groups((array).__asOutParam())" at line 513 of file VBoxManageInfo.cpp
```
(I am getting this on a Windows 10 host with VirtualBox 5.)

This can in turn cause `vm_exists?` to return false even though the VM might actually exist...

I propose that in order to detect missing VM, we look for `VBOX_E_OBJECT_NOT_FOUND` in the VBoxManage output and keep retrying when we get any other type of error.

This should make the fix to #2479 more resilient.