### PR TITLE
Remove punctuation from URL

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -8,10 +8,10 @@
 Vagrant.configure("2") do |config|
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
+  # https://docs.vagrantup.com
 
   # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
+  # boxes at https://atlas.hashicorp.com/search
   config.vm.box = "<%= box_name %>"
   <% if box_version -%>
   config.vm.box_version = "<%= box_version %>"


### PR DESCRIPTION
- Removed period from end of URL so as not to confuse URL handlers in some text editors

Ultimately closes #7423 