### PR TITLE
Fix `authorized_keys` permissions for BSDs

### DIFF
--- a/plugins/guests/bsd/cap/public_key.rb
+++ b/plugins/guests/bsd/cap/public_key.rb
@@ -54,6 +54,7 @@ module VagrantPlugins
             if test -f ~/.ssh/authorized_keys; then
               grep -v -x -f '#{remote_path}' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.tmp
               mv ~/.ssh/authorized_keys.tmp ~/.ssh/authorized_keys
+              chmod 0600 ~/.ssh/authorized_keys
             fi
 
             rm -f '#{remote_path}'

--- a/test/unit/plugins/guests/bsd/cap/remove_public_key_test.rb
+++ b/test/unit/plugins/guests/bsd/cap/remove_public_key_test.rb
@@ -1,0 +1,32 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestBSD::Cap::RemovePublicKey" do
+  let(:caps) do
+    VagrantPlugins::GuestBSD::Plugin
+      .components
+      .guest_capabilities[:bsd]
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".remove_public_key" do
+    let(:cap) { caps.get(:remove_public_key) }
+
+    it "removes the public key" do
+      cap.remove_public_key(machine, "ssh-rsa ...")
+      expect(comm.received_commands[0]).to match(/grep -v -x -f '\/tmp\/vagrant-(.+)' ~\/\.ssh\/authorized_keys > ~\/.ssh\/authorized_keys\.tmp/)
+      expect(comm.received_commands[0]).to match(/mv ~\/.ssh\/authorized_keys\.tmp ~\/.ssh\/authorized_keys/)
+      expect(comm.received_commands[0]).to match(/chmod 0600 ~\/.ssh\/authorized_keys/)
+      expect(comm.received_commands[0]).to match(/rm -f '\/tmp\/vagrant-(.+)'/)
+    end
+  end
+end


### PR DESCRIPTION
This is an extension of a6760dd8e7743e048cb2f38c474e05889356e8ac, applied to BSD guests.

Related to #7610