### PR TITLE
Fix non upstart linux nfs mounts

### DIFF
--- a/plugins/guests/linux/cap/nfs.rb
+++ b/plugins/guests/linux/cap/nfs.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
             # Emit a mount event
             commands << <<-EOH.gsub(/^ {14}/, '')
-              if command -v /sbin/init && /sbin/init --version | grep upstart; then
+              if test -x /sbin/initctl && command -v /sbin/init && /sbin/init --version | grep upstart; then
                 /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guest_path}
               fi
             EOH


### PR DESCRIPTION
I ran into a very weird bug when trying to run openwrt (x86) machines on vagrant, they locked when mounting nfs, even when it mounted successfully.

I discovered it was because the `/sbin/init` binary in openwrt ignores the `--version` parameter and open a menu, stoping the box creation process.

This fix should work for any non upstart (and the ones that use upstart) Linux distros.