### PR TITLE
core: Provide a way to globally disable box update checking

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -5,6 +5,7 @@ require "set"
 require "vagrant"
 require "vagrant/config/v2/util"
 require "vagrant/util/platform"
+require "vagrant/util/presence"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)
@@ -12,6 +13,8 @@ require File.expand_path("../vm_subvm", __FILE__)
 module VagrantPlugins
   module Kernel_V2
     class VMConfig < Vagrant.plugin("2", :config)
+      include Vagrant::Util::Presence
+
       DEFAULT_VM_NAME = :default
 
       attr_accessor :allowed_synced_folder_types
@@ -361,7 +364,11 @@ module VagrantPlugins
         @base_mac = nil if @base_mac == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
         @box = nil if @box == UNSET_VALUE
-        @box_check_update = true if @box_check_update == UNSET_VALUE
+
+        if @box_check_update == UNSET_VALUE
+          @box_check_update = !present?(ENV["VAGRANT_BOX_UPDATE_CHECK_DISABLE"])
+        end
+
         @box_download_ca_cert = nil if @box_download_ca_cert == UNSET_VALUE
         @box_download_ca_path = nil if @box_download_ca_path == UNSET_VALUE
         @box_download_checksum = nil if @box_download_checksum == UNSET_VALUE

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -75,9 +75,17 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
 
   context "#box_check_update" do
     it "defaults to true" do
-      subject.finalize!
+      with_temp_env("VAGRANT_BOX_UPDATE_CHECK_DISABLE" => "") do
+        subject.finalize!
+        expect(subject.box_check_update).to be(true)
+      end
+    end
 
-      expect(subject.box_check_update).to be_true
+    it "is false if VAGRANT_BOX_UPDATE_CHECK_DISABLE is set" do
+      with_temp_env("VAGRANT_BOX_UPDATE_CHECK_DISABLE" => "1") do
+        subject.finalize!
+        expect(subject.box_check_update).to be(false)
+      end
     end
   end
 

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -32,6 +32,16 @@ Vagrant to use this provider for any _new_ Vagrant environments. Existing
 Vagrant environments will continue to use the provider they came `up` with.
 Once you `vagrant destroy` existing environments, this will take effect.
 
+## `VAGRANT_BOX_UPDATE_CHECK_DISABLE`
+
+By default, Vagrant will query the metadata API server to see if a newer
+box version is available for download. This optional can be disabled on a
+per-Vagrantfile basis with `config.vm.box_check_update`, but it can also be
+disabled globally setting `VAGRANT_BOX_UPDATE_CHECK_DISABLE` to any non-empty
+value.
+
+This option will not affect global box functions like `vagrant box update`.
+
 ## `VAGRANT_CHECKPOINT_DISABLE`
 
 Vagrant does occasional network calls to check whether the version of Vagrant


### PR DESCRIPTION
This adds a new environmental variable `VAGRANT_BOX_UPDATE_CHECK_DISABLE`, which instructs Vagrant to not check for box updates when running regular Vagrant commands. This behaves the same as the existing `config.vm.box_update_check` configuration option, but can be set globally. Vagrantfile-supplied options will take precedence.

Fixes GH-7479