### PR TITLE
Lock bundler to 1.12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 
 cache: bundler
 
+before_install:
+  - gem install bundler -v '1.12.5'
+
 addons:
   apt:
     packages:

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -16,7 +16,11 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", ">= 1.5.2", "<= 1.12.0"
+  # Do not update the Bundler constraint. Vagrant relies on internal Bundler
+  # APIs, so even point releases can introduce breaking changes. These changes
+  # are *untestable* until after a release is made because there is no way for
+  # Bundler to exec into itself. Please do not update the Bundler constraint.
+  s.add_dependency "bundler", "= 1.12.5"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"


### PR DESCRIPTION
This commit removes any ambiguity about how and why bundler is locked to a specific constraint. It also updates to a version of Bundler that is known to work (all plugin commands verified).

- Fixes #7415 

/cc @mitchellh 