### PR TITLE
added missing part of logic - removed in b91c167

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -30,10 +30,13 @@ module VagrantPlugins
               grep -w '#{name}' /etc/hosts || {
                 sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
               }
-
-              # Restart network
-              service network restart
             EOH
+            if machine.guest.capability("flavor") != :rhel_7
+              comm.sudo <<-EOH.gsub(/^ {14}/, '')
+                # Restart network
+                service network restart
+              EOH
+            end
           end
         end
       end


### PR DESCRIPTION
`vagrant version - 1.8.5`
`VirtualBox version - 5.1.4r110228`

when working with CentOS7 box I'm getting [error](https://gist.github.com/wakeful/ff9639dccff2219cdf6766c0fb98bd0d). According to [b91c167](https://github.com/mitchellh/vagrant/commit/b91c167b191be6633e060d9772cf1c5ccc2b0291#diff-fd473b135e71706459b47b51cb86e249L20) 'network restart' was always skipped for rhel7 base boxes.


