### PR TITLE
exclude control options from ssh command for windows platform + correct rsync exclude parameter

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -69,14 +69,18 @@ module VagrantPlugins
         # Create the path for the control sockets. We used to do this
         # in the machine data dir but this can result in paths that are
         # too long for unix domain sockets.
-        controlpath = File.join(Dir.tmpdir, "ssh.#{rand(1000)}")
+        control_options = ""
+        if not Vagrant::Util::Platform.windows? or (/mingw/ =~ RUBY_PLATFORM) == nil
+          controlpath = File.join(Dir.tmpdir, "ssh.#{rand(1000)}")
+          control_options = "-o ControlMaster=auto " +
+                            "-o ControlPath=#{controlpath} " +
+                            "-o ControlPersist=10m "
+        end
 
         rsh = [
           "ssh -p #{ssh_info[:port]} " +
           proxy_command +
-          "-o ControlMaster=auto " +
-          "-o ControlPath=#{controlpath} " +
-          "-o ControlPersist=10m " +
+          control_options +
           "-o StrictHostKeyChecking=no " +
           "-o IdentitiesOnly=true " +
           "-o UserKnownHostsFile=/dev/null",

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -128,7 +128,7 @@ module VagrantPlugins
           "rsync",
           args,
           "-e", rsh,
-          excludes.map { |e| ["--exclude", e] },
+          excludes.map { |e| "--exclude=" + e },
           hostpath,
           "#{username}@#{host}:#{guestpath}",
         ].flatten

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -159,9 +159,8 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
         opts[:exclude] = "foo"
 
         expect(Vagrant::Util::Subprocess).to receive(:execute).with { |*args|
-          index = args.find_index("foo")
-          expect(index).to be > 0
-          expect(args[index-1]).to eql("--exclude")
+          index = args.find_index("--exclude=foo")
+          expect(index).to be >= 0
         }
 
         subject.rsync_single(machine, ssh_info, opts)
@@ -171,13 +170,11 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
         opts[:exclude] = ["foo", "bar"]
 
         expect(Vagrant::Util::Subprocess).to receive(:execute).with { |*args|
-          index = args.find_index("foo")
-          expect(index).to be > 0
-          expect(args[index-1]).to eql("--exclude")
+          index = args.find_index("--exclude=foo")
+          expect(index).to be >= 0
 
-          index = args.find_index("bar")
-          expect(index).to be > 0
-          expect(args[index-1]).to eql("--exclude")
+          index = args.find_index("--exclude=bar")
+          expect(index).to be >= 0
         }
 
         subject.rsync_single(machine, ssh_info, opts)


### PR DESCRIPTION
fixes #6702 and #7320 