### PR TITLE
guests/bsd: include -h to shutdown

### DIFF
--- a/plugins/guests/bsd/cap/halt.rb
+++ b/plugins/guests/bsd/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("/sbin/shutdown -p now", shell: "sh")
+            machine.communicate.sudo("/sbin/shutdown -p -h now", shell: "sh")
           rescue IOError
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.

--- a/test/unit/plugins/guests/bsd/cap/halt_test.rb
+++ b/test/unit/plugins/guests/bsd/cap/halt_test.rb
@@ -22,12 +22,12 @@ describe "VagrantPlugins::GuestBSD::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -p now")
+      comm.expect_command("/sbin/shutdown -p -h now")
       cap.halt(machine)
     end
 
     it "ignores an IOError" do
-      comm.stub_command("/sbin/shutdown -p now", raise: IOError)
+      comm.stub_command("/sbin/shutdown -p -h now", raise: IOError)
       expect {
         cap.halt(machine)
       }.to_not raise_error


### PR DESCRIPTION
Resolves #7634 by including the `-h` option with the shutdown command. The `-p` options works in conjunction with the `-h` option requiring it to be present. 

Vagrantfile used for testing:

```ruby
Vagrant.configure('2') do |config|
  config.vm.box = 'tmatilai/openbsd-5.5'
  config.vm.synced_folder '.', '/vagrant', disabled: true
end
```

Halting without `-h` option:

```
$ vagrant halt
==> default: Attempting graceful shutdown of VM...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

/sbin/shutdown -p now

Stdout from the command:



Stderr from the command:

shutdown: switch -p must be used with -h.
usage: shutdown [-] [-dfhknpr] time [warning-message ...]

$
```

Halting with `-h` option:

```
$ vagrant halt

==> default: Attempting graceful shutdown of VM...

$
```