### PR TITLE
Update development vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,8 +50,8 @@ su -l -c 'curl -sL https://get.rvm.io | bash -s stable' vagrant
 #usermod -a -G rvm vagrant
 
 # Install some Rubies
-su -l -c 'rvm install 2.1.1' vagrant
-su -l -c 'rvm --default use 2.1.1' vagrant
+su -l -c 'rvm install 2.2.3' vagrant
+su -l -c 'rvm --default use 2.2.3' vagrant
 
 # Output the Ruby version (for sanity)
 su -l -c 'ruby --version' vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,10 @@ su -l -c 'ruby --version' vagrant
 # Install Git
 apt-get install -y git
 
+# Prepare to run unit tests
+su -l vagrant -c 'gem install bundler -v 1.12.5'
+su -l vagrant -c 'cd /vagrant; bundle install'
+
 # Automatically move into the shared folder, but only add the command
 # if it's not already there.
 grep -q 'cd /vagrant' /home/vagrant/.bash_profile || echo 'cd /vagrant' >> /home/vagrant/.bash_profile


### PR DESCRIPTION
While looking into adding some tests for PR #7623 I noticed that the development vagrant VM doesn't install the proper version of Ruby neither does it install the necessary dependencies to immediately run the test suite.

These changes fix this.