### PR TITLE
darwin rdp: File was missing newlines

### DIFF
--- a/plugins/hosts/darwin/cap/rdp.rb
+++ b/plugins/hosts/darwin/cap/rdp.rb
@@ -40,12 +40,12 @@ module VagrantPlugins
             f.binmode
 
             opts.each do |k, v|
-              f.write("#{k}:#{v}")
+              f.write("#{k}:#{v}\r\n")
             end
 
             if rdp_info[:extra_args]
               rdp_info[:extra_args].each do |arg|
-                f.write("#{arg}")
+                f.write("#{arg}\r\n")
               end
             end
 

--- a/test/unit/plugins/hosts/darwin/cap/rdp_test.rb
+++ b/test/unit/plugins/hosts/darwin/cap/rdp_test.rb
@@ -18,6 +18,9 @@ describe VagrantPlugins::HostDarwin::Cap::RDP do
     expect(result).to match("full address:s:host:port")
     expect(result).to match("prompt for credentials:i:1")
     expect(result).to match("username:s:username")
+    result.lines.each do |line|
+      expect(line).to match(/\r\n$/)
+    end
   end
 
   it "includes extra RDP arguments" do
@@ -25,6 +28,9 @@ describe VagrantPlugins::HostDarwin::Cap::RDP do
     path = described_class.generate_config_file(rdp_info)
     result = File.read(path)
     expect(result).to match("screen mode id:i:0")
+    result.lines.each do |line|
+      expect(line).to match(/\r\n$/)
+    end
   end
 
   it "opens the RDP file" do


### PR DESCRIPTION
The RDP file being created for Darwin was missing newlines.

It works with both \n(unix) and \r\n(dos) but I decided to go the
MS route.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mitchellh/vagrant/7659)
<!-- Reviewable:end -->
