### PR TITLE
provisioners/ansible: honor galaxy_roles_path when running ansible-playbook

### DIFF
--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -67,10 +67,14 @@ module VagrantPlugins
           end
         end
 
+        def get_provisioning_working_directory
+          config.provisioning_path
+        end
+
         def execute_ansible_galaxy_on_guest
           command_values = {
-            role_file: get_galaxy_role_file(config.provisioning_path),
-            roles_path: get_galaxy_roles_path(config.provisioning_path)
+            role_file: "'#{get_galaxy_role_file}'",
+            roles_path: "'#{get_galaxy_roles_path}'"
           }
 
           remote_command = config.galaxy_command % command_values

--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -89,8 +89,8 @@ module VagrantPlugins
 
         def execute_ansible_galaxy_from_host
           command_values = {
-            role_file: get_galaxy_role_file(machine.env.root_path),
-            roles_path: get_galaxy_roles_path(machine.env.root_path)
+            role_file: get_galaxy_role_file,
+            roles_path: get_galaxy_roles_path
           }
           command_template = config.galaxy_command.gsub(' ', VAGRANT_ARG_SEPARATOR)
           str_command = command_template % command_values
@@ -102,6 +102,7 @@ module VagrantPlugins
             workdir: @machine.env.root_path.to_s
           }
 
+          # FIXME: role_file and roles_path arguments should be quoted in the console output
           ui_running_ansible_command "galaxy", str_command.gsub(VAGRANT_ARG_SEPARATOR, ' ')
 
           execute_command_from_host command
@@ -186,6 +187,10 @@ module VagrantPlugins
           end
 
           return machines
+        end
+
+        def get_provisioning_working_directory
+          machine.env.root_path
         end
 
         def get_inventory_ssh_machine(machine, ssh_info)


### PR DESCRIPTION
Changes:

- systematically set ANSIBLE_ROLES_PATH environment variable when
  galaxy_roles_path is defined.
- slightly refactor to introduce the concept of "provisioning working
  directory" (possible usage in the future for resolving GH-7195)
- fix a bug in ansible-galaxy execution by the ansible_local provisioner
  if the paths contains blank characters.

Fix #7269

Pull request created only to trigger the Travis CI checks