### PR TITLE
Fix minion_id config for salt provisioner

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -171,6 +171,20 @@ module VagrantPlugins
         end
       end
 
+      # Get command-line options for masterless provisioning
+      def get_masterless
+        options = ""
+
+        if @config.masterless
+          options = " --local"
+          if @config.minion_id
+            options += " --id #{@config.minion_id}"
+          end
+        end
+
+        return options
+      end
+
       # Copy master and minion configs to VM
       def upload_configs
         if @config.minion_config
@@ -322,16 +336,12 @@ module VagrantPlugins
 
       def call_highstate
         if @config.run_highstate
-          local=""
-          if @config.masterless
-            local=" --local"
-          end
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
             unless @config.masterless?
               @machine.communicate.sudo("salt '*' saltutil.sync_all")
             end
-            @machine.communicate.sudo("salt '*' state.highstate --verbose #{local}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+            @machine.communicate.sudo("salt '*' state.highstate --verbose#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
             if @config.verbose
                 @machine.env.ui.info(data.rstrip)
             end
@@ -342,7 +352,7 @@ module VagrantPlugins
               unless @config.masterless?
                 @machine.communicate.execute("C:\\salt\\salt-call.bat saltutil.sync_all", opts)
               end
-              @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate --retcode-passthrough #{local}#{get_loglevel}#{get_colorize}#{get_pillar}", opts) do |type, data|
+              @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate --retcode-passthrough#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}", opts) do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end
@@ -351,7 +361,7 @@ module VagrantPlugins
               unless @config.masterless?
                 @machine.communicate.sudo("salt-call saltutil.sync_all")
               end
-              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough #{local}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end


### PR DESCRIPTION
Changes introduced in #7207 removed the logic to handle the
`minion_id` configuration. This commit addresses that regression
by including the `--id #{@config.minion_id}` flag everywhere that
`--local` is used (as it had done before).

I'm not totally in love with the `get_masterless` abstraction here,
so if someone has a better suggestion I'll happily change it.

Fixes #7454
