### PR TITLE
guests: Use set -e when executing multi-line scripts

### DIFF
--- a/plugins/guests/arch/cap/change_host_name.rb
+++ b/plugins/guests/arch/cap/change_host_name.rb
@@ -7,17 +7,19 @@ module VagrantPlugins
 
           if !comm.test("hostname | grep -w '#{name}'")
             basename = name.split(".", 2)[0]
-            comm.sudo <<-EOH
-hostnamectl set-hostname '#{name}'
+            comm.sudo <<-EOH.gsub(/^ {14}/, "")
+              set -e
 
-# Remove comments and blank lines from /etc/hosts
-sed -i'' -e 's/#.*$//' -e '/^$/d' /etc/hosts
+              hostnamectl set-hostname '#{name}'
 
-# Prepend ourselves to /etc/hosts
-grep -w '#{name}' /etc/hosts || {
-  sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
-}
-EOH
+              # Remove comments and blank lines from /etc/hosts
+              sed -i'' -e 's/#.*$//' -e '/^$/d' /etc/hosts
+
+              # Prepend ourselves to /etc/hosts
+              grep -w '#{name}' /etc/hosts || {
+                sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
+              }
+            EOH
           end
         end
       end

--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         def self.configure_networks(machine, networks)
           comm = machine.communicate
 
-          commands   = []
+          commands   = ["set -e"]
           interfaces = []
 
           # The result will be something like:

--- a/plugins/guests/atomic/cap/change_host_name.rb
+++ b/plugins/guests/atomic/cap/change_host_name.rb
@@ -7,17 +7,19 @@ module VagrantPlugins
 
           if !comm.test("hostname | grep -w '#{name}'")
             basename = name.split(".", 2)[0]
-            comm.sudo <<-EOH
-hostnamectl set-hostname '#{name}'
+            comm.sudo <<-EOH.gsub(/^ {14}/, "")
+              set -e
 
-# Remove comments and blank lines from /etc/hosts
-sed -i'' -e 's/#.*$//' -e '/^$/d' /etc/hosts
+              hostnamectl set-hostname '#{name}'
 
-# Prepend ourselves to /etc/hosts
-grep -w '#{name}' /etc/hosts || {
-  sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
-}
-EOH
+              # Remove comments and blank lines from /etc/hosts
+              sed -i'' -e 's/#.*$//' -e '/^$/d' /etc/hosts
+
+              # Prepend ourselves to /etc/hosts
+              grep -w '#{name}' /etc/hosts || {
+                sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
+              }
+            EOH
           end
         end
       end

--- a/plugins/guests/coreos/cap/configure_networks.rb
+++ b/plugins/guests/coreos/cap/configure_networks.rb
@@ -42,7 +42,7 @@ module VagrantPlugins
             end
 
             # Build a list of commands
-            commands = []
+            commands = ["set -e"]
 
             # Stop default systemd
             commands << "systemctl stop etcd"

--- a/plugins/guests/darwin/cap/change_host_name.rb
+++ b/plugins/guests/darwin/cap/change_host_name.rb
@@ -9,6 +9,8 @@ module VagrantPlugins
             basename = name.split(".", 2)[0]
 
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               scutil --set ComputerName '#{name}'
               scutil --set HostName '#{name}'
 

--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -12,6 +12,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}'")
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Set the hostname
               echo '#{name}' > /etc/hostname
               hostname -F /etc/hostname

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         def self.configure_networks(machine, networks)
           comm = machine.communicate
 
-          commands   = []
+          commands   = ["set -e"]
           entries    = []
           interfaces = []
 

--- a/plugins/guests/debian/cap/nfs_client.rb
+++ b/plugins/guests/debian/cap/nfs_client.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           comm = machine.communicate
           comm.sudo <<-EOH.gsub(/^ {12}/, '')
+            set -e
             apt-get -yqq update
             apt-get -yqq install nfs-common portmap
           EOH

--- a/plugins/guests/debian/cap/rsync.rb
+++ b/plugins/guests/debian/cap/rsync.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
           comm = machine.communicate
           if !comm.test("command -v rsync")
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
               apt-get -yqq update
               apt-get -yqq install rsync
             EOH

--- a/plugins/guests/debian/cap/smb.rb
+++ b/plugins/guests/debian/cap/smb.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
           comm = machine.communicate
           if !comm.test("test -f /sbin/mount.cifs")
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
               apt-get -yqq update
               apt-get -yqq install cifs-utils
             EOH

--- a/plugins/guests/fedora/cap/change_host_name.rb
+++ b/plugins/guests/fedora/cap/change_host_name.rb
@@ -7,20 +7,22 @@ module VagrantPlugins
 
           if !comm.test("hostname | grep -w '#{name}'")
             basename = name.split(".", 2)[0]
-            comm.sudo <<-EOH
-echo '#{name}' > /etc/hostname
-hostname -F /etc/hostname
-hostnamectl set-hostname --static '#{name}'
-hostnamectl set-hostname --transient '#{name}'
+            comm.sudo <<-EOH.gsub(/^ {14}/, "")
+              set -e
 
-# Remove comments and blank lines from /etc/hosts
-sed -i'' -e 's/#.*$//' -e '/^$/d' /etc/hosts
+              echo '#{name}' > /etc/hostname
+              hostname -F /etc/hostname
+              hostnamectl set-hostname --static '#{name}'
+              hostnamectl set-hostname --transient '#{name}'
 
-# Prepend ourselves to /etc/hosts
-grep -w '#{name}' /etc/hosts || {
-  sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
-}
-EOH
+              # Remove comments and blank lines from /etc/hosts
+              sed -i'' -e 's/#.*$//' -e '/^$/d' /etc/hosts
+
+              # Prepend ourselves to /etc/hosts
+              grep -w '#{name}' /etc/hosts || {
+                sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
+              }
+            EOH
           end
         end
       end

--- a/plugins/guests/freebsd/cap/change_host_name.rb
+++ b/plugins/guests/freebsd/cap/change_host_name.rb
@@ -9,6 +9,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}' || hostname -s | grep -w '#{name}'", options)
             basename = name.split(".", 2)[0]
             command = <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Set the hostname
               hostname '#{name}'
               sed -i '' 's/^hostname=.*$/hostname=\"#{name}\"/' /etc/rc.conf

--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
           options = { shell: "sh" }
           comm = machine.communicate
 
-          commands   = []
+          commands   = ["set -e"]
           interfaces = []
 
           # Remove any previous network additions to the configuration file.

--- a/plugins/guests/linux/cap/insert_public_key.rb
+++ b/plugins/guests/linux/cap/insert_public_key.rb
@@ -16,6 +16,8 @@ module VagrantPlugins
           end
 
           comm.execute <<-EOH.gsub(/^ {12}/, '')
+            set -e
+
             mkdir -p ~/.ssh
             chmod 0700 ~/.ssh
             cat '#{remote_path}' >> ~/.ssh/authorized_keys

--- a/plugins/guests/linux/cap/mount_nfs.rb
+++ b/plugins/guests/linux/cap/mount_nfs.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
         def self.mount_nfs_folder(machine, ip, folders)
           comm = machine.communicate
 
-          commands = []
+          commands = ["set -e"]
 
           folders.each do |name, opts|
             # Expand the guest path so we can handle things like "~/vagrant"

--- a/plugins/guests/omnios/cap/change_host_name.rb
+++ b/plugins/guests/omnios/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname | grep -w '#{name}'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Set hostname
               echo '#{name}' > /etc/nodename
               hostname '#{name}'

--- a/plugins/guests/omnios/cap/mount_nfs_folder.rb
+++ b/plugins/guests/omnios/cap/mount_nfs_folder.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class MountNFSFolder
         def self.mount_nfs_folder(machine, ip, folders)
           comm   = machine.communicate
-          commands = []
+          commands = ["set -e"]
 
           folders.each do |_, opts|
             commands << <<-EOH.gsub(/^ {14}/, '')

--- a/plugins/guests/photon/cap/change_host_name.rb
+++ b/plugins/guests/photon/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Set the hostname
               echo '#{name}' > /etc/hostname
               hostname '#{name}'

--- a/plugins/guests/photon/cap/configure_networks.rb
+++ b/plugins/guests/photon/cap/configure_networks.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         def self.configure_networks(machine, networks)
           comm = machine.communicate
 
-          commands   = []
+          commands   = ["set -e"]
           interfaces = []
 
           comm.sudo("ifconfig | grep 'eth' | cut -f1 -d' '") do |_, result|

--- a/plugins/guests/pld/cap/change_host_name.rb
+++ b/plugins/guests/pld/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname | grep -w '#{name}'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               hostname '#{name}'
               sed -i 's/\\(HOSTNAME=\\).*/\\1#{name}/' /etc/sysconfig/network
 

--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}'", sudo: false)
             basename = name.split('.', 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Update sysconfig
               sed -i 's/\\(HOSTNAME=\\).*/\\1#{name}/' /etc/sysconfig/network
 

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
           network_scripts_dir = machine.guest.capability(:network_scripts_dir)
 
           interfaces = []
-          commands   = []
+          commands   = ["set -e"]
 
           comm.sudo("/sbin/ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, stdout|
             interfaces = stdout.split("\n")

--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -4,6 +4,8 @@ module VagrantPlugins
       class NFSClient
         def self.nfs_client_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
+            set -e
+
             if command -v dnf; then
               dnf -y install nfs-utils nfs-utils-lib portmap
             else

--- a/plugins/guests/redhat/cap/rsync.rb
+++ b/plugins/guests/redhat/cap/rsync.rb
@@ -4,6 +4,8 @@ module VagrantPlugins
       class RSync
         def self.rsync_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
+            set -e
+
             if command -v dnf; then
               dnf -y install rsync
             else

--- a/plugins/guests/slackware/cap/change_host_name.rb
+++ b/plugins/guests/slackware/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Set the hostname
               chmod o+w /etc/hostname
               echo '#{name}' > /etc/hostname

--- a/plugins/guests/slackware/cap/configure_networks.rb
+++ b/plugins/guests/slackware/cap/configure_networks.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         def self.configure_networks(machine, networks)
           comm = machine.communicate
 
-          commands   = []
+          commands   = ["set -e"]
           interfaces = []
 
           comm.sudo("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, result|

--- a/plugins/guests/suse/cap/change_host_name.rb
+++ b/plugins/guests/suse/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               echo '#{name}' > /etc/HOSTNAME
               hostname '#{name}'
 

--- a/plugins/guests/suse/cap/configure_networks.rb
+++ b/plugins/guests/suse/cap/configure_networks.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
           network_scripts_dir = machine.guest.capability(:network_scripts_dir)
 
-          commands   = []
+          commands   = ["set -e"]
           interfaces = []
 
           comm.sudo("ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |_, stdout|

--- a/plugins/guests/suse/cap/nfs_client.rb
+++ b/plugins/guests/suse/cap/nfs_client.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
       class NFSClient
         def self.nfs_client_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
+            set -e
             zypper -n install nfs-client
             /sbin/service rpcbind restart
             /sbin/service nfs restart

--- a/plugins/guests/ubuntu/cap/change_host_name.rb
+++ b/plugins/guests/ubuntu/cap/change_host_name.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep -w '#{name}'")
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
+              set -e
+
               # Set the hostname
               echo '#{name}' > /etc/hostname
               hostname -F /etc/hostname


### PR DESCRIPTION
This will ensure the entire script exits if one of the commands specified fails. Without this, an error is only raised if the last command fails to execute.