### PR TITLE
Documenting the need for ruby 2.2 to install listen gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and you're welcome to give it a shot. The following is an example showing how to
 
     rake install
 
-Ruby 2.0 is needed.
+Ruby 2.2 or higher is needed.
 
 ## Contributing to Vagrant
 


### PR DESCRIPTION
When running `bundle install` before `rake install` you get `Gem::InstallError: listen requires Ruby version >= 2.2.3, ~> 2.2.`