### PR TITLE
For for issue #7447

### DIFF
--- a/plugins/providers/hyperv/scripts/get_vm_status.ps1
+++ b/plugins/providers/hyperv/scripts/get_vm_status.ps1
@@ -9,18 +9,24 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 
 
 if($PSVersionTable.PSVersion.Major -le 4) {
-  $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationOperationFailedException]
+  $ExceptionType = "Microsoft.HyperV.PowerShell.VirtualizationOperationFailedException"
 } else {
-  $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationException]
+  $ExceptionType = "Microsoft.HyperV.PowerShell.VirtualizationException"
 }
 
 try {
     $VM = Get-VM -Id $VmId -ErrorAction "Stop"
     $State = $VM.state
     $Status = $VM.status
-} catch $ExceptionType {
-    $State = "not_created"
-    $Status = $State
+} catch [System.Exception] {
+    $type = [String]$_.Exception.GetType()
+    if ($type -eq $ExceptionType ) {
+      $State = "not_created"
+      $Status = $State
+    } else {
+      Write-Hosts "Uncaught stuff: $($_.Exception.Gettype())"
+      throw $_.Exception
+    }
 }
 
 $resultHash = @{


### PR DESCRIPTION
Change the exeception testing to look for the String name of the exception type. Dynamic use of the exception type does not work on Windows 8.1 and Windows Server 2012R2

Fixes #7447 