### PR TITLE
Fixing version check and catch statement in get_vm_status

### DIFF
--- a/plugins/providers/hyperv/scripts/get_vm_status.ps1
+++ b/plugins/providers/hyperv/scripts/get_vm_status.ps1
@@ -7,20 +7,40 @@ Param(
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
+# Make sure the exception type is loaded
+try
+{
+    # Microsoft.HyperV.PowerShell is present on all versions of Windows with HyperV
+    [void][System.Reflection.Assembly]::LoadWithPartialName('Microsoft.HyperV.PowerShell, Culture=neutral, PublicKeyToken=31bf3856ad364e35')
+    # Microsoft.HyperV.PowerShell.Objects is only present on Windows >= 10.0, so this will fail, and we ignore it since the needed exception
+    # type was loaded in Microsoft.HyperV.PowerShell
+    [void][System.Reflection.Assembly]::LoadWithPartialName('Microsoft.HyperV.PowerShell.Objects, Culture=neutral, PublicKeyToken=31bf3856ad364e35')
+} catch {
+	# Empty catch ok, since if we didn't load the types, we will fail in the next block
+}
 
-if($PSVersionTable.PSVersion.Major -le 4) {
+$VmmsPath = if ([environment]::Is64BitProcess) { "$($env:SystemRoot)\System32\vmms.exe" } else { "$($env:SystemRoot)\Sysnative\vmms.exe" }
+$HyperVVersion = [version](Get-Item $VmmsPath).VersionInfo.ProductVersion
+
+if($HyperVVersion -lt ([version]'10.0')) {
   $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationOperationFailedException]
 } else {
   $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationException]
 }
-
 try {
     $VM = Get-VM -Id $VmId -ErrorAction "Stop"
     $State = $VM.state
     $Status = $VM.status
-} catch $ExceptionType {
-    $State = "not_created"
-    $Status = $State
+} catch [Exception] {
+    if($_.Exception.GetType() -eq $ExceptionType)
+    {
+        $State = "not_created"
+        $Status = $State
+    }
+    else 
+    {
+        throw;
+    }
 }
 
 $resultHash = @{


### PR DESCRIPTION
Use the version of Hyper-V instead of Powershell to determine which
exception is thrown by Get-VM. Also fixing an invalid catch statement,
since Powershell can not use variables to match thrown exceptions in
catch.