### PR TITLE
Require "vagrant/util/presence" in package action

### DIFF
--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -3,6 +3,7 @@ require "pathname"
 
 require 'vagrant/util/safe_chdir'
 require 'vagrant/util/subprocess'
+require 'vagrant/util/presence'
 
 module Vagrant
   module Action


### PR DESCRIPTION
This is a hotfix for the issue introduced by GH-7353

It fixes the following error (reproduced with acceptance test in [vagrant-parallels](https://github.com/Parallels/vagrant-parallels) plugin):

```
...
Failures:

  1) provider/parallels/package it should behave like provider/package with a running machine can package and bring the box back up
     Failure/Error: expect(execute('vagrant', 'package')).to exit_with(0)
       expected command to exit with 0 but got exit code: 1

       stdout: You appear to be running Vagrant outside of the official installers.
       Note that the installers are what ensure that Vagrant has all required
       dependencies, and Vagrant assumes that these dependencies exist. By
       running outside of the installer environment, Vagrant may not function
       properly. To remove this warning, install Vagrant using one of the
       official packages from vagrantup.com.
       ==> default: Attempting graceful shutdown of VM...


       stderr: /Users/legal/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/bundler/gems/vagrant-06a12097b1bd/lib/vagrant/action/general/package.rb:44:in `validate!': uninitialized constant Vagrant::Util::Presence (NameError)
       	from /Users/legal/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/bundler/gems/vagrant-06a12097b1bd/lib/vagrant/action/general/package.rb:73:in `call'
       	from /Users/legal/Documents/vagrant-parallels/lib/vagrant-parallels/action/package.rb:23:in `call'
```

cc: @sethvargo 