### PR TITLE
Detect NFS server by service name on Arch

### DIFF
--- a/plugins/hosts/arch/cap/nfs.rb
+++ b/plugins/hosts/arch/cap/nfs.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         end
 
         def self.nfs_installed(environment)
-          Kernel.system("grep -Fq nfsd /proc/filesystems")
+          Kernel.system("systemctl --no-pager --no-legend --plain list-unit-files --all --type=service | grep --fixed-strings --quiet nfs-server.service")
         end
       end
     end


### PR DESCRIPTION
Fixes #7629.
nfs-server.service seems to load kernel modules it needs itself, while nfsd appears in `/proc/filesystems` only after the kernel module has been loaded, so vagrant fails to detect NFS server until it's started first time after the system has booted. The updated command checks if the NFS service actually exists and hopes that it'll figure the stuff out itself.

`list-unit-files` is utilized rather than `list-units` because systemd seems to not list units that are disabled: https://lists.fedoraproject.org/pipermail/devel/2011-November/159117.html

The issue appeared at d29acc8982323b6f9e98b08d60ff4b8b5f0b9938. The fix wasn't wrong as checking nfs doesn't really make sense because it's client-side capability but insufficiend because it fails until the kernel module is loaded which doesn't happen on boot on a default setup.

@Barthalion I'd appreciate you taking a look at it as I've changed your line.