### PR TITLE
fix #7489 preventing winrm connection leakage

### DIFF
--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -56,11 +56,15 @@ module VagrantPlugins
       def powershell(command, &block)
         # Ensure an exit code
         command += "\r\nif ($?) { exit 0 } else { if($LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 } }"
-        execute_with_rescue(executor.method("run_powershell_script"), command, &block)
+        session.create_executor do |executor|
+          execute_with_rescue(executor.method("run_powershell_script"), command, &block)
+        end
       end
 
       def cmd(command, &block)
-        execute_with_rescue(executor.method("run_cmd"), command, &block)
+        session.create_executor do |executor|
+          execute_with_rescue(executor.method("run_cmd"), command, &block)
+        end
       end
 
       def wql(query, &block)
@@ -170,10 +174,6 @@ module VagrantPlugins
 
       def session
         @session ||= new_session
-      end
-
-      def executor
-        @executor ||= session.create_executor
       end
 
       def endpoint

--- a/test/unit/plugins/communicators/winrm/shell_test.rb
+++ b/test/unit/plugins/communicators/winrm/shell_test.rb
@@ -6,7 +6,7 @@ require Vagrant.source_root.join("plugins/communicators/winrm/config")
 describe VagrantPlugins::CommunicatorWinRM::WinRMShell do
   include_context "unit"
 
-  let(:session) { double("winrm_session", create_executor: executor) }
+  let(:session) { double("winrm_session") }
   let(:executor) { double("command_executor") }
   let(:port) { config.transport == :ssl ? 5986 : 5985 }
   let(:config)  {
@@ -21,6 +21,8 @@ describe VagrantPlugins::CommunicatorWinRM::WinRMShell do
       c.finalize!
     end
   }
+
+  before { allow(session).to receive(:create_executor).and_yield(executor) }
 
   subject do
     described_class.new('localhost', port, config).tap do |comm|


### PR DESCRIPTION
This ensures that all winrm commands open a new connection and close it after the command. While the previous shell code is "mostly" leak proof, it keeps a connection open for each `WinRMShell` instance and does not close them until the vagrant process exits. Thats generally a more efficient approach and reduces connection startup overhead for multiple commands. In the case of Windows 2008 R2, the default maximum open shells is 5. So if one uses multiple vagrant plugins, it may be easy to exceed this maximum and errors will ensue.

The cost savings of openning new connections really does not outweigh the error scenarios possible here on Windows 2008R2 (and Windows 7).