### PR TITLE
Fix CentOS7 network config - do not prompt before overwriting

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -50,6 +50,11 @@ module VagrantPlugins
             EOH
           end
 
+          commands << <<-EOH.gsub(/^ {14}/, '')
+            # Restart network
+            service network restart
+          EOH
+
           comm.sudo(commands.join("\n"))
         end
       end

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
               /sbin/ifdown '#{network[:device]}' || true
 
               # Move new config into place
-              mv '#{remote_path}' '#{final_path}'
+              mv -f '#{remote_path}' '#{final_path}'
 
               # Bring the interface up
               ARPCHECK=no /sbin/ifup '#{network[:device]}'


### PR DESCRIPTION
`vagrant version - 1.8.5`
`VirtualBox version - 5.1.4r110228`

assuming a scenario - vagrant up -> power off -> vagrant up
vagrant will stuck on the network configuration

`DEBUG ssh: stdout: mv: overwrite '/etc/sysconfig/network-scripts/ifcfg-eth0'?`
`DEBUG ssh: Sending SSH keep-alive...`
