### PR TITLE
core/boxes: Do not update the same box twice

### DIFF
--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -86,6 +86,8 @@ module VagrantPlugins
         end
 
         def update_vms(argv, provider, download_options)
+          machines = {}
+
           with_target_vms(argv, provider: provider) do |machine|
             if !machine.config.vm.box
               machine.ui.output(I18n.t(
@@ -100,6 +102,14 @@ module VagrantPlugins
               next
             end
 
+            name     = machine.box.name
+            provider = machine.box.provider
+            version  = machine.config.vm.box_version || machine.box.version
+
+            machines["#{name}_#{provider}_#{version}"] = machine
+          end
+
+          machines.each do |_, machine|
             box = machine.box
             version = machine.config.vm.box_version
             # Get download options from machine configuration if not specified


### PR DESCRIPTION
Vagrant's environment (which includes the known list of boxes and versions) is established at the start of the Vagrant run. This means that box downloads which occur during the run are not contained in the
set until the next run. This causes duplicate box downloads to raise an error in multi-machine Vagrantfiles.

This commit fixes that issue by pre-processing the machines by provider and version, creating a unique set of boxes to update.

Fixes GH-6042