### PR TITLE
fix for #7610 (incorrect permissions on ~/.ssh/authorized_keys causes authentication failure after insecure keypair replacement)

### DIFF
--- a/plugins/guests/linux/cap/public_key.rb
+++ b/plugins/guests/linux/cap/public_key.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
           contents = contents.strip << "\n"
 
           remote_path = "/tmp/vagrant-remove-pubkey-#{Time.now.to_i}"
-          Tempfile.open("vagrant-bsd-remove-public-key") do |f|
+          Tempfile.open("vagrant-linux-remove-public-key") do |f|
             f.binmode
             f.write(contents)
             f.fsync

--- a/plugins/guests/linux/cap/public_key.rb
+++ b/plugins/guests/linux/cap/public_key.rb
@@ -54,6 +54,7 @@ module VagrantPlugins
             if test -f ~/.ssh/authorized_keys; then
               grep -v -x -f '#{remote_path}' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.tmp
               mv ~/.ssh/authorized_keys.tmp ~/.ssh/authorized_keys
+              chmod 0600 ~/.ssh/authorized_keys
             fi
 
             rm -f '#{remote_path}'

--- a/test/unit/plugins/guests/linux/cap/remove_public_key_test.rb
+++ b/test/unit/plugins/guests/linux/cap/remove_public_key_test.rb
@@ -1,0 +1,32 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestLinux::Cap::RemovePublicKey" do
+  let(:caps) do
+    VagrantPlugins::GuestLinux::Plugin
+      .components
+      .guest_capabilities[:linux]
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".remove_public_key" do
+    let(:cap) { caps.get(:remove_public_key) }
+
+    it "removes the public key" do
+      cap.remove_public_key(machine, "ssh-rsa ...")
+      expect(comm.received_commands[0]).to match(/grep -v -x -f '\/tmp\/vagrant-(.+)' ~\/\.ssh\/authorized_keys > ~\/.ssh\/authorized_keys\.tmp/)
+      expect(comm.received_commands[0]).to match(/mv ~\/.ssh\/authorized_keys\.tmp ~\/.ssh\/authorized_keys/)
+      expect(comm.received_commands[0]).to match(/chmod 0600 ~\/.ssh\/authorized_keys/)
+      expect(comm.received_commands[0]).to match(/rm -f '\/tmp\/vagrant-(.+)'/)
+    end
+  end
+end


### PR DESCRIPTION
This fixes the issue reported in https://github.com/mitchellh/vagrant/issues/7610.  I'm not sure if any additional test cases are necessary to cover this; I can certainly write some if they are.