### PR TITLE
Make Debian guest detection more reliable

### DIFF
--- a/plugins/guests/debian/guest.rb
+++ b/plugins/guests/debian/guest.rb
@@ -4,7 +4,17 @@ module VagrantPlugins
   module GuestDebian
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("cat /etc/issue | grep 'Debian'")
+        machine.communicate.test <<-EOH.gsub(/^ {10}/, "")
+          if test -r /etc/os-release; then
+            source /etc/os-release && test xdebian = x$ID
+          elif test -x /usr/bin/lsb_release; then
+            /usr/bin/lsb_release -i 2>/dev/null | grep -q Debian
+          elif test -r /etc/issue; then
+            cat /etc/issue | grep 'Debian'
+          else
+            exit 1
+          fi
+        EOH
       end
     end
   end


### PR DESCRIPTION
`/etc/issue` is far from being a reliable source for OS detection as it
can be changed by a user without affecting any OS functionality. As
newer Debian systems run systemd by default, check for `/etc/os-release`
and fallback to `lsb_release` for older Debian versions. Check #7625 for
a similar issue. Even `lsb_release` is not manatory, therefore keep the
current code of parsing `/etc/issue` to avoid regressions.

This fixes #7826 