### PR TITLE
[windows] Use subprocess for safe_exec on windows

### DIFF
--- a/lib/vagrant/util/safe_exec.rb
+++ b/lib/vagrant/util/safe_exec.rb
@@ -23,6 +23,7 @@ module Vagrant
         begin
           if fork_instead
             if Vagrant::Util::Platform.windows?
+              @@logger.debug("Using subprocess because windows platform")
               args = args.dup << {notify: [:stdout, :stderr]}
               result = Vagrant::Util::Subprocess.execute(command, *args) do |type, data|
                 case type

--- a/lib/vagrant/util/safe_exec.rb
+++ b/lib/vagrant/util/safe_exec.rb
@@ -7,6 +7,9 @@ module Vagrant
     # thread. In that case, `safe_exec` automatically falls back to
     # forking.
     class SafeExec
+
+      @@logger = Log4r::Logger.new("vagrant::util::safe_exec")
+
       def self.exec(command, *args)
         # Create a list of things to rescue from. Since this is OS
         # specific, we need to do some defined? checks here to make
@@ -18,10 +21,26 @@ module Vagrant
 
         fork_instead = false
         begin
-          pid = nil
-          pid = fork if fork_instead
-          Kernel.exec(command, *args) if pid.nil?
-          Process.wait(pid) if pid
+          if fork_instead
+            if Vagrant::Util::Platform.windows?
+              args = args.dup << {notify: [:stdout, :stderr]}
+              result = Vagrant::Util::Subprocess.execute(command, *args) do |type, data|
+                case type
+                when :stdout
+                  @@logger.info(data, new_line: false)
+                when :stderr
+                  @@logger.info(data, new_line: false)
+                end
+              end
+              Kernel.exit(result.exit_code)
+            else
+              pid = fork
+              Kernel.exec(command, *args)
+              Process.wait(pid)
+            end
+          else
+            Kernel.exec(command, *args)
+          end
         rescue *rescue_from
           # We retried already, raise the issue and be done
           raise if fork_instead


### PR DESCRIPTION
Detects Windows platform within `SafeExec.exec` and uses `Subprocess` instead of `fork`. Related to #6938. 

I am curious if there's actually a need for two code paths here. Always running through `Subprocess` when using `Kernel.exec` directly fails seems like a more consistent implementation. Any thoughts?