### PR TITLE
Support rest-client 2.x as a dependency

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-sftp", "~> 2.1"
   s.add_dependency "net-scp", "~> 1.1.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
-  s.add_dependency "rest-client", ">= 1.6.0", "< 2.0"
+  s.add_dependency "rest-client", ">= 1.6.0", "< 3.0"
   s.add_dependency "wdm", "~> 0.1.0"
   s.add_dependency "winrm", "~> 1.6"
   s.add_dependency "winrm-fs", "~> 0.3.0"


### PR DESCRIPTION
Hi,
I want to use rest-client latest version 2.0 as vagrant's dependency.
https://rubygems.org/gems/rest-client
Is it possible?
I checked to pass the test suite by Ruby 2.2.5 and 2.3.1 by myself after I updated.

