### PR TITLE
guests/linux: Place ethernet devices at start of device list

### DIFF
--- a/plugins/guests/linux/cap/network_interfaces.rb
+++ b/plugins/guests/linux/cap/network_interfaces.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         # Valid ethernet device prefix values.
         # eth - classic prefix
         # en  - predictable interface names prefix
-        ETHERNET_PREFIX = ["eth", "en"]
+        POSSIBLE_ETHERNET_PREFIXES = ["eth".freeze, "en".freeze].freeze
 
         @@logger = Log4r::Logger.new("vagrant::guest::linux::network_interfaces")
 
@@ -25,8 +25,8 @@ module VagrantPlugins
           # Break out integers from strings and sort the arrays to provide
           # a natural sort for the interface names
           ifaces = ifaces.map do |iface|
-            unless eth_prefix
-              eth_prefix = ETHERNET_PREFIX.detect do |prefix|
+            if eth_prefix.nil?
+              eth_prefix = POSSIBLE_ETHERNET_PREFIXES.detect do |prefix|
                 iface.start_with?(prefix)
               end
             end

--- a/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
+++ b/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
@@ -56,6 +56,5 @@ describe "VagrantPlugins::GuestLinux::Cap::NetworkInterfaces" do
       result = cap.network_interfaces(machine)
       expect(result).to eq(["enp0s3", "enp0s5", "enp0s8", "bridge0", "docker0"])
     end
-
   end
 end

--- a/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
+++ b/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
@@ -44,5 +44,18 @@ describe "VagrantPlugins::GuestLinux::Cap::NetworkInterfaces" do
       result = cap.network_interfaces(machine)
       expect(result).to eq(["enp0s3", "enp0s5", "enp0s8", "enp0s10", "enp1s3"])
     end
+
+    it "sorts ethernet devices discovered with classic naming first in list" do
+      expect(comm).to receive(:sudo).and_yield(:stdout, "eth1\neth2\ndocker0\nbridge0\neth0")
+      result = cap.network_interfaces(machine)
+      expect(result).to eq(["eth0", "eth1", "eth2", "bridge0", "docker0"])
+    end
+
+    it "sorts ethernet devices discovered with predictable network interfaces naming first in list" do
+      expect(comm).to receive(:sudo).and_yield(:stdout, "enp0s8\ndocker0\nenp0s3\nbridge0\nenp0s5")
+      result = cap.network_interfaces(machine)
+      expect(result).to eq(["enp0s3", "enp0s5", "enp0s8", "bridge0", "docker0"])
+    end
+
   end
 end


### PR DESCRIPTION
Always provide sorted ethernet devices at the start of the network devices list.

Fixes #7844 