### PR TITLE
guests: Prevent ssh disconnect from causing error on halt

### DIFF
--- a/plugins/guests/bsd/cap/halt.rb
+++ b/plugins/guests/bsd/cap/halt.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.halt(machine)
           begin
             machine.communicate.sudo("/sbin/shutdown -p now", shell: "sh")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.
           end

--- a/plugins/guests/darwin/cap/halt.rb
+++ b/plugins/guests/darwin/cap/halt.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
             # Darwin does not support the `-p` option like the rest of the
             # BSD-based guests, so it needs its own cap.
             machine.communicate.sudo("/sbin/shutdown -h now")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing because SSH connection closed and it probably
             # means the VM just shut down really fast.
           end

--- a/plugins/guests/esxi/cap/halt.rb
+++ b/plugins/guests/esxi/cap/halt.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.halt(machine)
           begin
             machine.communicate.execute("/bin/halt -d 0")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.
           end

--- a/plugins/guests/linux/cap/halt.rb
+++ b/plugins/guests/linux/cap/halt.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.halt(machine)
           begin
             machine.communicate.sudo("shutdown -h now")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.
           end

--- a/plugins/guests/smartos/cap/halt.rb
+++ b/plugins/guests/smartos/cap/halt.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
           begin
             machine.communicate.execute(
               "#{machine.config.smartos.suexec_cmd} /usr/sbin/shutdown -y -i5 -g0")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.
           end

--- a/plugins/guests/solaris/cap/halt.rb
+++ b/plugins/guests/solaris/cap/halt.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
           begin
             machine.communicate.execute(
               "#{machine.config.solaris.suexec_cmd} /usr/sbin/shutdown -y -i5 -g0")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.
           end

--- a/plugins/guests/solaris11/cap/halt.rb
+++ b/plugins/guests/solaris11/cap/halt.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
           begin
             machine.communicate.execute(
               "#{machine.config.solaris11.suexec_cmd} /usr/sbin/shutdown -y -i5 -g0")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.
           end

--- a/plugins/guests/suse/cap/halt.rb
+++ b/plugins/guests/suse/cap/halt.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.halt(machine)
           begin
             machine.communicate.sudo("/sbin/shutdown -h now")
-          rescue IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.
           end

--- a/plugins/guests/tinycore/cap/halt.rb
+++ b/plugins/guests/tinycore/cap/halt.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.halt(machine)
           begin
             machine.communicate.sudo("poweroff")
-          rescue Net::SSH::Disconnect, IOError
+          rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.
           end

--- a/test/unit/plugins/guests/bsd/cap/halt_test.rb
+++ b/test/unit/plugins/guests/bsd/cap/halt_test.rb
@@ -9,6 +9,7 @@ describe "VagrantPlugins::GuestBSD::Cap::Halt" do
 
   let(:machine) { double("machine") }
   let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:shutdown_command) { "/sbin/shutdown -p now" }
 
   before do
     allow(machine).to receive(:communicate).and_return(comm)
@@ -22,12 +23,19 @@ describe "VagrantPlugins::GuestBSD::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -p now")
+      comm.expect_command(shutdown_command)
       cap.halt(machine)
     end
 
     it "ignores an IOError" do
-      comm.stub_command("/sbin/shutdown -p now", raise: IOError)
+      comm.stub_command(shutdown_command, raise: IOError)
+      expect {
+        cap.halt(machine)
+      }.to_not raise_error
+    end
+
+    it "ignores a Vagrant::Errors::SSHDisconnected" do
+      comm.stub_command(shutdown_command, raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error

--- a/test/unit/plugins/guests/esxi/cap/halt_test.rb
+++ b/test/unit/plugins/guests/esxi/cap/halt_test.rb
@@ -1,12 +1,13 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
+describe "VagrantPlugins::GuestEsxi::Cap::Halt" do
   let(:caps) do
-    VagrantPlugins::GuestDarwin::Plugin
+    VagrantPlugins::GuestEsxi::Plugin
       .components
-      .guest_capabilities[:darwin]
+      .guest_capabilities[:esxi]
   end
 
+  let(:shutdown_command){ "/bin/halt -d 0" }
   let(:machine) { double("machine") }
   let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
 
@@ -22,19 +23,19 @@ describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -h now")
+      comm.expect_command(shutdown_command)
       cap.halt(machine)
     end
 
     it "ignores an IOError" do
-      comm.stub_command("/sbin/shutdown -h now", raise: IOError)
+      comm.stub_command(shutdown_command, raise: IOError)
       expect {
         cap.halt(machine)
       }.to_not raise_error
     end
 
     it "ignores a Vagrant::Errors::SSHDisconnected" do
-      comm.stub_command("/sbin/shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      comm.stub_command(shutdown_command, raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error

--- a/test/unit/plugins/guests/linux/cap/halt_test.rb
+++ b/test/unit/plugins/guests/linux/cap/halt_test.rb
@@ -32,5 +32,12 @@ describe "VagrantPlugins::GuestLinux::Cap::Halt" do
         cap.halt(machine)
       }.to_not raise_error
     end
+
+    it "does not raise a SSHDisconnected" do
+      comm.stub_command("shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      expect {
+        cap.halt(machine)
+      }.to_not raise_error
+    end
   end
 end

--- a/test/unit/plugins/guests/openbsd/cap/halt_test.rb
+++ b/test/unit/plugins/guests/openbsd/cap/halt_test.rb
@@ -33,7 +33,7 @@ describe "VagrantPlugins::GuestOpenBSD::Cap::Halt" do
       }.to_not raise_error
     end
 
-    it "ignores an Vagrant::Errors::SSHDisconnected" do
+    it "ignores a Vagrant::Errors::SSHDisconnected" do
       comm.stub_command("/sbin/shutdown -p -h now", raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)

--- a/test/unit/plugins/guests/smartos/cap/halt_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/halt_test.rb
@@ -1,10 +1,11 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::VagrantPlugins::Cap::Halt" do
+describe "VagrantPlugins::GuestSmartos::Cap::Halt" do
   let(:plugin) { VagrantPlugins::GuestSmartos::Plugin.components.guest_capabilities[:smartos].get(:halt) }
   let(:machine) { double("machine") }
-  let(:config) { double("config", smartos: VagrantPlugins::GuestSmartos::Config.new) }
+  let(:config) { double("config", smartos: double("smartos", suexec_cmd: 'pfexec')) }
   let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:shutdown_command){ "pfexec /usr/sbin/shutdown -y -i5 -g0" }
 
   before do
     machine.stub(:communicate).and_return(communicator)
@@ -17,9 +18,22 @@ describe "VagrantPlugins::VagrantPlugins::Cap::Halt" do
 
   describe ".halt" do
     it "sends a shutdown signal" do
-      communicator.expect_command(%Q(pfexec /usr/sbin/shutdown -y -i5 -g0))
+      communicator.expect_command(shutdown_command)
       plugin.halt(machine)
+    end
+
+    it "ignores an IOError" do
+      communicator.stub_command(shutdown_command, raise: IOError)
+      expect {
+        plugin.halt(machine)
+      }.to_not raise_error
+    end
+
+    it "ignores a Vagrant::Errors::SSHDisconnected" do
+      communicator.stub_command(shutdown_command, raise: Vagrant::Errors::SSHDisconnected)
+      expect {
+        plugin.halt(machine)
+      }.to_not raise_error
     end
   end
 end
-

--- a/test/unit/plugins/guests/solaris/cap/halt_test.rb
+++ b/test/unit/plugins/guests/solaris/cap/halt_test.rb
@@ -1,13 +1,14 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
+describe "VagrantPlugins::GuestSolaris::Cap::Halt" do
   let(:caps) do
-    VagrantPlugins::GuestDarwin::Plugin
+    VagrantPlugins::GuestSolaris::Plugin
       .components
-      .guest_capabilities[:darwin]
+      .guest_capabilities[:solaris]
   end
 
-  let(:machine) { double("machine") }
+  let(:shutdown_command){ "sudo /usr/sbin/shutdown -y -i5 -g0" }
+  let(:machine) { double("machine", config: double("config", solaris: double("solaris", suexec_cmd: 'sudo'))) }
   let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
 
   before do
@@ -22,19 +23,19 @@ describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -h now")
+      comm.expect_command(shutdown_command)
       cap.halt(machine)
     end
 
     it "ignores an IOError" do
-      comm.stub_command("/sbin/shutdown -h now", raise: IOError)
+      comm.stub_command(shutdown_command, raise: IOError)
       expect {
         cap.halt(machine)
       }.to_not raise_error
     end
 
     it "ignores a Vagrant::Errors::SSHDisconnected" do
-      comm.stub_command("/sbin/shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      comm.stub_command(shutdown_command, raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error

--- a/test/unit/plugins/guests/solaris11/cap/halt_test.rb
+++ b/test/unit/plugins/guests/solaris11/cap/halt_test.rb
@@ -1,13 +1,14 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
+describe "VagrantPlugins::GuestSolaris11::Cap::Halt" do
   let(:caps) do
-    VagrantPlugins::GuestDarwin::Plugin
+    VagrantPlugins::GuestSolaris11::Plugin
       .components
-      .guest_capabilities[:darwin]
+      .guest_capabilities[:solaris11]
   end
 
-  let(:machine) { double("machine") }
+  let(:shutdown_command){ "sudo /usr/sbin/shutdown -y -i5 -g0" }
+  let(:machine) { double("machine", config: double("config", solaris11: double("solaris11", suexec_cmd: 'sudo'))) }
   let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
 
   before do
@@ -22,19 +23,19 @@ describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -h now")
+      comm.expect_command(shutdown_command)
       cap.halt(machine)
     end
 
     it "ignores an IOError" do
-      comm.stub_command("/sbin/shutdown -h now", raise: IOError)
+      comm.stub_command(shutdown_command, raise: IOError)
       expect {
         cap.halt(machine)
       }.to_not raise_error
     end
 
     it "ignores a Vagrant::Errors::SSHDisconnected" do
-      comm.stub_command("/sbin/shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      comm.stub_command(shutdown_command, raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error

--- a/test/unit/plugins/guests/suse/cap/halt_test.rb
+++ b/test/unit/plugins/guests/suse/cap/halt_test.rb
@@ -32,5 +32,12 @@ describe "VagrantPlugins::GuestSUSE::Cap::Halt" do
         cap.halt(machine)
       }.to_not raise_error
     end
+
+    it "ignores a Vagrant::Errors::SSHDisconnected" do
+      comm.stub_command("shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      expect {
+        cap.halt(machine)
+      }.to_not raise_error
+    end
   end
 end

--- a/test/unit/plugins/guests/tinycore/cap/halt_test.rb
+++ b/test/unit/plugins/guests/tinycore/cap/halt_test.rb
@@ -1,12 +1,13 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
+describe "VagrantPlugins::GuestTinyCore::Cap::Halt" do
   let(:caps) do
-    VagrantPlugins::GuestDarwin::Plugin
+    VagrantPlugins::GuestTinyCore::Plugin
       .components
-      .guest_capabilities[:darwin]
+      .guest_capabilities[:tinycore]
   end
 
+  let(:shutdown_command){ "poweroff" }
   let(:machine) { double("machine") }
   let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
 
@@ -22,19 +23,19 @@ describe "VagrantPlugins::GuestDarwin::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -h now")
+      comm.expect_command(shutdown_command)
       cap.halt(machine)
     end
 
     it "ignores an IOError" do
-      comm.stub_command("/sbin/shutdown -h now", raise: IOError)
+      comm.stub_command(shutdown_command, raise: IOError)
       expect {
         cap.halt(machine)
       }.to_not raise_error
     end
 
     it "ignores a Vagrant::Errors::SSHDisconnected" do
-      comm.stub_command("/sbin/shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      comm.stub_command(shutdown_command, raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error


### PR DESCRIPTION
When halting the VM the sshd may be stopped before the ssh connection in use has been closed. This causes an SSHDisconnected error to bubble up and the UI to display an error message. Change rescues out the SSHDisconnected exception to prevent error message from surfacing.