### PR TITLE
guests/redhat: fix network configuration in CentOS 5

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
           interfaces = []
           commands   = []
 
-          comm.sudo("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, stdout|
+          comm.sudo("/sbin/ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, stdout|
             interfaces = stdout.split("\n")
           end
 

--- a/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
@@ -12,7 +12,7 @@ describe "VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks" do
 
   before do
     allow(machine).to receive(:communicate).and_return(comm)
-    comm.stub_command("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'",
+    comm.stub_command("/sbin/ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'",
       stdout: "eth1\neth2")
   end
 


### PR DESCRIPTION
ip command is not on PATH by default in CentOS 5 so call it with the full path.