### PR TITLE
guests/bsds: shutdown fixes and dragonfly detection

### DIFF
--- a/plugins/guests/bsd/guest.rb
+++ b/plugins/guests/bsd/guest.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module GuestBSD
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("uname -s | grep -i 'Darwin|BSD'")
+        machine.communicate.test("uname -s | grep -i 'BSD'")
       end
     end
   end

--- a/plugins/guests/dragonflybsd/guest.rb
+++ b/plugins/guests/dragonflybsd/guest.rb
@@ -1,0 +1,9 @@
+module VagrantPlugins
+  module GuestDragonFlyBSD
+    class Guest < Vagrant.plugin("2", :guest)
+      def detect?(machine)
+        machine.communicate.test("uname -s | grep -i 'DragonFly'")
+      end
+    end
+  end
+end

--- a/plugins/guests/dragonflybsd/plugin.rb
+++ b/plugins/guests/dragonflybsd/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestDragonFlyBSD
+    class Plugin < Vagrant.plugin("2")
+      name "DragonFly BSD guest"
+      description "DragonFly BSD guest support."
+
+      guest(:dragonflybsd, :bsd) do
+        require_relative "guest"
+        Guest
+      end
+    end
+  end
+end

--- a/plugins/guests/openbsd/cap/halt.rb
+++ b/plugins/guests/openbsd/cap/halt.rb
@@ -1,0 +1,19 @@
+module VagrantPlugins
+  module GuestOpenBSD
+    module Cap
+      class Halt
+        def self.halt(machine)
+          begin
+            # Versions of OpenBSD prior to 5.7 require the -h option to be
+            # provided with the -p option. Later options allow the -h to
+            # be optional.
+            machine.communicate.sudo("/sbin/shutdown -p -h now", shell: "sh")
+          rescue IOError, Vagrant::Errors::SSHDisconnected
+            # Do nothing, because it probably means the machine shut down
+            # and SSH connection was lost.
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/openbsd/plugin.rb
+++ b/plugins/guests/openbsd/plugin.rb
@@ -21,6 +21,11 @@ module VagrantPlugins
         Cap::ConfigureNetworks
       end
 
+      guest_capability(:openbsd, :halt) do
+        require_relative "cap/halt"
+        Cap::Halt
+      end
+
       guest_capability(:openbsd, :rsync_install) do
         require_relative "cap/rsync"
         Cap::RSync

--- a/test/unit/plugins/guests/openbsd/cap/halt_test.rb
+++ b/test/unit/plugins/guests/openbsd/cap/halt_test.rb
@@ -1,0 +1,43 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestOpenBSD::Cap::Halt" do
+  let(:caps) do
+    VagrantPlugins::GuestOpenBSD::Plugin
+      .components
+      .guest_capabilities[:openbsd]
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".halt" do
+    let(:cap) { caps.get(:halt) }
+
+    it "runs the shutdown command" do
+      comm.expect_command("/sbin/shutdown -p -h now")
+      cap.halt(machine)
+    end
+
+    it "ignores an IOError" do
+      comm.stub_command("/sbin/shutdown -p -h now", raise: IOError)
+      expect {
+        cap.halt(machine)
+      }.to_not raise_error
+    end
+
+    it "ignores an Vagrant::Errors::SSHDisconnected" do
+      comm.stub_command("/sbin/shutdown -p -h now", raise: Vagrant::Errors::SSHDisconnected)
+      expect {
+        cap.halt(machine)
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Adds guest detection for DragonFly BSD. Removes Darwin from matching base BSD guest. Provide custom halt behavior for OpenBSD which requires `-h` option to be used on versions prior to 5.7.

http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sbin/shutdown/shutdown.8?rev=1.40&content-type=text/x-cvsweb-markup
http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sbin/shutdown/shutdown.c?rev=1.40&content-type=text/x-cvsweb-markup