### PR TITLE
More robust Ansible detection for local Ansible provisioner

### DIFF
--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
 
           # Check that ansible binaries are well installed on the guest,
           @machine.communicate.execute(
-            "ansible-galaxy info --help && ansible-playbook --help",
+            'test -x "$(command -v ansible-galaxy)" && test -x "$(command -v ansible-playbook)"',
             error_class: Ansible::Errors::AnsibleNotFoundOnGuest,
             error_key: :ansible_not_found_on_guest
           )


### PR DESCRIPTION
For the local Ansible provisioner, I would like to suggest a more robust way of Ansible guest detection. The current way of [checking return values](https://github.com/mitchellh/vagrant/blob/a4f45a18a653bd5b157a00c5ffaa3ba0c74ea5f5/plugins/provisioners/ansible/provisioner/guest.rb#L55-L60) has already caused trouble for the Ansible 2.0 detection (#6869). Future changes to the Ansible CLI and the return codes may break the detection suggested in #6869 again. Therefore, this PR changes the detection behavior to check that `ansible-galaxy` and `ansible-playbook` are both included in `$PATH` and executable. What do you think?