### PR TITLE
Fix RDP connections on OS X

### DIFF
--- a/plugins/hosts/darwin/cap/rdp.rb
+++ b/plugins/hosts/darwin/cap/rdp.rb
@@ -40,12 +40,12 @@ module VagrantPlugins
             f.binmode
 
             opts.each do |k, v|
-              f.write("#{k}:#{v}")
+              f.puts("#{k}:#{v}")
             end
 
             if rdp_info[:extra_args]
               rdp_info[:extra_args].each do |arg|
-                f.write("#{arg}")
+                f.puts("#{arg}")
               end
             end
 

--- a/test/unit/plugins/hosts/darwin/cap/rdp_test.rb
+++ b/test/unit/plugins/hosts/darwin/cap/rdp_test.rb
@@ -13,18 +13,18 @@ describe VagrantPlugins::HostDarwin::Cap::RDP do
 
   it "includes the default options" do
     path = described_class.generate_config_file(rdp_info)
-    result = File.read(path)
-    expect(result).to match("drivestoredirect:s:*")
-    expect(result).to match("full address:s:host:port")
-    expect(result).to match("prompt for credentials:i:1")
-    expect(result).to match("username:s:username")
+    result = File.readlines(path).map(&:chomp)
+    expect(result).to include("drivestoredirect:s:*")
+    expect(result).to include("full address:s:host:port")
+    expect(result).to include("prompt for credentials:i:1")
+    expect(result).to include("username:s:username")
   end
 
   it "includes extra RDP arguments" do
     rdp_info.merge!(extra_args: ["screen mode id:i:0"])
     path = described_class.generate_config_file(rdp_info)
-    result = File.read(path)
-    expect(result).to match("screen mode id:i:0")
+    result = File.readlines(path).map(&:chomp)
+    expect(result).to include("screen mode id:i:0")
   end
 
   it "opens the RDP file" do


### PR DESCRIPTION
Changes introduced in 982af05 caused the RDP configuration file to be written
with all settings on one line instead of one setting per line. The Microsoft
Remote Desktop client for OS X rejects these configuration files as being
malformed. This patch restores the configuration to one line per setting and
adds tests to guard against regression.