### PR TITLE
Support Vagrantfile-relative VAGRANT_DOTFILE_PATHs

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -157,9 +157,13 @@ module Vagrant
       end
 
       # Setup the local data directory. If a configuration path is given,
-      # then it is expanded relative to the working directory. Otherwise,
+      # it is expanded relative to the root path or to the working directory
+      # depending on whether it starts with the "{}" placeholder. Otherwise,
       # we use the default which is expanded relative to the root path.
       opts[:local_data_path] ||= ENV["VAGRANT_DOTFILE_PATH"] if !opts[:child]
+      if opts[:local_data_path] && opts[:local_data_path].start_with?("{}") && !root_path.nil?
+	opts[:local_data_path] = File.join(root_path, opts[:local_data_path].sub(/^\{\}/, ''))
+      end
       opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA) if !root_path.nil?
       if opts[:local_data_path]
         @local_data_path = Pathname.new(File.expand_path(opts[:local_data_path], @cwd))

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -160,9 +160,13 @@ module Vagrant
       # it is expanded relative to the root path or to the working directory
       # depending on whether it starts with the "{}" placeholder. Otherwise,
       # we use the default which is expanded relative to the root path.
-      opts[:local_data_path] ||= ENV["VAGRANT_DOTFILE_PATH"] if !opts[:child]
-      if opts[:local_data_path] && opts[:local_data_path].match("^\{\}") && !root_path.nil?
-	opts[:local_data_path] = File.join(root_path, opts[:local_data_path].sub(/^\{\}/, ''))
+      if ENV.has_key?("VAGRANT_DOTFILE_PATH") && !opts[:child]
+        dotfile_path = ENV["VAGRANT_DOTFILE_PATH"]
+        if dotfile_path.match(/^\{\}/) && !root_path.nil?
+          opts[:local_data_path] = File.join(root_path, dotfile_path.sub(/^\{\}/, ''))
+        else
+          opts[:local_data_path] = dotfile_path
+        end
       end
       opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA) if !root_path.nil?
       if opts[:local_data_path]

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -159,10 +159,13 @@ module Vagrant
       # Setup the local data directory. If a configuration path is given,
       # it is expanded relative to the root path. Otherwise, we use the
       # default (which is also expanded relative to the root path).
-      if ENV.has_key?("VAGRANT_DOTFILE_PATH") && !opts[:child]
-        opts[:local_data_path] ||= root_path.join(ENV["VAGRANT_DOTFILE_PATH"]) if !root_path.nil?
+      if !root_path.nil?
+        if !(ENV["VAGRANT_DOTFILE_PATH"] or "").empty? && !opts[:child]
+          opts[:local_data_path] ||= root_path.join(ENV["VAGRANT_DOTFILE_PATH"])
+        else
+          opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA)
+        end
       end
-      opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA) if !root_path.nil?
       if opts[:local_data_path]
         @local_data_path = Pathname.new(File.expand_path(opts[:local_data_path], @cwd))
       end

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -161,7 +161,7 @@ module Vagrant
       # depending on whether it starts with the "{}" placeholder. Otherwise,
       # we use the default which is expanded relative to the root path.
       opts[:local_data_path] ||= ENV["VAGRANT_DOTFILE_PATH"] if !opts[:child]
-      if opts[:local_data_path] && opts[:local_data_path].start_with?("{}") && !root_path.nil?
+      if opts[:local_data_path] && opts[:local_data_path].match("^\{\}") && !root_path.nil?
 	opts[:local_data_path] = File.join(root_path, opts[:local_data_path].sub(/^\{\}/, ''))
       end
       opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA) if !root_path.nil?

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -157,21 +157,16 @@ module Vagrant
       end
 
       # Setup the local data directory. If a configuration path is given,
-      # it is expanded relative to the root path or to the working directory
-      # depending on whether it starts with the "{}" placeholder. Otherwise,
-      # we use the default which is expanded relative to the root path.
+      # it is expanded relative to the root path. Otherwise, we use the
+      # default (which is also expanded relative to the root path).
       if ENV.has_key?("VAGRANT_DOTFILE_PATH") && !opts[:child]
-        dotfile_path = ENV["VAGRANT_DOTFILE_PATH"]
-        if dotfile_path.match(/^\{\}/) && !root_path.nil?
-          opts[:local_data_path] = File.join(root_path, dotfile_path.sub(/^\{\}/, ''))
-        else
-          opts[:local_data_path] = dotfile_path
-        end
+        opts[:local_data_path] ||= root_path.join(ENV["VAGRANT_DOTFILE_PATH"]) if !root_path.nil?
       end
       opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA) if !root_path.nil?
       if opts[:local_data_path]
         @local_data_path = Pathname.new(File.expand_path(opts[:local_data_path], @cwd))
       end
+      @logger.debug("Effective local data path: #{@local_data_path}")
 
       # If we have a root path, load the ".vagrantplugins" file.
       if root_path

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -987,6 +987,16 @@ VF
           end
         end
       end
+
+      it "is set relative to the empty string when there is no valid work directory" do
+        Dir.mktmpdir("out-of-tree-directory") do |temp_dir|
+          with_temp_env("VAGRANT_DOTFILE_PATH" => ".vagrant-custom") do
+            instance = env.create_vagrant_env(cwd: temp_dir)
+            expect(instance.cwd.to_s).to eq(temp_dir)
+            expect(instance.local_data_path.to_s).to eq("")
+          end
+        end
+      end
     end
 
     describe "upgrading V1 dotfiles" do

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -921,6 +921,74 @@ VF
       end
     end
 
+    context "with environmental variable VAGRANT_DOTFILE_PATH set to the empty string" do
+      it "is set to the default, from the work directory" do
+        with_temp_env("VAGRANT_DOTFILE_PATH" => "") do
+          instance = env.create_vagrant_env
+          expect(instance.cwd).to eq(env.workdir)
+          expect(instance.local_data_path.to_s).to eq(File.join(env.workdir, ".vagrant"))
+        end
+      end
+
+      it "is set to the default, from a sub-directory of the work directory" do
+        Dir.mktmpdir("sub-directory", env.workdir) do |temp_dir|
+          with_temp_env("VAGRANT_DOTFILE_PATH" => "") do
+            instance = env.create_vagrant_env(cwd: temp_dir)
+            expect(instance.cwd.to_s).to eq(temp_dir)
+            expect(instance.local_data_path.to_s).to eq(File.join(env.workdir, ".vagrant"))
+          end
+        end
+      end
+    end
+
+    context "with environmental variable VAGRANT_DOTFILE_PATH set to an absolute path" do
+      it "is set to VAGRANT_DOTFILE_PATH from the work directory" do
+        Dir.mktmpdir("sub-directory", env.workdir) do |temp_dir|
+          dotfile_path = File.join(temp_dir, ".vagrant-custom")
+
+          with_temp_env("VAGRANT_DOTFILE_PATH" => dotfile_path) do
+            instance = env.create_vagrant_env
+            expect(instance.cwd).to eq(env.workdir)
+            expect(instance.local_data_path.to_s).to eq(dotfile_path)
+          end
+        end
+      end
+
+      it "is set to VAGRANT_DOTFILE_PATH from a sub-directory of the work directory" do
+        Dir.mktmpdir("sub-directory", env.workdir) do |temp_dir|
+          dotfile_path = File.join(temp_dir, ".vagrant-custom")
+
+          with_temp_env("VAGRANT_DOTFILE_PATH" => dotfile_path) do
+            instance = env.create_vagrant_env(cwd: temp_dir)
+            expect(instance.cwd.to_s).to eq(temp_dir)
+            expect(instance.local_data_path.to_s).to eq(dotfile_path)
+          end
+        end
+      end
+    end
+
+    context "with environmental variable VAGRANT_DOTFILE_PATH set to a relative path" do
+      it "is set relative to the the work directory, from the work directory" do
+        Dir.mktmpdir("sub-directory", env.workdir) do |temp_dir|
+          with_temp_env("VAGRANT_DOTFILE_PATH" => ".vagrant-custom") do
+            instance = env.create_vagrant_env
+            expect(instance.cwd).to eq(env.workdir)
+            expect(instance.local_data_path.to_s).to eq(File.join(env.workdir, ".vagrant-custom"))
+          end
+        end
+      end
+
+      it "is set relative to the the work directory, from a sub-directory of the work directory" do
+        Dir.mktmpdir("sub-directory", env.workdir) do |temp_dir|
+          with_temp_env("VAGRANT_DOTFILE_PATH" => ".vagrant-custom") do
+            instance = env.create_vagrant_env(cwd: temp_dir)
+            expect(instance.cwd.to_s).to eq(temp_dir)
+            expect(instance.local_data_path.to_s).to eq(File.join(env.workdir, ".vagrant-custom"))
+          end
+        end
+      end
+    end
+
     describe "upgrading V1 dotfiles" do
       let(:v1_dotfile_tempfile) do
         Tempfile.new("vagrant-upgrade-dotfile").tap do |f|

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -988,7 +988,7 @@ VF
         end
       end
 
-      it "is set relative to the empty string when there is no valid work directory" do
+      it "is set to the empty string when there is no valid work directory" do
         Dir.mktmpdir("out-of-tree-directory") do |temp_dir|
           with_temp_env("VAGRANT_DOTFILE_PATH" => ".vagrant-custom") do
             instance = env.create_vagrant_env(cwd: temp_dir)

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -68,6 +68,8 @@ a scripting environment in order to set the directory that Vagrant sees.
 
 `VAGRANT_DOTFILE_PATH` can be set to change the directory where Vagrant stores VM-specific state, such as the VirtualBox VM UUID. By default, this is set to `.vagrant`. If you keep your Vagrantfile in a Dropbox folder in order to share the folder between your desktop and laptop (for example), Vagrant will overwrite the files in this directory with the details of the VM on the most recently-used host. To avoid this, you could set `VAGRANT_DOTFILE_PATH` to `.vagrant-laptop` and `.vagrant-desktop` on the respective machines. (Remember to update your `.gitignore`!)
 
+Non-absolute paths in this environmental variable are interpreted as relative to the current working directory unless prefixed with `{}` (example: `{}/.vagrant-laptop`), in which case they're interpreted as relative to the Vagrantfile.
+
 ## `VAGRANT_HOME`
 
 `VAGRANT_HOME` can be set to change the directory where Vagrant stores

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -68,7 +68,7 @@ a scripting environment in order to set the directory that Vagrant sees.
 
 `VAGRANT_DOTFILE_PATH` can be set to change the directory where Vagrant stores VM-specific state, such as the VirtualBox VM UUID. By default, this is set to `.vagrant`. If you keep your Vagrantfile in a Dropbox folder in order to share the folder between your desktop and laptop (for example), Vagrant will overwrite the files in this directory with the details of the VM on the most recently-used host. To avoid this, you could set `VAGRANT_DOTFILE_PATH` to `.vagrant-laptop` and `.vagrant-desktop` on the respective machines. (Remember to update your `.gitignore`!)
 
-Non-absolute paths in this environmental variable are interpreted as relative to the current working directory unless prefixed with `{}` (example: `{}/.vagrant-laptop`), in which case they're interpreted as relative to the Vagrantfile.
+Non-absolute paths in this environmental variable are interpreted as relative to the Vagrantfile's location.
 
 ## `VAGRANT_HOME`
 

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -68,8 +68,6 @@ a scripting environment in order to set the directory that Vagrant sees.
 
 `VAGRANT_DOTFILE_PATH` can be set to change the directory where Vagrant stores VM-specific state, such as the VirtualBox VM UUID. By default, this is set to `.vagrant`. If you keep your Vagrantfile in a Dropbox folder in order to share the folder between your desktop and laptop (for example), Vagrant will overwrite the files in this directory with the details of the VM on the most recently-used host. To avoid this, you could set `VAGRANT_DOTFILE_PATH` to `.vagrant-laptop` and `.vagrant-desktop` on the respective machines. (Remember to update your `.gitignore`!)
 
-Non-absolute paths in this environmental variable are interpreted as relative to the Vagrantfile's location.
-
 ## `VAGRANT_HOME`
 
 `VAGRANT_HOME` can be set to change the directory where Vagrant stores


### PR DESCRIPTION
These changes allow the VAGRANT_DOTFILE_PATH variable to contain paths relative to the Vagrantfile's location. This allows setting this variable globally in a `.bashrc` to avoid conflicts in Dropbox-shared directories while still allowing Vagrant commands to be issued from any project subdirectory.

This seems to be a common request and sidesteps the usual hack of setting the variable at the top of the Vagrantfile and reinvoke itself.

A placeholder `{}` at the start of the path is replaced by the path to the Vagrantfile. I'm personally using this to have non-conflicting `.vagrant` directories like so:
```
export VAGRANT_DOTFILE_PATH="{}/.vagrant-${USER}@${HOSTNAME}"
```