### PR TITLE
plugin: Write out state file via create-new-then-rename

### DIFF
--- a/lib/vagrant/plugin/state_file.rb
+++ b/lib/vagrant/plugin/state_file.rb
@@ -1,4 +1,6 @@
 require "json"
+require "fileutils"
+require "tempfile"
 
 module Vagrant
   module Plugin
@@ -91,8 +93,11 @@ module Vagrant
 
       # This saves the state back into the state file.
       def save!
-        @path.open("w+") do |f|
+        Tempfile.open(@path.basename.to_s, @path.dirname.to_s) do |f|
           f.write(JSON.dump(@data))
+          f.chmod(0644)
+          f.close
+          FileUtils.mv(f.path, @path)
         end
       end
 


### PR DESCRIPTION
This makes updates atomic, so it's useful generally.  However
I'm making this change specifically to support rpm-ostree.

For more information, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1352152