### PR TITLE
Added box_download_proxy

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -414,6 +414,7 @@ module Vagrant
           downloader_options[:headers] = ["Accept: application/json"] if opts[:json]
           downloader_options[:ui] = env[:ui] if opts[:ui]
           downloader_options[:location_trusted] = env[:box_download_location_trusted]
+          downloader_options[:proxy] = env[:box_download_proxy]
 
           Util::Downloader.new(url, temp_path, downloader_options)
         end

--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -45,7 +45,8 @@ module Vagrant
             client_cert: env[:client_cert] ||
                            machine.config.vm.box_download_client_cert,
             insecure: !env[:insecure].nil? ?
-                        env[:insecure] : machine.config.vm.box_download_insecure
+                        env[:insecure] : machine.config.vm.box_download_insecure,
+            proxy: machine.config.vm.box_download_proxy
           }
 
           env[:ui].output(I18n.t(

--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -67,6 +67,7 @@ module Vagrant
           box_download_checksum_type = machine.config.vm.box_download_checksum_type
           box_download_checksum = machine.config.vm.box_download_checksum
           box_download_location_trusted = machine.config.vm.box_download_location_trusted
+          box_download_proxy = machine.config.vm.box_download_proxy
           box_formats = machine.provider_options[:box_format] ||
             machine.provider_name
 
@@ -92,6 +93,7 @@ module Vagrant
               box_checksum_type: box_download_checksum_type,
               box_checksum: box_download_checksum,
               box_download_location_trusted: box_download_location_trusted,
+              box_download_proxy: box_download_proxy,
             }))
           rescue Errors::BoxAlreadyExists
             # Just ignore this, since it means the next part will succeed!

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -52,6 +52,7 @@ module Vagrant
         @ui          = options[:ui]
         @client_cert = options[:client_cert]
         @location_trusted = options[:location_trusted]
+        @proxy       = options[:proxy]
       end
 
       # This executes the actual download, downloading the source file
@@ -231,6 +232,7 @@ module Vagrant
         options << "--cert" << @client_cert if @client_cert
         options << "-u" << @auth if @auth
         options << "--location-trusted" if @location_trusted
+        options += ["--proxy", @proxy] if @proxy
 
         if @headers
           Array(@headers).each do |header|

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -89,6 +89,7 @@ module VagrantPlugins
             box_client_cert: options[:client_cert],
             box_download_insecure: options[:insecure],
             box_download_location_trusted: options[:location_trusted],
+            box_download_proxy: options[:proxy],
             ui: Vagrant::UI::Prefixed.new(@env.ui, "box"),
           })
 

--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -110,6 +110,9 @@ module VagrantPlugins
             if download_options[:insecure].nil?
               download_options[:insecure] = machine.config.vm.box_download_insecure
             end
+            if download_options[:proxy].nil?
+                download_options[:proxy] = machine.config.vm.box_download_proxy
+            end
             box_update(box, version, machine.ui, download_options)
           end
         end
@@ -142,7 +145,8 @@ module VagrantPlugins
             box_client_cert: download_options[:client_cert],
             box_download_ca_cert: download_options[:ca_cert],
             box_download_ca_path: download_options[:ca_path],
-            box_download_insecure: download_options[:insecure]
+            box_download_insecure: download_options[:insecure],
+            box_download_proxy: download_options[:proxy]
           })
         end
       end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -29,6 +29,7 @@ module VagrantPlugins
       attr_accessor :box_download_client_cert
       attr_accessor :box_download_insecure
       attr_accessor :box_download_location_trusted
+      attr_accessor :box_download_proxy
       attr_accessor :communicator
       attr_accessor :graceful_halt_timeout
       attr_accessor :guest
@@ -55,6 +56,7 @@ module VagrantPlugins
         @box_download_client_cert      = UNSET_VALUE
         @box_download_insecure         = UNSET_VALUE
         @box_download_location_trusted = UNSET_VALUE
+        @box_download_proxy            = UNSET_VALUE
         @box_url                       = UNSET_VALUE
         @box_version                   = UNSET_VALUE
         @clone                         = UNSET_VALUE
@@ -369,6 +371,7 @@ module VagrantPlugins
         @box_download_client_cert = nil if @box_download_client_cert == UNSET_VALUE
         @box_download_insecure = false if @box_download_insecure == UNSET_VALUE
         @box_download_location_trusted = false if @box_download_location_trusted == UNSET_VALUE
+        @box_download_proxy = nil if @box_download_proxy == UNSET_VALUE
         @box_url = nil if @box_url == UNSET_VALUE
         @box_version = nil if @box_version == UNSET_VALUE
         @clone = nil if @clone == UNSET_VALUE

--- a/test/unit/plugins/commands/box/command/update_test.rb
+++ b/test/unit/plugins/commands/box/command/update_test.rb
@@ -101,6 +101,7 @@ describe VagrantPlugins::CommandBox::Command::Update do
             expect(opts[:box_download_ca_cert]).to be_nil
             expect(opts[:box_client_cert]).to be_nil
             expect(opts[:box_download_insecure]).to be_nil
+            expect(opts[:box_download_proxy]).to be_nil
           end
 
           opts
@@ -254,7 +255,8 @@ describe VagrantPlugins::CommandBox::Command::Update do
           with(machine.config.vm.box_version,
                {download_options:
                  {ca_cert: nil, ca_path: nil, client_cert: nil,
-                  insecure: false}}).
+                  insecure: false,
+                  proxy: nil}}).
           and_return(nil)
 
         expect(action_runner).to receive(:run).never
@@ -292,7 +294,8 @@ describe VagrantPlugins::CommandBox::Command::Update do
             with(machine.config.vm.box_version,
                  {download_options:
                    {ca_cert: nil, ca_path: nil, client_cert: nil,
-                    insecure: false}}).
+                    insecure: false,
+                    proxy: nil}}).
             and_return([md, md.version("1.1"), md.version("1.1").provider("virtualbox")])
 
           expect(action_runner).to receive(:run).with { |action, opts|
@@ -319,7 +322,8 @@ describe VagrantPlugins::CommandBox::Command::Update do
               with(machine.config.vm.box_version,
                    {download_options:
                      {ca_cert: "oof", ca_path: "rab", client_cert: "zab",
-                      insecure: false}}).
+                      insecure: false,
+                      proxy: nil}}).
               and_return([md, md.version("1.1"), md.version("1.1").provider("virtualbox")])
 
             expect(action_runner).to receive(:run).with { |action, opts|
@@ -341,7 +345,8 @@ describe VagrantPlugins::CommandBox::Command::Update do
                 with(machine.config.vm.box_version,
                      {download_options:
                        {ca_cert: "foo", ca_path: "bar", client_cert: "baz",
-                        insecure: true}}).
+                        insecure: true,
+                        proxy: nil}}).
                 and_return([md, md.version("1.1"),
                             md.version("1.1").provider("virtualbox")])
 

--- a/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
+++ b/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
@@ -119,7 +119,7 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
 
       expect(box).to receive(:has_update?).with(machine.config.vm.box_version,
           {download_options:
-            {ca_cert: nil, ca_path: nil, client_cert: nil, insecure: false}}).
+            {ca_cert: nil, ca_path: nil, client_cert: nil, insecure: false, proxy: nil}}).
         and_return([md, md.version("1.1"), md.version("1.1").provider("virtualbox")])
 
       expect(app).to receive(:call).with(env).once
@@ -194,7 +194,7 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
       it "uses download options from machine" do
         expect(box).to receive(:has_update?).with(machine.config.vm.box_version,
           {download_options:
-            {ca_cert: "foo", ca_path: "bar", client_cert: "baz", insecure: true}})
+            {ca_cert: "foo", ca_path: "bar", client_cert: "baz", insecure: true, proxy: nil}})
 
         expect(app).to receive(:call).with(env).once
 
@@ -204,7 +204,7 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
       it "overrides download options from machine with options from env" do
         expect(box).to receive(:has_update?).with(machine.config.vm.box_version,
           {download_options:
-            {ca_cert: "oof", ca_path: "rab", client_cert: "zab", insecure: false}})
+            {ca_cert: "oof", ca_path: "rab", client_cert: "zab", insecure: false, proxy: nil}})
 
         env[:ca_cert] = "oof"
         env[:ca_path] = "rab"

--- a/website/source/docs/vagrantfile/machine_settings.html.md
+++ b/website/source/docs/vagrantfile/machine_settings.html.md
@@ -79,6 +79,10 @@ from the server will not be verified. By default, if the URL is an HTTPS
 URL, then SSL certs will be verified.
 
 <hr>
+`config.vm.box_download_proxy` - The HTTP proxy to use. If not specified,
+the environment variables `http_proxy` or `https_proxy` would be used instead.
+
+<hr>
 
 `config.vm.box_download_location_trusted` - If true, then all HTTP redirects will be
 treated as trusted. That means credentials used for initial URL will be used for


### PR DESCRIPTION
You have to set your environmental variables `http_proxy` or `https_proxy` correctly when using vagrant behind a proxy, which makes your `Vagrantfile` not self-sufficient. Commands like `vagrant up` will check if the box is up-to-date, failing potentially in unfriendly ways if the proxy environment variables are not set correctly (in my case it would take 60s to time-out before continuing...). And managing your environment variables gets messy when you have to use different proxies for different domains.
This pull request only attempts to solve the proxy problems when downloading boxes, a new configuration option `box_download_proxy` would allow you to specify the proxy to use when downloading a box or when checking for updates.
