### PR TITLE
Incorrect length calculation in network_interfaces

### DIFF
--- a/plugins/guests/linux/cap/network_interfaces.rb
+++ b/plugins/guests/linux/cap/network_interfaces.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
           if eth_prefix
             eth_start = ifaces.index{|iface| iface.start_with?(eth_prefix) }
             eth_end = ifaces.rindex{|iface| iface.start_with?(eth_prefix) }
-            ifaces.unshift(*ifaces.slice!(eth_start, eth_end - 1))
+            ifaces.unshift(*ifaces.slice!(eth_start, eth_end - eth_start + 1))
             @@logger.debug("Ethernet preferred sorted list: #{ifaces.inspect}")
           end
           ifaces


### PR DESCRIPTION
It uses `eth_end - 1` rather than `eth_end - eth_start + 1` as the length paramter for the `slice!` method. In cases when the network interface list is short, the output is incorrect. For example, if the array is `['docker0', 'eth0', 'eth1']`, the code will produce `['eth0', 'docker0', 'eth1']` rather than `['eth0', 'eth1', 'docker0']`. This PR fixes this.