### PR TITLE
Bump nokogiri dependency to the latest stable version

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "winrm-fs", "~> 0.3.0"
 
   # We lock this down to avoid compilation issues.
-  s.add_dependency "nokogiri", "= 1.6.7.1"
+  s.add_dependency "nokogiri", "= 1.6.8"
 
   # NOTE: The ruby_dep gem is an implicit dependency from the listen gem. Later versions
   # of the ruby_dep gem impose an aggressive constraint on the required ruby version (>= 2.2.5).


### PR DESCRIPTION
ChefDK 0.18.26 released with Berkshelf 5.1.0 and embedded Ruby 2.3.1. To use Ruby 2.3.1 and berkshelf 5.1.0 together with vagrant-berkshelf plugin, vagrant-berkshelf plugin have to update nokogiri dependency to 1.6.8 because nokogiri 1.6.7.1 is not compatible with Ruby < 2.3 as following:

```
C:\oss\vagrant-berkshelf>gem install nokogiri -v '1.6.7.1'
WARNING:  You don't have c:\users\joel\appdata\local\chefdk\gem\ruby\2.3.0\bin in your PATH,
          gem executables will not run.
ERROR:  Error installing nokogiri:
        nokogiri requires Ruby version < 2.3, >= 1.9.2.
```

And when nokogiri 1.6.8 is set as dependency in vagrant-berkshelf Gemfile, following error is shown:

```
C:\oss\vagrant-berkshelf>bundle install
Your Gemfile lists the gem vagrant-berkshelf (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Fetching git://github.com/mitchellh/vagrant.git
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
Resolving dependencies..........
Bundler could not find compatible versions for gem "nokogiri":
  In Gemfile:
    nokogiri (>= 1.6.8) x86-mingw32

    vagrant x86-mingw32 was resolved to 1.8.6.dev, which depends on
      nokogiri (= 1.6.7.1) x86-mingw32
```

Above error suggests nokogiri dependency needs to be upgraded in vagrant first, then vagrant-berkshelf can upgrade nokogiri dependency to 1.6.8, then ChefDK 0.18.26 can be used with vagrant-berkshelf plugin without following error:

```
C:\Users\Joel\test>vagrant up test
Bringing machine 'test' up with 'virtualbox' provider...
The Berkshelf version at "C:\\opscode\\chefdk\\embedded\\bin/berks.BAT" is invalid.
Vagrant Berkshelf requires ~> 4.0, but the current version is 5.1.0.

Please download and install the latest version of the ChefDK from:

    https://downloads.chef.io/chef-dk

and follow the installation instructions. Do not forget to add the ChefDK to
your PATH.
```

The environment of this context is Windows 10. 

https://github.com/mitchellh/vagrant/issues/6766, https://github.com/berkshelf/vagrant-berkshelf/issues/305, https://github.com/berkshelf/vagrant-berkshelf/pull/306 is related with this.
