### PR TITLE
Machine data directory for base box package

### DIFF
--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -56,14 +56,20 @@ module VagrantPlugins
         # better in the future. We just hardcode this to keep VirtualBox working
         # for now.
         provider = Vagrant.plugin("2").manager.providers[:virtualbox]
-        vm = Vagrant::Machine.new(
-          options[:base],
-          :virtualbox, provider[0], nil, provider[1],
-          @env.vagrantfile.config,
-          nil, nil,
-          @env, @env.vagrantfile, true)
-        @logger.debug("Packaging base VM: #{vm.name}")
-        package_vm(vm, options)
+        tmp_data_directory = File.join(@env.tmp_path, SecureRandom.uuid)
+        FileUtils.mkdir_p(tmp_data_directory)
+        begin
+          vm = Vagrant::Machine.new(
+            options[:base],
+            :virtualbox, provider[0], nil, provider[1],
+            @env.vagrantfile.config,
+            Pathname.new(tmp_data_directory), nil,
+            @env, @env.vagrantfile, true)
+          @logger.debug("Packaging base VM: #{vm.name}")
+          package_vm(vm, options)
+        ensure
+          FileUtils.rm_rf(tmp_data_directory)
+        end
       end
 
       def package_target(name, options)

--- a/test/unit/plugins/commands/package/command_test.rb
+++ b/test/unit/plugins/commands/package/command_test.rb
@@ -1,0 +1,102 @@
+require_relative "../../../base"
+require_relative "../../../../../plugins/commands/package/command"
+
+RSpec::Matchers.define :a_machine_named do |name|
+  match{ |actual| actual.name.to_s == name.to_s }
+end
+
+RSpec::Matchers.define :an_existing_directory do
+  match{ |actual| File.directory?(actual) }
+end
+
+describe VagrantPlugins::CommandPackage::Command do
+  include_context "unit"
+
+  let(:argv)     { [] }
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:package_command) { described_class.new(argv, iso_env) }
+
+  let(:action_runner) { double("action_runner") }
+
+  before do
+    iso_env.stub(action_runner: action_runner)
+  end
+
+  describe "#execute" do
+
+    context "with no arguments" do
+
+      it "packages default machine" do
+        expect(package_command).to receive(:package_vm).with(a_machine_named('default'), {})
+        package_command.execute
+      end
+    end
+
+    context "with single argument" do
+      context "set to default" do
+
+        let(:argv){ ['default'] }
+
+        it "packages default machine" do
+          expect(package_command).to receive(:package_vm).with(a_machine_named('default'), {})
+          package_command.execute
+        end
+      end
+
+      context "set to undefined vm" do
+
+        let(:argv){ ['undefined'] }
+
+        it "raises machine not found error" do
+          expect{ package_command.execute }.to raise_error(Vagrant::Errors::MachineNotFound)
+        end
+      end
+    end
+
+    context "with multiple arguments" do
+
+      let(:argv){ ['default', 'undefined'] }
+
+      it "ignores the extra arguments" do
+        expect(package_command).to receive(:package_vm).with(a_machine_named('default'), {})
+        package_command.execute
+      end
+    end
+
+    context "with --base option" do
+      context "and no option value" do
+
+        let(:argv){ ['--base'] }
+
+        it "shows help" do
+          expect{ package_command.execute }.to raise_error(Vagrant::Errors::CLIInvalidOptions)
+        end
+      end
+
+      context "and option value" do
+
+        let(:argv){ ['--base', 'machine-id'] }
+
+        it "packages vm defined within virtualbox" do
+          expect(package_command).to receive(:package_base).with(:base => 'machine-id')
+          package_command.execute
+        end
+
+        it "provides a machine data directory" do
+          expect(Vagrant::Machine).to receive(:new).with(
+            'machine-id', :virtualbox, anything, nil, anything, anything, an_existing_directory,
+            anything, anything, anything, anything).and_return(double("vm", name: "machine-id"))
+          allow(package_command).to receive(:package_vm)
+          package_command.execute
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Fixes an issue referenced in #5070 by providing a temporary machine data directory. Includes some initial basic tests on the `package` command that includes testing for a valid machine data directory when using `--base` option.