### PR TITLE
Fix Vagrant not prioritizing configured providers correctly

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -338,7 +338,7 @@ module Vagrant
       # a priority to each in the order they exist so that we try these first.
       config = {}
       root_config.vm.__providers.reverse.each_with_index do |key, idx|
-        config[key] = idx
+        config[key] = idx + 1
       end
 
       # Determine the max priority so that we can add the config priority

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -866,6 +866,30 @@ VF
       end
     end
 
+    it "is the provider in the Vagrantfile that is usable even if only one specified (1)" do
+      subject.vagrantfile.config.vm.provider "foo"
+      subject.vagrantfile.config.vm.finalize!
+
+      plugin_providers[:foo] = [provider_usable_class(true), { priority: 5 }]
+      plugin_providers[:bar] = [provider_usable_class(true), { priority: 7 }]
+
+      with_temp_env("VAGRANT_DEFAULT_PROVIDER" => nil) do
+        expect(subject.default_provider).to eq(:foo)
+      end
+    end
+
+    it "is the provider in the Vagrantfile that is usable even if only one specified (2)" do
+      subject.vagrantfile.config.vm.provider "bar"
+      subject.vagrantfile.config.vm.finalize!
+
+      plugin_providers[:foo] = [provider_usable_class(true), { priority: 7 }]
+      plugin_providers[:bar] = [provider_usable_class(true), { priority: 5 }]
+
+      with_temp_env("VAGRANT_DEFAULT_PROVIDER" => nil) do
+        expect(subject.default_provider).to eq(:bar)
+      end
+    end
+
     it "is the highest usable provider outside the Vagrantfile" do
       subject.vagrantfile.config.vm.provider "foo"
       subject.vagrantfile.config.vm.finalize!


### PR DESCRIPTION
Fixes #7135: config.vm.provider not setting provider in multi-machine Vagrantfile

Steps to reproduce:
1. Make `Vagrantfile`
2. Configure only one provider using `config.vm.provider`.
3. `vagrant up`
4. Default provider may get used instead of configured one.

I tracked the bug to these lines in lib/vagrant/environment.rb:
```
      root_config.vm.__providers.reverse.each_with_index do |key, idx|
        config[key] = idx
      end
```
Later in the same function it increases the provider's priority if the provider was mentioned in the config:
```
        priority = config[key] + max_priority if config.key?(key)
```
However, if the index of the provider in the `__providers` list is 0, as it would be if it's the only one, priority ends up being set to the max priority instead of to the max priority + 1. That means there are 2 providers with the same priority, the one you specified and the one which originally had the max priority, which means that there's no reason to prefer the provider you specified over the original default.

This patch addresses the issue by ensuring that the `config[]` dict gets set with values greater than 0.