### PR TITLE
Update Ruby for Travis to 2.2.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - bsdtar
 
 rvm:
-  - 2.2.3
+  - 2.2.5
 
 branches:
   only:


### PR DESCRIPTION
> RubyDep: WARNING: Your Ruby is: 2.2.3 (insecure). Recommendation: install 2.2.5 or 2.3.1. (Or, at least to 2.2.4 or 2.3.0)

I want to update the Ruby for Travis to 2.2.5, as I saw above message.
Is it possible?

Thanks.
