### PR TITLE
Fix chef installation detection

### DIFF
--- a/plugins/provisioners/chef/cap/omnios/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_installed.rb
@@ -7,11 +7,11 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            knife = "/opt/#{product}/bin/knife"
+            knife = "/opt/#{product}/bin/knife --version"
             command = "test -x #{knife}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep 'Chef: #{version}'"
+              command << "&& #{knife} | grep 'Chef: #{version}'"
             end
 
             machine.communicate.test(command, sudo: true)         


### PR DESCRIPTION
Running knife without any commands returns exit code 1 on Chef 12.12.15. This updates the test to always use the --version flag so that the exit code is 0 as expected.