### PR TITLE
Use the cmd shell to check winrm availability to fix `vagrant up --no-provision` on nano

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -104,7 +104,7 @@ module VagrantPlugins
         @logger.info("Checking whether WinRM is ready...")
 
         result = Timeout.timeout(@machine.config.winrm.timeout) do
-          shell(true).powershell("hostname")
+          shell(true).cmd("hostname")
         end
 
         @logger.info("WinRM is ready!")

--- a/test/unit/plugins/communicators/winrm/communicator_test.rb
+++ b/test/unit/plugins/communicators/winrm/communicator_test.rb
@@ -45,7 +45,7 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
             port: '22',
           })
           # Makes ready? return true
-          allow(shell).to receive(:powershell).with("hostname").and_return({ exitcode: 0 })
+          allow(shell).to receive(:cmd).with("hostname").and_return({ exitcode: 0 })
         end
 
         it "retries ssh_info until ready" do
@@ -57,22 +57,22 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
 
   describe ".ready?" do
     it "returns true if hostname command executes without error" do
-      expect(shell).to receive(:powershell).with("hostname").and_return({ exitcode: 0 })
+      expect(shell).to receive(:cmd).with("hostname").and_return({ exitcode: 0 })
       expect(subject.ready?).to be_true
     end
 
     it "returns false if hostname command fails with a transient error" do
-      expect(shell).to receive(:powershell).with("hostname").and_raise(VagrantPlugins::CommunicatorWinRM::Errors::TransientError)
+      expect(shell).to receive(:cmd).with("hostname").and_raise(VagrantPlugins::CommunicatorWinRM::Errors::TransientError)
       expect(subject.ready?).to be_false
     end
 
     it "raises an error if hostname command fails with an unknown error" do
-      expect(shell).to receive(:powershell).with("hostname").and_raise(Vagrant::Errors::VagrantError)
+      expect(shell).to receive(:cmd).with("hostname").and_raise(Vagrant::Errors::VagrantError)
       expect { subject.ready? }.to raise_error(Vagrant::Errors::VagrantError)
     end
 
     it "raises timeout error when hostname command takes longer then winrm timeout" do
-      expect(shell).to receive(:powershell).with("hostname") do
+      expect(shell).to receive(:cmd).with("hostname") do
         sleep 2 # winrm.timeout = 1
       end
       expect { subject.ready? }.to raise_error(Timeout::Error)


### PR DESCRIPTION
As of the RTM release of Windows Nano, the initial availability check of the winrm communicator hangs. Not just on RTM but all previous technical previews of nano, the version of the winrm gem used by vagrant cannot speak powershell to nano. I plan to refactor the communicator code later touse the newer winrm that can talk to nano. This PR switches the initial availability check to `:cmd` so that at least a basic `vagrant up` with `--no-provision` can succeed. If vagrant releases before the new winrm refactor, this small change will get other tools like Test-Kitchen working with vagrant on Windows Nano.