### PR TITLE
Add NFSv4 warning and information

### DIFF
--- a/plugins/synced_folders/nfs/synced_folder.rb
+++ b/plugins/synced_folders/nfs/synced_folder.rb
@@ -130,6 +130,11 @@ module VagrantPlugins
         opts[:nfs_udp] = true if !opts.key?(:nfs_udp)
         opts[:nfs_version] ||= 3
 
+
+        if opts[:nfs_version].to_s.start_with?('4') && opts[:nfs_udp]
+          machine.ui.info I18n.t("vagrant.actions.vm.nfs.v4_with_udp_warning")
+        end
+
         # We use a CRC32 to generate a 32-bit checksum so that the
         # fsid is compatible with both old and new kernels.
         opts[:uuid] = Zlib.crc32(opts[:hostpath]).to_s

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1845,6 +1845,19 @@ en:
           exporting: Exporting NFS shared folders...
           installing: "Installing NFS client..."
           mounting: Mounting NFS shared folders...
+          v4_with_udp_warning: |-
+
+            WARNING: Invalid NFS settings detected!
+
+            Detected UDP enabled with NFSv4. NFSv4 does not support UDP.
+            If folder mount fails disable UDP using the following option:
+
+              nfs_udp: false
+
+            For more information see:
+            RFC5661: https://tools.ietf.org/html/rfc5661#section-2.9.1
+            RFC7530: https://tools.ietf.org/html/rfc7530#section-3.1
+
         provision:
           beginning: "Running provisioner: %{provisioner}..."
           disabled_by_config: |-

--- a/website/source/docs/synced-folders/nfs.html.md
+++ b/website/source/docs/synced-folders/nfs.html.md
@@ -188,3 +188,29 @@ will refuse to export the filesystem. The error message given by NFS is
 often not clear. One error message seen is `<path> does not support NFS`.
 There is no workaround for this other than sharing a directory which is not
 encrypted.
+
+**Version 4:** UDP is generally not a valid transport protocol for NFSv4.
+Early implementations of NFS 4.0 still allowed UDP which allows the UDP
+transport protocol to be used in rare cases. RFC5661 explicitly states
+UDP alone should not be used for the transport protocol in NFS 4.1. Errors
+due to unsupported transport protocols for specific versions of NFS are
+not always clear. A common error message when attempting to use UDP with
+NFSv4:
+
+```
+mount.nfs: an incorrect mount option was specified
+```
+
+When using NFSv4, ensure the `nfs_udp` option is set to false. For example:
+
+```
+config.vm.synced_folder ".", "/vagrant",
+    :nfs => true,
+    :nfs_version => 4,
+    :nfs_udp => false
+```
+
+For more information about transport protocols and NFS version 4 see:
+
+* NFSv4.0 - [RFC7530](https://tools.ietf.org/html/rfc7530#section-3.1)
+* NFSv4.1 - [RFC5661](https://tools.ietf.org/html/rfc5661#section-2.9.1)


### PR DESCRIPTION
Include warning when mounting synced folder using NFS with possibly invalid options. Adds note to documentation about NFSv4 and UDP.