### PR TITLE
add the `salt_call_args` option

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -29,6 +29,7 @@ module VagrantPlugins
       attr_accessor :log_level
       attr_accessor :masterless
       attr_accessor :minion_id
+      attr_accessor :salt_call_args
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -68,6 +69,7 @@ module VagrantPlugins
         @bootstrap_options = UNSET_VALUE
         @masterless = UNSET_VALUE
         @minion_id = UNSET_VALUE
+	@salt_call_args = UNSET_VALUE
         @version = UNSET_VALUE
         @run_service = UNSET_VALUE
         @master_id = UNSET_VALUE
@@ -99,6 +101,7 @@ module VagrantPlugins
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @masterless         = false if @masterless == UNSET_VALUE
         @minion_id          = nil if @minion_id == UNSET_VALUE
+        @salt_call_args     = nil if @salt_call_args == UNSET_VALUE
         @version            = nil if @version == UNSET_VALUE
         @run_service        = nil if @run_service == UNSET_VALUE
         @master_id          = nil if @master_id == UNSET_VALUE

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -151,24 +151,47 @@ module VagrantPlugins
       end
 
       ## Actions
-      # Get pillar string to pass with the salt command
-      def get_pillar
-        " pillar='#{@config.pillar_data.to_json}'" if !@config.pillar_data.empty?
-      end
 
-      # Get colorization option string to pass with the salt command
-      def get_colorize
-        @config.colorize ? " --force-color" : " --no-color"
-      end
+      # Get salt command options - either for salt-call or salt
+      def get_salt_cmd_options(is_call)
 
-      # Get log output level option string to pass with the salt command
-      def get_loglevel
+        if is_call
+          options = "--retcode-passthrough"
+        else
+          options = "--verbose"
+        end
+
+        if is_call and @config.salt_call_args
+           options = "%s %s" % [options, @config.salt_call_args]
+        end
+
+        if @config.masterless
+           options = "%s --local" % options
+        end
+
+        if @config.colorize
+          options = "%s --force-color" % options
+        else
+          options = "%s --no-color" % options
+        end
+
+
         log_levels = ["all", "garbage", "trace", "debug", "info", "warning", "error", "quiet"]
         if log_levels.include? @config.log_level
-          " --log-level=#{@config.log_level}"
+          options = "%s --log-level=%s" % [options, @config.log_level]
         else
-          " --log-level=debug"
+          options = "%s --log-level=debug" % options
         end
+
+        if @config.pillar_data
+           options = "%s pillar='%s'" % [options, @config.pillar_data.to_json]
+        end
+
+        if @config.verbose
+          @machine.env.ui.info "Using salt-call options: %s" % options
+        end
+
+        return options
       end
 
       # Copy master and minion configs to VM
@@ -238,19 +261,19 @@ module VagrantPlugins
           bootstrap_path = get_bootstrap
           if @machine.config.vm.communicator == :winrm
             if @config.version
-              options += " -version %s" % @config.version            
+              options += " -version %s" % @config.version
             end
             if @config.run_service
               @machine.env.ui.info "Salt minion will be stopped after installing."
-              options += " -runservice %s" % @config.run_service            
+              options += " -runservice %s" % @config.run_service
             end
             if @config.minion_id
               @machine.env.ui.info "Setting minion to @config.minion_id."
-              options += " -minion %s" % @config.minion_id            
+              options += " -minion %s" % @config.minion_id
             end
             if @config.master_id
               @machine.env.ui.info "Setting master to @config.master_id."
-              options += " -master %s" % @config.master_id            
+              options += " -master %s" % @config.master_id
             end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else
@@ -322,16 +345,12 @@ module VagrantPlugins
 
       def call_highstate
         if @config.run_highstate
-          local=""
-          if @config.masterless
-            local=" --local"
-          end
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
             unless @config.masterless?
               @machine.communicate.sudo("salt '*' saltutil.sync_all")
             end
-            @machine.communicate.sudo("salt '*' state.highstate --verbose #{local}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+            @machine.communicate.sudo("salt '*' state.highstate #{get_salt_cmd_options(false)}") do |type, data|
             if @config.verbose
                 @machine.env.ui.info(data.rstrip)
             end
@@ -342,7 +361,7 @@ module VagrantPlugins
               unless @config.masterless?
                 @machine.communicate.execute("C:\\salt\\salt-call.bat saltutil.sync_all", opts)
               end
-              @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate --retcode-passthrough #{local}#{get_loglevel}#{get_colorize}#{get_pillar}", opts) do |type, data|
+              @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate #{get_salt_cmd_options(true)}", opts) do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end
@@ -351,7 +370,7 @@ module VagrantPlugins
               unless @config.masterless?
                 @machine.communicate.sudo("salt-call saltutil.sync_all")
               end
-              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough #{local}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+              @machine.communicate.sudo("salt-call state.highstate #{get_salt_cmd_options(true)}") do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end

--- a/website/source/docs/provisioning/salt.html.md
+++ b/website/source/docs/provisioning/salt.html.md
@@ -106,11 +106,13 @@ pre-seeding it before use. Example: `{minion_name:/path/to/key.pub}`
 
 ## Execute States
 
-Either of the following may be used to actually execute states
-during provisioning.
+Used to actually execute states during provisioning.
 
 * `run_highstate` - (boolean) Executes `state.highstate` on
 vagrant up. Can be applied to any machine.
+
+* `salt_call_args`  (string) - Extra arguments to pass as-is to `salt-call` when executing states.
+Can be useful, for example, for `pillar_root` and `file_root`.
 
 ## Execute Runners
 


### PR DESCRIPTION
This option allows you to pass additional arguments to `salt-call`
during state execution, (similar to `install_args` in installation).
This is useful, for example, for `file-root` and `pillar-root`.

I have also taken the opportunity to reorganize the option string building of
`salt-call` in a similar way to `install`. Instead of multiple methods
that were called once, there is one simple method.
