### PR TITLE
Use ip instead of deprecated ifconfig for Red Hat/CentOS guests

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
           interfaces = []
           commands   = []
 
-          comm.sudo("ifconfig -a | grep -o ^[0-9a-z]* | grep -v '^lo'") do |_, stdout|
+          comm.sudo("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, stdout|
             interfaces = stdout.split("\n")
           end
 

--- a/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
@@ -12,7 +12,7 @@ describe "VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks" do
 
   before do
     allow(machine).to receive(:communicate).and_return(comm)
-    comm.stub_command("ifconfig -a | grep -o ^[0-9a-z]* | grep -v '^lo'",
+    comm.stub_command("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'",
       stdout: "eth1\neth2")
   end
 


### PR DESCRIPTION
This specifically addresses Red Hat/CentOS 7 guests were /sbin/ifconfig has been marked as deprecated. The 'net-tools' package is no longer part of the core group and is not installed by default.  As with the Debian guest, the /sbin/ip command is now favoured.