### PR TITLE
Allow closing a Vagrant::Util::Subprocess's STDIN

### DIFF
--- a/test/unit/vagrant/util/subprocess_test.rb
+++ b/test/unit/vagrant/util/subprocess_test.rb
@@ -1,0 +1,50 @@
+require File.expand_path("../../../base", __FILE__)
+require "vagrant/util/subprocess"
+
+describe Vagrant::Util::Subprocess do
+  describe '#execute' do
+    before do
+      # ensure we have `cat` and `echo` in our PATH so that we can run these
+      # tests successfully.
+      ['cat', 'echo'].each do |cmd|
+        if !Vagrant::Util::Which.which(cmd)
+          pending("cannot run subprocess tests without command #{cmd.inspect}")
+        end
+      end
+    end
+
+    let (:cat) { described_class.new('cat', :notify => [:stdin]) }
+
+    it 'yields the STDIN stream for the process if we set :notify => :stdin' do
+      echo = described_class.new('echo', 'hello world', :notify => [:stdin])
+      echo.execute do |type, data|
+        expect(type).to eq(:stdin)
+        expect(data).to be_a(::IO)
+      end
+    end
+
+    it 'can close STDIN' do
+      result = cat.execute do |type, stdin|
+        # We should be able to close STDIN without raising an exception
+        stdin.close
+      end
+
+      # we should exit successfully.
+      expect(result.exit_code).to eq(0)
+    end
+
+    it 'can write to STDIN correctly' do
+      data = "hello world\n"
+      result = cat.execute do |type, stdin|
+        stdin.write(data)
+        stdin.close
+      end
+
+      # we should exit successfully.
+      expect(result.exit_code).to eq(0)
+
+      # we should see our data as the output from `cat`
+      expect(result.stdout).to eq(data)
+    end
+  end
+end


### PR DESCRIPTION
Previously, there was no way to close the STDIN stream of a subprocess,
so commands that read from stdin in a subprocess would hang forever,
such as `/bin/sh -s`. If one tried to close the stdin, the
IO.select() call in Subprocess#execute would raise an error for calling
select() on a closed IO.

Here's a concrete example of a command that needs to close STDIN to work
properly:

```ruby
script = SOME_VERY_LONG_STRING
command = %w(ssh foo.example.com /bin/sh -s foo bar)
result = ::Vagrant::Util::Subprocess.execute(*command) do |type, data_or_io|
  if type == :stdin
    data_or_io.write(script)
    data_or_io.write("\n")
    data_or_io.close
    next
  end

  puts "Remote: #{data_or_io}"
end
```