### PR TITLE
Add CloudLinux 7 to RHEL 7 flavors.

### DIFF
--- a/plugins/guests/redhat/cap/flavor.rb
+++ b/plugins/guests/redhat/cap/flavor.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
           end
 
           # Detect various flavors we care about
-          if output =~ /(CentOS|Red Hat Enterprise|Scientific) Linux( .+)? release 7/i
+          if output =~ /(CentOS|Red Hat Enterprise|Scientific|Cloud)\s*Linux( .+)? release 7/i
             return :rhel_7
           else
             return :rhel

--- a/test/unit/plugins/guests/redhat/cap/flavor_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/flavor_test.rb
@@ -25,6 +25,7 @@ describe "VagrantPlugins::GuestRedHat::Cap::Flavor" do
       "CentOS Linux 2.4 release 7" => :rhel_7,
       "Red Hat Enterprise Linux release 7" => :rhel_7,
       "Scientific Linux release 7" => :rhel_7,
+      "CloudLinux release 7.2 (Valeri Kubasov)" => :rhel_7,
 
       "CentOS" => :rhel,
       "RHEL 6" => :rhel,


### PR DESCRIPTION
Hello,

that pull-request fixes the  #7427 issue: [CloudLinux](https://cloudlinux.com/) 7 is a RHEL 7 derivative distribution, so "rhel_7" flavor should be used for it.

[/etc/redhat-release](http://repo.cloudlinux.com/cloudlinux/7/os/x86_64/Packages/cloudlinux-release-7.2-1.el7.x86_64.rpm) content:
```
CloudLinux release 7.2 (Valeri Kubasov)
```

Thank you!