### PR TITLE
Strip leading slash left in front of drive letter by uri.path

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -472,6 +472,8 @@ module Vagrant
           if uri.scheme == "file"
             url = uri.path
             url ||= uri.opaque
+            #7570 Strip leading slash left in front of drive letter by uri.path
+            Util::Platform.windows? && url.gsub!(/^\/([a-zA-Z]:)/, '\1')
 
             begin
               File.open(url, "r") do |f|


### PR DESCRIPTION
Fixes GH-7570