### PR TITLE
Fix issuee 6690: rsync-path is not quoted

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -116,7 +116,7 @@ module VagrantPlugins
           rsync_path = machine.guest.capability(:rsync_command)
         end
         if rsync_path
-          args << "--rsync-path"<< rsync_path
+           args << "--rsync-path=\""<< rsync_path << "\""
         end
 
         # Build up the actual command to execute


### PR DESCRIPTION
Added quotes to rsync-path argument parameters to ensure it runs properly on Windows Command Line and Git Bash

Resolves issue https://github.com/mitchellh/vagrant/issues/6690