### PR TITLE
A more reliable way to detect Ubuntu

### DIFF
--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module GuestUbuntu
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("[ -x /usr/bin/lsb_release ] && /usr/bin/lsb_release -i 2>/dev/null | grep Ubuntu")
+        machine.communicate.test("test -r /etc/os-release && . /etc/os-release && test xubuntu = x$ID")
       end
     end
   end


### PR DESCRIPTION
`lsb_release` command is included in lsb-release package. Sometimes this is not installed; ex: Docker official Ubuntu image.

```sh
$ docker run --rm -it ubuntu:precise bash -l -c 'lsb_release -i'
bash: lsb_release: command not found
$ docker run --rm -it ubuntu:trusty bash -l -c 'lsb_release -i' 
Distributor ID: Ubuntu
$ docker run --rm -it ubuntu:xenial bash -l -c 'lsb_release -i'
bash: lsb_release: command not found
```

`/etc/os-release` is included in base-files package, so this is more reliable than lsb_release.

```sh
$ docker run --rm -it ubuntu:precise bash -l -c '. /etc/os-release && echo $ID'  
ubuntu
$ docker run --rm -it ubuntu:trusty bash -l -c '. /etc/os-release && echo $ID' 
ubuntu
$ docker run --rm -it ubuntu:xenial bash -l -c '. /etc/os-release && echo $ID'
ubuntu
```

This pull-request uses `/etc/os-release` for Ubuntu detection.
