### PR TITLE
Do not use UNC path for Solaris guest on Windows

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -609,9 +609,10 @@ module VagrantPlugins
         end
 
         def share_folders(folders)
+          guestOS = read_guest_property("/VirtualBox/GuestInfo/OS/Product")
           folders.each do |folder|
             hostpath = folder[:hostpath]
-            if Vagrant::Util::Platform.windows?
+            if Vagrant::Util::Platform.windows? && guestOS != "SunOS"
               hostpath = Vagrant::Util::Platform.windows_unc_path(hostpath)
             end
             args = ["--name",

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -610,9 +610,10 @@ module VagrantPlugins
         end
 
         def share_folders(folders)
+          guestOS = read_guest_property("/VirtualBox/GuestInfo/OS/Product")
           folders.each do |folder|
             hostpath = folder[:hostpath]
-            if Vagrant::Util::Platform.windows?
+            if Vagrant::Util::Platform.windows? && guestOS != "SunOS"
               hostpath = Vagrant::Util::Platform.windows_unc_path(hostpath)
             end
             args = ["--name",

--- a/plugins/providers/virtualbox/driver/version_5_1.rb
+++ b/plugins/providers/virtualbox/driver/version_5_1.rb
@@ -610,9 +610,10 @@ module VagrantPlugins
         end
 
         def share_folders(folders)
+          guestOS = read_guest_property("/VirtualBox/GuestInfo/OS/Product")
           folders.each do |folder|
             hostpath = folder[:hostpath]
-            if Vagrant::Util::Platform.windows?
+            if Vagrant::Util::Platform.windows? && guestOS != "SunOS"
               hostpath = Vagrant::Util::Platform.windows_unc_path(hostpath)
             end
             args = ["--name",


### PR DESCRIPTION
Virtualbox Solaris guest additions are not compatible with UNC path Issue #7264 
