### PR TITLE
Remove --interactive flag from Docker command

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
         run_cmd += volumes.map { |v| ['-v', v.to_s] }
         run_cmd += %W(--privileged) if params[:privileged]
         run_cmd += %W(-h #{params[:hostname]}) if params[:hostname]
-        run_cmd << "-i" << "-t" if params[:pty]
+        run_cmd << "-t" if params[:pty]
         run_cmd << "--rm=true" if params[:rm]
         run_cmd += params[:extra_args] if params[:extra_args]
         run_cmd += [image, cmd]


### PR DESCRIPTION
See: https://github.com/mitchellh/vagrant/issues/7597.

Due to the childprocess gem setting STDIN to a pipe, Docker will fail as it requires STDIN to be a TTY if run with --interactive.