### PR TITLE
core/box_collection: Ensure removal

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -1,4 +1,5 @@
 require "digest/sha1"
+require "fileutils"
 require "monitor"
 require "tmpdir"
 
@@ -447,7 +448,7 @@ module Vagrant
 
       yield dir
     ensure
-      dir.rmtree if dir.exist?
+      FileUtils.rm_rf(dir.to_s)
     end
 
     # Checks if a box with a given name exists.


### PR DESCRIPTION
The docs for Ruby say Pathname#rmtree will recursively delete, but apparently that is a lie, at least on Windows (see GH-7496). Switch to using FileUtils to ensure the directory is deleted.

Fixes GH-7496