### PR TITLE
Append newline to each key added

### DIFF
--- a/plugins/guests/linux/cap/insert_public_key.rb
+++ b/plugins/guests/linux/cap/insert_public_key.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
             mkdir -p ~/.ssh
             chmod 0700 ~/.ssh
             cat '#{remote_path}' >> ~/.ssh/authorized_keys
+            echo "\n" >> ~/.ssh/authorized_keys
             chmod 0600 ~/.ssh/authorized_keys
 
             # Remove the temporary file

--- a/plugins/guests/linux/cap/insert_public_key.rb
+++ b/plugins/guests/linux/cap/insert_public_key.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class InsertPublicKey
         def self.insert_public_key(machine, contents)
           comm = machine.communicate
-          contents = contents.chomp
+          contents = contents.chomp+"\n"
 
           remote_path = "/tmp/vagrant-authorized-keys-#{Time.now.to_i}"
           Tempfile.open("vagrant-linux-insert-public-key") do |f|
@@ -19,7 +19,6 @@ module VagrantPlugins
             mkdir -p ~/.ssh
             chmod 0700 ~/.ssh
             cat '#{remote_path}' >> ~/.ssh/authorized_keys
-            echo "\n" >> ~/.ssh/authorized_keys
             chmod 0600 ~/.ssh/authorized_keys
 
             # Remove the temporary file

--- a/plugins/guests/linux/cap/insert_public_key.rb
+++ b/plugins/guests/linux/cap/insert_public_key.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class InsertPublicKey
         def self.insert_public_key(machine, contents)
           comm = machine.communicate
-          contents = contents.chomp+"\n"
+          contents = contents.chomp << "\n"
 
           remote_path = "/tmp/vagrant-authorized-keys-#{Time.now.to_i}"
           Tempfile.open("vagrant-linux-insert-public-key") do |f|


### PR DESCRIPTION
The change to this file [10 days ago](https://github.com/mitchellh/vagrant/commit/e2b7e28082a4b5e546655526773477e8df833bdd#diff-715ea9eefd185460afff2f7cf7eb0c3b) removed a newline character at the end of each ssh public key added to the `authorized_keys` file. This meant that when another key was added, it continued on the same line as the one before and thus wasn't being detected/able to be used when a ssh connection came in with a key file.

With regards to https://github.com/mitchellh/vagrant/issues/7455 this is an (ugly) fix.

I'm sure someone knows a better command to concat a file and a string and append it to the `authorized_keys` file. But this does fix the problem.