### PR TITLE
VirtualBox provider: Extension to allow disk resizing on VM import

### DIFF
--- a/plugins/providers/virtualbox/action/customize.rb
+++ b/plugins/providers/virtualbox/action/customize.rb
@@ -22,6 +22,21 @@ module VagrantPlugins
             customizations.each do |command|
               processed_command = command.collect do |arg|
                 arg = env[:machine].id if arg == :id
+
+                if arg =~ /^disk(\d+)$/
+                  disk_id = $1.to_i
+                  disks = env[:machine].provider.driver.read_disks
+
+                  if not disks or disk_id >= disks.size
+                    raise Vagrant::Errors::VMCustomizationFailed, {
+                      command: "Discovering UUID for the specified disk",
+                      error:   "Disk with index #{disk_id} does not exist"
+                    }
+                  end
+
+                  arg = disks[disk_id]
+                end
+
                 arg.to_s
               end
 

--- a/plugins/providers/virtualbox/action/import.rb
+++ b/plugins/providers/virtualbox/action/import.rb
@@ -50,7 +50,7 @@ module VagrantPlugins
 
           # Import the virtual machine
           ovf_file = env[:machine].box.directory.join("box.ovf").to_s
-          id = env[:machine].provider.driver.import(ovf_file) do |progress|
+          id = env[:machine].provider.driver.import(ovf_file, env[:machine].provider_config.use_vdi) do |progress|
             env[:ui].clear_line
             env[:ui].report_progress(progress, 100, false)
           end

--- a/plugins/providers/virtualbox/config.rb
+++ b/plugins/providers/virtualbox/config.rb
@@ -64,6 +64,11 @@ module VagrantPlugins
       # @return [Hash]
       attr_reader :network_adapters
 
+      # Import machine using vdi disks
+      #
+      # @return [Boolean]
+      attr_accessor :use_vdi
+
       def initialize
         @auto_nat_dns_proxy = UNSET_VALUE
         @check_guest_additions = UNSET_VALUE
@@ -75,6 +80,7 @@ module VagrantPlugins
         @gui              = UNSET_VALUE
         @linked_clone = UNSET_VALUE
         @linked_clone_snapshot = UNSET_VALUE
+        @use_vdi = UNSET_VALUE
 
         # We require that network adapter 1 is a NAT device.
         network_adapter(1, :nat)
@@ -147,6 +153,10 @@ module VagrantPlugins
 
         if @functional_vboxsf == UNSET_VALUE
           @functional_vboxsf = true
+        end
+
+        if @use_vdi == UNSET_VALUE
+          @use_vdi = false
         end
 
         # Default is to not show a GUI

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -266,6 +266,12 @@ module VagrantPlugins
         def read_state
         end
 
+        # Return the array of disk UUID associated with this VM.
+        #
+        # @return [Array]
+        def read_disks
+        end
+
         # Returns a list of all forwarded ports in use by active
         # virtual machines.
         #

--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -123,6 +123,7 @@ module VagrantPlugins
           :read_machine_folder,
           :read_network_interfaces,
           :read_state,
+          :read_disks,
           :read_used_ports,
           :read_vms,
           :reconfig_host_only,

--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -166,7 +166,7 @@ module VagrantPlugins
           execute("controlvm", @uuid, "poweroff")
         end
 
-        def import(ovf)
+        def import(ovf, use_vdi)
           ovf = Vagrant::Util::Platform.cygwin_windows_path(ovf)
 
           output = ""

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -269,7 +269,7 @@ module VagrantPlugins
           execute("controlvm", @uuid, "poweroff")
         end
 
-        def import(ovf)
+        def import(ovf, use_vdi)
           ovf = Vagrant::Util::Platform.cygwin_windows_path(ovf)
 
           output = ""

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -169,7 +169,7 @@ module VagrantPlugins
           execute("controlvm", @uuid, "poweroff")
         end
 
-        def import(ovf)
+        def import(ovf, use_vdi)
           ovf = Vagrant::Util::Platform.cygwin_windows_path(ovf)
 
           output = ""

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -273,7 +273,7 @@ module VagrantPlugins
           execute("controlvm", @uuid, "poweroff")
         end
 
-        def import(ovf)
+        def import(ovf, use_vdi)
           ovf = Vagrant::Util::Platform.cygwin_windows_path(ovf)
 
           output = ""

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -269,7 +269,7 @@ module VagrantPlugins
           execute("controlvm", @uuid, "poweroff")
         end
 
-        def import(ovf)
+        def import(ovf, use_vdi)
           ovf = Vagrant::Util::Platform.cygwin_windows_path(ovf)
 
           output = ""
@@ -278,7 +278,11 @@ module VagrantPlugins
 
           # Dry-run the import to get the suggested name and path
           @logger.debug("Doing dry-run import to determine parallel-safe name...")
-          output = execute("import", "-n", ovf)
+          cmd = ["import", "-n", ovf]
+          if use_vdi
+            cmd = ["import", "-n", "--options", "importtovdi", ovf]
+          end
+          output = execute(*cmd)
           result = /Suggested VM name "(.+?)"/.match(output)
           if !result
             raise Vagrant::Errors::VirtualBoxNoName, output: output
@@ -554,6 +558,18 @@ module VagrantPlugins
           end
 
           nil
+        end
+
+        def read_disks
+          disks = [].tap do |d|
+            execute("showvminfo", @uuid, "--machinereadable", retryable: true).split("\n").each do |line|
+              if line =~ /^.+-ImageUUID-.+="(.+?)"$/
+                d.push($1.to_s)
+              end
+            end
+          end
+
+          disks
         end
 
         def read_used_ports

--- a/plugins/providers/virtualbox/driver/version_5_1.rb
+++ b/plugins/providers/virtualbox/driver/version_5_1.rb
@@ -269,7 +269,7 @@ module VagrantPlugins
           execute("controlvm", @uuid, "poweroff")
         end
 
-        def import(ovf)
+        def import(ovf, use_vdi)
           ovf = Vagrant::Util::Platform.cygwin_windows_path(ovf)
 
           output = ""
@@ -278,7 +278,11 @@ module VagrantPlugins
 
           # Dry-run the import to get the suggested name and path
           @logger.debug("Doing dry-run import to determine parallel-safe name...")
-          output = execute("import", "-n", ovf)
+          cmd = ["import", "-n", ovf]
+          if use_vdi
+            cmd = ["import", "-n", "--options", "importtovdi", ovf]
+          end
+          output = execute(*cmd)
           result = /Suggested VM name "(.+?)"/.match(output)
           if !result
             raise Vagrant::Errors::VirtualBoxNoName, output: output
@@ -554,6 +558,18 @@ module VagrantPlugins
           end
 
           nil
+        end
+
+        def read_disks
+          disks = [].tap do |d|
+            execute("showvminfo", @uuid, "--machinereadable", retryable: true).split("\n").each do |line|
+              if line =~ /^.+-ImageUUID-.+="(.+?)"$/
+                d.push($1.to_s)
+              end
+            end
+          end
+
+          disks
         end
 
         def read_used_ports


### PR DESCRIPTION
The extension consists of two parts:
- allow VM import using `--options importtovdi` option
- enable substitution of :diskN (e.g., :disk0) during VM customization
  with UUID of the Nth disk associated with the VM

Example:

```
config.vm.provider "virtualbox" do |v|
  v.use_vdi = true
  v.customize 'pre-boot', ['modifyhd', :disk0, '--resize', '30000']
end
```
