### PR TITLE
winrm communicator: the task is only really finished when $out_file is closed

### DIFF
--- a/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
+++ b/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
@@ -95,6 +95,29 @@ do {
   $cur_line = SlurpOutput $out_file $cur_line
 } while (!($registered_task.state -eq 3))
 
+function Test-FileLock {
+  param (
+    [Parameter(Mandatory=$true)]
+    [String]$Path
+  )
+  if (!(Test-Path $Path)) {
+    return $false
+  }
+  try {
+    (New-Object IO.FileInfo $Path).
+      Open([IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None).
+      Close()
+    $false
+  } catch {
+    return $true
+  }
+}
+
+# the task is only really finished when $out_file is closed.
+while (Test-FileLock $out_file) {
+  Start-Sleep -m 100
+}
+
 $exit_code = $registered_task.LastTaskResult
 [System.Runtime.Interopservices.Marshal]::ReleaseComObject($schedule) | Out-Null
 


### PR DESCRIPTION
I was getting the following error:

```
==> test: del : Cannot remove item C:\Windows\Temp\WinRM_Elevated_Shell.log: The process cannot access the file
==> test: 'C:\Windows\Temp\WinRM_Elevated_Shell.log' because it is being used by another process.
==> test: At C:\tmp\vagrant-elevated-shell.ps1:19 char:3
==> test: +   del $out_file
==> test: +   ~~~~~~~~~~~~~
==> test:     + CategoryInfo          : WriteError: (C:\Windows\Temp\WinRM_Elevated_Shell.log:FileInfo) [Remove-Item], IOExcepti
==> test:    on
==> test:     + FullyQualifiedErrorId : RemoveFileSystemItemIOError,Microsoft.PowerShell.Commands.RemoveItemCommand
```
My Vagrantfile has something like:

    config.vm.provision "shell", inline: "c:/tmp/provision/install-a.ps1", name: "Install a"
    config.vm.provision "shell", inline: "c:/tmp/provision/install-b.ps1", name: "Install b"

The error happens when its trying to run the second provision script.

It turns out that the install-a.ps1 scheduled task was not really finished until the $out_file is closed.

PS my Host and Guest is Windows 10 64-bit. Vagrant is 1.8.4. VirtualBox is 5.0.24r108355.