### PR TITLE
Revert "Set max_network_adapters to 36 for Virtualbox"

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -178,7 +178,7 @@ module VagrantPlugins
 
         # Returns the maximum number of network adapters.
         def max_network_adapters
-          36
+          8
         end
 
         # Returns a list of forwarded ports for a VM.

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1366,7 +1366,7 @@ en:
         There is no available slots on the VirtualBox VM for the configured
         high-level network interfaces. "private_network" and "public_network"
         network configurations consume a single network adapter slot on the
-        VirtualBox VM. VirtualBox limits the number of slots to 36, and it
+        VirtualBox VM. VirtualBox limits the number of slots to 8, and it
         appears that every slot is in use. Please lower the number of used
         network adapters.
       virtualbox_not_detected: |-


### PR DESCRIPTION
Reverts mitchellh/vagrant#7293

Fixes https://github.com/mitchellh/vagrant/issues/7417