### PR TITLE
Add Virtuozzo Linux 7 to list of RHEL flavors

### DIFF
--- a/plugins/guests/redhat/cap/flavor.rb
+++ b/plugins/guests/redhat/cap/flavor.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
           end
 
           # Detect various flavors we care about
-          if output =~ /(CentOS|Red Hat Enterprise|Scientific|Cloud)\s*Linux( .+)? release 7/i
+          if output =~ /(CentOS|Red Hat Enterprise|Scientific|Cloud|Virtuozzo)\s*Linux( .+)? release 7/i
             return :rhel_7
           else
             return :rhel


### PR DESCRIPTION
Virtuozzo linux is based on RHEL and needs the same type of network configuration.