### PR TITLE
Improving resilience of some VirtualBox commands.

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -422,8 +422,15 @@ module VagrantPlugins
               # Ignore our own used ports
               next if uuid == @uuid
 
-              read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
-                ports << hostport
+              begin
+                read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
+                  ports << hostport
+                end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -85,11 +85,18 @@ module VagrantPlugins
 
           execute("list", "vms").split("\n").each do |line|
             if vm_name = line[/^".+?"\s+\{(.+?)\}$/, 1]
-              info = execute("showvminfo", vm_name, "--machinereadable", retryable: true)
-              info.split("\n").each do |line|
-                if network_name = line[/^hostonlyadapter\d+="(.+?)"$/, 1]
-                  networks.delete(network_name)
+              begin
+                info = execute("showvminfo", vm_name, "--machinereadable", retryable: true)
+                info.split("\n").each do |line|
+                  if network_name = line[/^hostonlyadapter\d+="(.+?)"$/, 1]
+                    networks.delete(network_name)
+                  end
                 end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -525,8 +525,15 @@ module VagrantPlugins
               # Ignore our own used ports
               next if uuid == @uuid
 
-              read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
-                ports << hostport
+              begin
+                read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
+                  ports << hostport
+                end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -458,8 +458,15 @@ module VagrantPlugins
               # Ignore our own used ports
               next if uuid == @uuid
 
-              read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
-                ports << hostport
+              begin
+                read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
+                  ports << hostport
+                end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -83,11 +83,18 @@ module VagrantPlugins
 
           execute("list", "vms").split("\n").each do |line|
             if line =~ /^".+?"\s+\{(.+?)\}$/
-              info = execute("showvminfo", $1.to_s, "--machinereadable", retryable: true)
-              info.split("\n").each do |inner_line|
-                if inner_line =~ /^hostonlyadapter\d+="(.+?)"$/
-                  networks.delete($1.to_s)
+              begin
+                info = execute("showvminfo", $1.to_s, "--machinereadable", retryable: true)
+                info.split("\n").each do |inner_line|
+                  if inner_line =~ /^hostonlyadapter\d+="(.+?)"$/
+                    networks.delete($1.to_s)
+                  end
                 end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -569,8 +569,15 @@ module VagrantPlugins
               # Ignore our own used ports
               next if uuid == @uuid
 
-              read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
-                ports << hostport
+              begin
+                read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
+                  ports << hostport
+                end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -180,11 +180,18 @@ module VagrantPlugins
 
           execute("list", "vms", retryable: true).split("\n").each do |line|
             if line =~ /^".+?"\s+\{(.+?)\}$/
-              info = execute("showvminfo", $1.to_s, "--machinereadable", retryable: true)
-              info.split("\n").each do |inner_line|
-                if inner_line =~ /^hostonlyadapter\d+="(.+?)"$/
-                  networks.delete($1.to_s)
+              begin
+                info = execute("showvminfo", $1.to_s, "--machinereadable", retryable: true)
+                info.split("\n").each do |inner_line|
+                  if inner_line =~ /^hostonlyadapter\d+="(.+?)"$/
+                    networks.delete($1.to_s)
+                  end
                 end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -565,8 +565,15 @@ module VagrantPlugins
               # Ignore our own used ports
               next if uuid == @uuid
 
-              read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
-                ports << hostport
+              begin
+                read_forwarded_ports(uuid, true).each do |_, _, hostport, _|
+                  ports << hostport
+                end
+              rescue Vagrant::Errors::VBoxManageError => e
+                raise if !e.extra_data[:stderr].include?("VBOX_E_OBJECT_NOT_FOUND")
+
+                # VirtualBox could not find the vm. It may have been deleted
+                # by another process after we called 'vboxmanage list vms'? Ignore this error.
               end
             end
           end


### PR DESCRIPTION
These changes are an attempt at reducing the number of race conditions we seem to be getting when running multiple vagrant environments using virtualbox on the same host machine.

The `read_used_ports` and `delete_unused_host_only_networks` functions use VBoxManage to retrieve a list of VMs and call `vboxmanage showvminfo` on each of them.

A call to `vboxmanage showvminfo` will fail if the VM has just been deleted by a different vagrant process.

Shall we just swallow any VBoxManage error that contain `VBOX_E_OBJECT_NOT_FOUND` (as this is likely to mean that the VM is gone and we shouldn't have to worry about it any more)?
