### PR TITLE
Bump listen gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - bsdtar
 
 rvm:
-  - 2.0.0
+  - 2.2.3
 
 branches:
   only:

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = "Build and distribute virtualized development environments."
   s.description   = "Vagrant is a tool for building and distributing virtualized development environments."
 
-  s.required_ruby_version     = ">= 2.0.0"
+  s.required_ruby_version     = "~> 2.2"
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", ">= 0.6.0", "<= 0.8.0"
-  s.add_dependency "listen", "~> 3.0.2"
+  s.add_dependency "listen", "~> 3.1.5"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.1"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
   s.add_dependency "net-ssh", "~> 3.0.1"


### PR DESCRIPTION
This Fixes GH-7441 by bumping the listen gem to a version that supports older OSX. The problem is that that older version does not support older Ruby, so we need to bump the Ruby version too.