### PR TITLE
Add info on how to install/reinstall/upgrade the plugin

### DIFF
--- a/website/source/vmware/index.html.erb
+++ b/website/source/vmware/index.html.erb
@@ -397,6 +397,23 @@ description: |-
           </p>
         </div>
       </div>
+      
+      <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+          <h2>How do I install or upgrade the plugin?</h2>
+          <p>
+            To upgrade the plugin (such as after upgrading Vagrant itself), you'll have to uninstall the plugin first:
+            <pre>
+              $ vagrant plugin uninstall vagrant-vmware-fusion
+            </pre>
+            Then, you can install the new plugin:
+            <pre>
+              $ vagrant plugin install vagrant-vmware-fusion
+            <pre>
+          </p>
+        </div>
+      </div>
+
     </div>
     </section>
 


### PR DESCRIPTION
After upgrading Vagrant from 1.7.x to 1.8.x I started getting the following error:
```
An unexpected error occurred while loading the Vagrant VMware
provider. Please contact support with the following
error code: '7'.
Vagrant failed to initialize at a very early stage:

The plugins failed to load properly. The error message given is
shown below
```

Errors like the above are very unhelpful, but appears to be caused by incompatibility of the previously installed vmware plugin, which is not automatically upgraded when upgrading vagrant.

The fix is to uninstall the current vmware plugin and install it again, which will then fetch the new plugin.

I couldn't find anywhere how to actually download the new plugin, nevermind installing it, so had to rollback to Vagrant 1.7.x meanwhile.

This would be very helpful information on this page.