### PR TITLE
Don't restore Gem::Specification.all if it's not being replaced

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -271,7 +271,6 @@ module Vagrant
       Gem.paths = ENV
 
       # Reset the all specs override that Bundler does
-      old_all = Gem::Specification._all
       Gem::Specification.reset
 
       # /etc/gemrc and so on.
@@ -299,7 +298,6 @@ module Vagrant
 
       Gem.configuration = old_config
       Gem.paths = ENV
-      Gem::Specification.all = old_all
     end
 
     # This method returns a proper "tempfile" on disk. Ruby's Tempfile class


### PR DESCRIPTION
Revert 3f9fb2ef03a78bc9177a52d4629a5e80e6e42b2e from GH-2769

- For compatibility with ba77d4b533e449fa610531a7832b8fd1837eb9db

Fixes GH-7073