### PR TITLE
guests/linux: Update network interface sorting implementation

### DIFF
--- a/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
+++ b/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
@@ -56,5 +56,17 @@ describe "VagrantPlugins::GuestLinux::Cap::NetworkInterfaces" do
       result = cap.network_interfaces(machine)
       expect(result).to eq(["enp0s3", "enp0s5", "enp0s8", "bridge0", "docker0"])
     end
+
+    it "sorts ethernet devices discovered with predictable network interfaces naming first in list with less" do
+      expect(comm).to receive(:sudo).and_yield(:stdout, "enp0s3\nenp0s8\ndocker0")
+      result = cap.network_interfaces(machine)
+      expect(result).to eq(["enp0s3", "enp0s8", "docker0"])
+    end
+
+    it "does not include ethernet devices aliases within prefix device listing" do
+      expect(comm).to receive(:sudo).and_yield(:stdout, "eth1\neth2\ndocker0\nbridge0\neth0\neth0:0")
+      result = cap.network_interfaces(machine)
+      expect(result).to eq(["eth0", "eth1", "eth2", "bridge0", "docker0", "eth0:0"])
+    end
   end
 end

--- a/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
+++ b/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
@@ -64,9 +64,15 @@ describe "VagrantPlugins::GuestLinux::Cap::NetworkInterfaces" do
     end
 
     it "does not include ethernet devices aliases within prefix device listing" do
-      expect(comm).to receive(:sudo).and_yield(:stdout, "eth1\neth2\ndocker0\nbridge0\neth0\neth0:0")
+      expect(comm).to receive(:sudo).and_yield(:stdout, "eth1\neth2\ndocker0\nbridge0\neth0\ndocker1\neth0:0")
       result = cap.network_interfaces(machine)
-      expect(result).to eq(["eth0", "eth1", "eth2", "bridge0", "docker0", "eth0:0"])
+      expect(result).to eq(["eth0", "eth1", "eth2", "bridge0", "docker0", "docker1", "eth0:0"])
+    end
+
+    it "properly sorts non-consistent device name formats" do
+      expect(comm).to receive(:sudo).and_yield(:stdout, "eth0\neth1\ndocker0\nveth437f7f9\nveth06b3e44\nveth8bb7081")
+      result = cap.network_interfaces(machine)
+      expect(result).to eq(["eth0", "eth1", "docker0", "veth8bb7081", "veth437f7f9", "veth06b3e44"])
     end
   end
 end


### PR DESCRIPTION
Always pull ordered ethernet devices to the head of the list. Ensure
aliases are not included.

Fixes: #7858
Fixes: #7458
Fixes: #7876