### PR TITLE
Add support for vmcx (Hyper-V binary config format) to the Hyper-V import script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ BUG FIXES:
   - guests/ubuntu: Fix detection on older guests [GH-7632, GH-7524, GH-7625]
   - hosts/arch: Detect NFS server by service name on arch [GH-7630, GH-7629]
   - hosts/darwin: Fix generated RDP configuration file [GH-7698]
+  - provisioners/ansible: Add support for `ssh.proxy_command` setting [GH-7752]
   - synced_folders/nfs: Display warning when configured for NFSv4 and UDP [GH-7740]
   - synced_folders/rsync: Properly ignore excluded files within synced directory
       from `chown` command. [GH-5256, GH-7726]

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -37,18 +37,27 @@ module VagrantPlugins
           config_path = nil
           config_type = nil
           vm_dir.each_child do |f|
-
             if f.extname.downcase == '.xml'
               config_path = f
               config_type = 'xml'
               break
             end
-            if f.extname.downcase == '.vmcx'
-              config_path = f
-              config_type = 'vmcx'
-              break
+          end
+
+
+          # Only check for .vmcx if there is no XML found to not
+          # risk breaking older vagrant boxes that added an XML
+          # file manually
+          if config_type == nil
+            vm_dir.each_child do |f|
+              if f.extname.downcase == '.vmcx'
+                config_path = f
+                config_type = 'vmcx'
+                break
+              end
             end
           end
+
 
           image_path = nil
           image_ext = nil

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -119,7 +119,7 @@ module VagrantPlugins
           # We have to normalize the paths to be Windows paths since
           # we're executing PowerShell.
           options = {
-            vm_config:  config_path.to_s.gsub("/", "\\"),
+            vm_config_file:  config_path.to_s.gsub("/", "\\"),
             vm_config_type:  config_type,
             image_path:      image_path.to_s.gsub("/", "\\")
           }

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -35,9 +35,17 @@ module VagrantPlugins
           end
 
           config_path = nil
+          config_type = nil
           vm_dir.each_child do |f|
-            if f.extname.downcase == ".xml"
+
+            if f.extname.downcase == '.xml'
               config_path = f
+              config_type = 'xml'
+              break
+            end
+            if f.extname.downcase == '.vmcx'
+              config_path = f
+              config_type = 'vmcx'
               break
             end
           end
@@ -111,7 +119,8 @@ module VagrantPlugins
           # We have to normalize the paths to be Windows paths since
           # we're executing PowerShell.
           options = {
-            vm_xml_config:  config_path.to_s.gsub("/", "\\"),
+            vm_config:  config_path.to_s.gsub("/", "\\"),
+            vm_config_type:  config_type,
             image_path:      image_path.to_s.gsub("/", "\\")
           }
           options[:switchname] = switch if switch

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -44,7 +44,6 @@ module VagrantPlugins
             end
           end
 
-
           # Only check for .vmcx if there is no XML found to not
           # risk breaking older vagrant boxes that added an XML
           # file manually
@@ -57,7 +56,6 @@ module VagrantPlugins
               end
             end
           end
-
 
           image_path = nil
           image_ext = nil
@@ -116,12 +114,16 @@ module VagrantPlugins
           end
 
           env[:ui].detail("Cloning virtual hard drive...")
-          source_path = image_path.to_s
-          dest_path   = env[:machine].data_dir.join("#{image_filename}#{image_ext}").to_s
-          if differencing_disk
-            env[:machine].provider.driver.execute("clone_vhd.ps1", {Source: source_path, Destination: dest_path})
-          else
-            FileUtils.cp(source_path, dest_path)
+            source_path = image_path.to_s
+            dest_path   = env[:machine].data_dir.join("#{image_filename}#{image_ext}").to_s
+
+          # Still hard copy the disk of old XML configurations
+          if config_type == 'xml'
+            if differencing_disk
+              env[:machine].provider.driver.execute("clone_vhd.ps1", {Source: source_path, Destination: dest_path})
+            else
+              FileUtils.cp(source_path, dest_path)
+            end
           end
           image_path = dest_path
 
@@ -130,7 +132,9 @@ module VagrantPlugins
           options = {
             vm_config_file:  config_path.to_s.gsub("/", "\\"),
             vm_config_type:  config_type,
-            image_path:      image_path.to_s.gsub("/", "\\")
+            source_path:     source_path.to_s,
+            dest_path:       env[:machine].data_dir.join("Virtual Hard Disks").join("#{image_filename}#{image_ext}").to_s,
+            data_path:       env[:machine].data_dir.to_s.gsub("/", "\\")
           }
           options[:switchname] = switch if switch
           options[:memory] = memory if memory
@@ -139,6 +143,7 @@ module VagrantPlugins
           options[:vmname] = vmname if vmname
           options[:auto_start_action] = auto_start_action if auto_start_action
           options[:auto_stop_action] = auto_stop_action if auto_stop_action
+          options[:differencing_disk] = differencing_disk if differencing_disk
 
           env[:ui].detail("Creating and registering the VM...")
           server = env[:machine].provider.driver.import(options)

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
     module Action
       class Import
         def initialize(app, env)
-          @app    = app
+          @app = app
           @logger = Log4r::Logger.new("vagrant::hyperv::import")
         end
 
@@ -64,7 +64,7 @@ module VagrantPlugins
             if %w{.vhd .vhdx}.include?(f.extname.downcase)
               image_path = f
               image_ext = f.extname.downcase
-              image_filename = File.basename(f,image_ext)
+              image_filename = File.basename(f, image_ext)
               break
             end
           end
@@ -114,8 +114,8 @@ module VagrantPlugins
           end
 
           env[:ui].detail("Cloning virtual hard drive...")
-            source_path = image_path.to_s
-            dest_path   = env[:machine].data_dir.join("#{image_filename}#{image_ext}").to_s
+          source_path = image_path.to_s
+          dest_path = env[:machine].data_dir.join("#{image_filename}#{image_ext}").to_s
 
           # Still hard copy the disk of old XML configurations
           if config_type == 'xml'
@@ -130,11 +130,11 @@ module VagrantPlugins
           # We have to normalize the paths to be Windows paths since
           # we're executing PowerShell.
           options = {
-            vm_config_file:  config_path.to_s.gsub("/", "\\"),
-            vm_config_type:  config_type,
-            source_path:     source_path.to_s,
-            dest_path:       env[:machine].data_dir.join("Virtual Hard Disks").join("#{image_filename}#{image_ext}").to_s,
-            data_path:       env[:machine].data_dir.to_s.gsub("/", "\\")
+              vm_config_file: config_path.to_s.gsub("/", "\\"),
+              vm_config_type: config_type,
+              source_path:    source_path.to_s,
+              dest_path:      env[:machine].data_dir.join("Virtual Hard Disks").join("#{image_filename}#{image_ext}").to_s,
+              data_path:      env[:machine].data_dir.to_s.gsub("/", "\\")
           }
           options[:switchname] = switch if switch
           options[:memory] = memory if memory

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -115,13 +115,14 @@ module VagrantPlugins
 
           env[:ui].detail("Cloning virtual hard drive...")
           source_path = image_path.to_s
-          dest_path = env[:machine].data_dir.join("#{image_filename}#{image_ext}").to_s
+          dest_path = env[:machine].data_dir.join("Virtual Hard Disks").join("#{image_filename}#{image_ext}").to_s
 
           # Still hard copy the disk of old XML configurations
           if config_type == 'xml'
             if differencing_disk
               env[:machine].provider.driver.execute("clone_vhd.ps1", {Source: source_path, Destination: dest_path})
             else
+              FileUtils.mkdir_p(env[:machine].data_dir.join("Virtual Hard Disks"))
               FileUtils.cp(source_path, dest_path)
             end
           end
@@ -133,7 +134,7 @@ module VagrantPlugins
               vm_config_file: config_path.to_s.gsub("/", "\\"),
               vm_config_type: config_type,
               source_path:    source_path.to_s,
-              dest_path:      env[:machine].data_dir.join("Virtual Hard Disks").join("#{image_filename}#{image_ext}").to_s,
+              dest_path:      dest_path,
               data_path:      env[:machine].data_dir.to_s.gsub("/", "\\")
           }
           options[:switchname] = switch if switch

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -74,7 +74,12 @@ module VagrantPlugins
        end
 
        def import(options)
-         execute('import_vm.ps1', options)
+         config_type = options.delete(:vm_config_type)
+         if config_type === "vmcx"
+           execute('import_vm_vmcx.ps1', options)
+         else
+           execute('import_vm_xml.ps1', options)
+         end
        end
 
        def net_set_vlan(vlan_id)

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -78,6 +78,9 @@ module VagrantPlugins
          if config_type === "vmcx"
            execute('import_vm_vmcx.ps1', options)
          else
+           option.delete(:data_path)
+           option.delete(:source_path)
+           option.delete(:differencing_disk)
            execute('import_vm_xml.ps1', options)
          end
        end

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -78,9 +78,9 @@ module VagrantPlugins
          if config_type === "vmcx"
            execute('import_vm_vmcx.ps1', options)
          else
-           option.delete(:data_path)
-           option.delete(:source_path)
-           option.delete(:differencing_disk)
+           options.delete(:data_path)
+           options.delete(:source_path)
+           options.delete(:differencing_disk)
            execute('import_vm_xml.ps1', options)
          end
        end

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -18,8 +18,6 @@
     [string]$differencing_disk=$null
 )
 
-"$($data_path)/Snapshots"
-
 # Include the following modules
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
@@ -124,9 +122,11 @@ if ($generation -ne 1) {
 }
 
 $report = Compare-VM -CompatibilityReport $vmConfig
+
+£ Stop if there is incomatibilities which would fail anyhow.
 if($report.Incompatibilities.Length -gt 0){
-$report.Incompatibilities
-    Write-Error-Message ConvertTo-Json $report.Incompatibilities
+    Write-Error-Message $(ConvertTo-Json $($report.Incompatibilities | Select -ExpandProperty Message))
+    exit 0
 }
 
 # Differencing disk
@@ -150,7 +150,7 @@ if($differencing_disk){
     }
     
 }
- 
+
 Import-VM -CompatibilityReport $vmConfig
 
 $vm_id = (Get-VM $vm_name).id.guid

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -18,7 +18,7 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
 # load the config from the vmcx and make a copy for editing, use TMP path so we are sure there is no vhd at the destination
-$vmConfig = (Compare-VM -Copy -Path $vm_config -GenerateNewID -VhdDestinationPath $env:Temp)
+$vmConfig = (Compare-VM -Copy -Path $vm_config_file -GenerateNewID -VhdDestinationPath $env:Temp)
 
 $generation = $vmConfig.VM.Generation
 

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -123,7 +123,7 @@ if ($generation -ne 1) {
 
 $report = Compare-VM -CompatibilityReport $vmConfig
 
-£ Stop if there is incomatibilities which would fail anyhow.
+# Stop if there is incompatibilities which would fail anyhow.
 if($report.Incompatibilities.Length -gt 0){
     Write-Error-Message $(ConvertTo-Json $($report.Incompatibilities | Select -ExpandProperty Message))
     exit 0

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -27,7 +27,7 @@ $VmProperties = @{
     Path = $vm_config_file 
     SnapshotFilePath   = Join-Path $data_path 'Snapshots'
     VhdDestinationPath = Join-Path $data_path 'Virtual Hard Disks'
-    VirtualMachinePath = Join-Path $data_path 'Virtual Machines'
+    VirtualMachinePath = $data_path
 }
 
 $vmConfig = (Compare-VM -Copy -GenerateNewID @VmProperties)

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -1,0 +1,167 @@
+﻿Param(
+    [Parameter(Mandatory=$true)]
+    [string]$vm_config,
+    [Parameter(Mandatory=$true)]
+    [string]$image_path,
+
+    [string]$switchname=$null,
+    [string]$memory=$null,
+    [string]$maxmemory=$null,   
+    [string]$cpus=$null,
+    [string]$vmname=$null,
+    [string]$auto_start_action=$null,
+    [string]$auto_stop_action=$null
+)
+
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+# load the config from the vmcx and make a copy for editing, use TMP path so we are sure there is no vhd at the destination
+$vmConfig = (Compare-VM -Copy -Path $vm_config -GenerateNewID -VhdDestinationPath $env:Temp)
+
+$generation = $vmConfig.VM.Generation
+
+if (!$vmname) {
+    # Get the name of the vm
+    $vm_name = $vmconfig.VM.VMName
+}else {
+    $vm_name = $vmname
+}
+
+if (!$cpus) {
+    # Get the processorcount of the VM
+    $processors = (Get-VMProcessor -VM $vmConfig.VM).Count
+    
+}else {
+    $processors = $cpus
+}
+
+function GetUniqueName($name) {
+    Get-VM | ForEach-Object -Process {
+        if ($name -eq $_.Name) {
+            $name =  $name + "_1"
+        }
+    }
+    return $name
+}
+
+do {
+    $name = $vm_name
+    $vm_name = GetUniqueName $name
+} while ($vm_name -ne $name)
+
+if (!$memory) {
+    $configMemory = Get-VMMemory -VM $vmConfig.VM
+    $dynamicmemory = $configMemory.DynamicMemoryEnabled
+
+    # Memory values need to be in bytes
+    $MemoryMaximumBytes = ($configMemory.Maximum)
+    $MemoryStartupBytes = ($configMemory.Startup)
+    $MemoryMinimumBytes = ($configMemory.Minimum)
+}
+else {
+    if (!$maxmemory){
+        $dynamicmemory = $False
+        $MemoryMaximumBytes = ($memory -as [int]) * 1MB
+        $MemoryStartupBytes = ($memory -as [int]) * 1MB
+        $MemoryMinimumBytes = ($memory -as [int]) * 1MB
+    }
+    else {
+        $dynamicmemory = $True
+        $MemoryMaximumBytes = ($maxmemory -as [int]) * 1MB
+        $MemoryStartupBytes = ($memory -as [int]) * 1MB
+        $MemoryMinimumBytes = ($memory -as [int]) * 1MB
+    }
+}
+
+
+if (!$switchname) {
+    $switchname = (Get-VMNetworkAdapter -VM $vmConfig.VM).SwitchName
+}
+
+$vm_params = @{
+    Name = $vm_name
+    NoVHD = $True
+    MemoryStartupBytes = $MemoryStartupBytes
+    SwitchName = $switchname
+    ErrorAction = "Stop"
+}
+
+# Generation parameter was added in ps v4
+if((get-command New-VM).Parameters.Keys.Contains("generation")) {
+    $vm_params.Generation = $generation
+}
+
+# Create the VM using the values in the hash map
+$vm = New-VM @vm_params
+
+$notes = $vmConfig.VM.Notes
+
+# Set-VM parameters to configure new VM with old values
+
+$more_vm_params = @{
+    ProcessorCount = $processors
+    MemoryStartupBytes = $MemoryStartupBytes
+}
+
+If ($dynamicmemory) {
+    $more_vm_params.Add("DynamicMemory",$True)
+    $more_vm_params.Add("MemoryMinimumBytes",$MemoryMinimumBytes)
+    $more_vm_params.Add("MemoryMaximumBytes", $MemoryMaximumBytes)
+} else {
+    $more_vm_params.Add("StaticMemory",$True)
+}
+
+if ($notes) {
+    $more_vm_params.Add("Notes",$notes)
+}
+
+if ($auto_start_action) {
+    $more_vm_params.Add("AutomaticStartAction",$auto_start_action)
+}
+
+if ($auto_stop_action) {
+    $more_vm_params.Add("AutomaticStopAction",$auto_stop_action)
+}
+
+# Set the values on the VM
+$vm | Set-VM @more_vm_params -Passthru
+
+# Only set EFI secure boot for Gen 2 machines, not gen 1
+if ($generation -ne 1) {
+    Set-VMFirmware -VM $vm -EnableSecureBoot (Get-VMFirmware -VM $vmConfig.VM).SecureBoot
+}
+
+# Get all controller on the VM, first scsi, then IDE if it is a Gen 1 device
+$controllers = Get-VMScsiController -VM $vmConfig.VM
+if($generation -eq 1){
+    $controllers = @($controllers) + @(Get-VMIdeController -VM $vmConfig.VM)
+}
+
+foreach($controller in $controllers){
+    foreach($drive in $controller.Drives){
+        $addDriveParam = @{
+            ControllerNumber = $drive.ControllerNumber
+            Path = $image_path
+        }
+        if($drive.PoolName){
+            $addDriveParam.Add("ResourcePoolname",$drive.PoolName)
+        }
+
+        # If the drive path is set, it is a harddisk, only support single harddisk
+        if ($drive.Path) {
+            $addDriveParam.add("ControllerType", $ControllerType)
+            $vm | Add-VMHardDiskDrive @AddDriveparam
+        }
+    }
+}
+
+$vm_id = (Get-VM $vm_name).id.guid
+$resultHash = @{
+    name = $vm_name
+    id = $vm_id
+}
+
+$result = ConvertTo-Json $resultHash
+Write-Output-Message $result

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -1,6 +1,6 @@
 ﻿Param(
     [Parameter(Mandatory=$true)]
-    [string]$vm_config,
+    [string]$vm_config_file,
     [Parameter(Mandatory=$true)]
     [string]$image_path,
 

--- a/plugins/providers/hyperv/scripts/import_vm_xml.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_xml.ps1
@@ -1,6 +1,6 @@
 Param(
     [Parameter(Mandatory=$true)]
-    [string]$vm_config,
+    [string]$vm_config_file,
     [Parameter(Mandatory=$true)]
     [string]$image_path,
 

--- a/plugins/providers/hyperv/scripts/import_vm_xml.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_xml.ps1
@@ -1,6 +1,6 @@
 Param(
     [Parameter(Mandatory=$true)]
-    [string]$vm_xml_config,
+    [string]$vm_config,
     [Parameter(Mandatory=$true)]
     [string]$image_path,
 
@@ -17,7 +17,7 @@ Param(
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-[xml]$vmconfig = Get-Content -Path  $vm_xml_config
+[xml]$vmconfig = Get-Content -Path  $vm_config
 
 $generation = [int]($vmconfig.configuration.properties.subtype.'#text')+1
 

--- a/plugins/providers/hyperv/scripts/import_vm_xml.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_xml.ps1
@@ -17,7 +17,7 @@ Param(
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-[xml]$vmconfig = Get-Content -Path  $vm_config
+[xml]$vmconfig = Get-Content -Path $vm_config_file
 
 $generation = [int]($vmconfig.configuration.properties.subtype.'#text')+1
 

--- a/plugins/providers/hyperv/scripts/import_vm_xml.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_xml.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory=$true)]
     [string]$vm_config_file,
     [Parameter(Mandatory=$true)]
-    [string]$image_path,
+    [string]$dest_path,
 
     [string]$switchname=$null,
     [string]$memory=$null,
@@ -190,7 +190,7 @@ foreach ($controller in $controllers) {
 
         $addDriveParam = @{
             ControllerNumber = $rx.Match($controller.node.name).value
-            Path = $image_path
+            Path = $dest_path
         }
 
         if ($drive.pool_id."#text") {


### PR DESCRIPTION
Added an import script that reads the new vmcx format with powershell. It uses native commands to read the format and create the machine the same way as it does right now with the XML's. This way there is no need anymore to hack an XML to get Hyper-V boxes to work.

As Hyper-V support seems to get close in packer, we really need this small feature added so we can start using those boxes as quickly as possible.

This should fix: #7706 and #6102 
