### PR TITLE
Skip checking for conflicts on ports that are disabled

### DIFF
--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -93,6 +93,11 @@ module Vagrant
             guest_port = options[:guest]
             host_port  = options[:host]
 
+            if options[:disabled]
+              @logger.debug("Skipping disabled port #{host_port}.")
+              next
+            end
+
             if options[:protocol] && options[:protocol] != "tcp"
               @logger.debug("Skipping #{host_port} because UDP protocol.")
               next


### PR DESCRIPTION
Currently, the supported way (see GH#1922) to disable the default port
2222 port forward is:

    config.vm.network :forwarded_port, guest: 22, host: 2222, disabled: true

However, the port collision detection runs on all ports, regardless of
the `disabled` flag.  This leads it to attempt to connect to port
2222, notice it is taken, and abort with a port conflict -- even
though it will not be attempting to use the port at all.

Skip disabled ports when doing port conflict detection.

A workaround that does not require a Vagrant upgrade to one containing
this fix is to instead set `auto_correct` on the disabled port:

    config.vm.network :forwarded_port, guest: 22, host: 2222, disabled: true, auto_correct: true

This allows the disabled port to be reshuffled off to some other
unused port.