### PR TITLE
Ubuntu/xenial64 base box requires us to modprobe vboxsf ourselves

### DIFF
--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
           expanded_guest_path = machine.guest.capability(
             :shell_expand_guest_path, guestpath)
 
-          mount_commands = []
+          mount_commands = ['modprobe vboxsf']
 
           if options[:owner].is_a? Integer
             mount_uid = options[:owner]


### PR DESCRIPTION
Attempts to use virtualbox shared folders with the Ubuntu 16.04 Cloud Image base box from https://vagrantcloud.com/ubuntu/boxes/xenial64 result in mount errors about invalid filesystem type.  The base box does ship the vboxsf module in /lib/modules, but only inserts the `vboxguest` module.  This plugin runs before any user-defined provisioners, so adding the modprobe to a shell provisioner is insufficient.