### PR TITLE
Make ansible-playbook command configurable

### DIFF
--- a/plugins/provisioners/ansible/config/base.rb
+++ b/plugins/provisioners/ansible/config/base.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
       class Base < Vagrant.plugin("2", :config)
 
         GALAXY_COMMAND_DEFAULT = "ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force".freeze
+        PLAYBOOK_COMMAND_DEFAULT = "ansible-playbook".freeze
 
         attr_accessor :extra_vars
         attr_accessor :galaxy_role_file
@@ -14,6 +15,7 @@ module VagrantPlugins
         attr_accessor :inventory_path
         attr_accessor :limit
         attr_accessor :playbook
+        attr_accessor :playbook_command
         attr_accessor :raw_arguments
         attr_accessor :skip_tags
         attr_accessor :start_at_task
@@ -33,6 +35,7 @@ module VagrantPlugins
           @inventory_path      = UNSET_VALUE
           @limit               = UNSET_VALUE
           @playbook            = UNSET_VALUE
+          @playbook_command    = UNSET_VALUE
           @raw_arguments       = UNSET_VALUE
           @skip_tags           = UNSET_VALUE
           @start_at_task       = UNSET_VALUE
@@ -44,23 +47,24 @@ module VagrantPlugins
         end
 
         def finalize!
-          @extra_vars          = nil                    if @extra_vars          == UNSET_VALUE
-          @galaxy_role_file    = nil                    if @galaxy_role_file    == UNSET_VALUE
-          @galaxy_roles_path   = nil                    if @galaxy_roles_path   == UNSET_VALUE
-          @galaxy_command      = GALAXY_COMMAND_DEFAULT if @galaxy_command      == UNSET_VALUE
-          @host_vars           = {}                     if @host_vars           == UNSET_VALUE
-          @groups              = {}                     if @groups              == UNSET_VALUE
-          @inventory_path      = nil                    if @inventory_path      == UNSET_VALUE
-          @limit               = nil                    if @limit               == UNSET_VALUE
-          @playbook            = nil                    if @playbook            == UNSET_VALUE
-          @raw_arguments       = nil                    if @raw_arguments       == UNSET_VALUE
-          @skip_tags           = nil                    if @skip_tags           == UNSET_VALUE
-          @start_at_task       = nil                    if @start_at_task       == UNSET_VALUE
-          @sudo                = false                  if @sudo                != true
-          @sudo_user           = nil                    if @sudo_user           == UNSET_VALUE
-          @tags                = nil                    if @tags                == UNSET_VALUE
-          @vault_password_file = nil                    if @vault_password_file == UNSET_VALUE
-          @verbose             = false                  if @verbose             == UNSET_VALUE
+          @extra_vars          = nil                      if @extra_vars          == UNSET_VALUE
+          @galaxy_role_file    = nil                      if @galaxy_role_file    == UNSET_VALUE
+          @galaxy_roles_path   = nil                      if @galaxy_roles_path   == UNSET_VALUE
+          @galaxy_command      = GALAXY_COMMAND_DEFAULT   if @galaxy_command      == UNSET_VALUE
+          @host_vars           = {}                       if @host_vars           == UNSET_VALUE
+          @groups              = {}                       if @groups              == UNSET_VALUE
+          @inventory_path      = nil                      if @inventory_path      == UNSET_VALUE
+          @limit               = nil                      if @limit               == UNSET_VALUE
+          @playbook            = nil                      if @playbook            == UNSET_VALUE
+          @playbook_command    = PLAYBOOK_COMMAND_DEFAULT if @playbook_command    == UNSET_VALUE
+          @raw_arguments       = nil                      if @raw_arguments       == UNSET_VALUE
+          @skip_tags           = nil                      if @skip_tags           == UNSET_VALUE
+          @start_at_task       = nil                      if @start_at_task       == UNSET_VALUE
+          @sudo                = false                    if @sudo                != true
+          @sudo_user           = nil                      if @sudo_user           == UNSET_VALUE
+          @tags                = nil                      if @tags                == UNSET_VALUE
+          @vault_password_file = nil                      if @vault_password_file == UNSET_VALUE
+          @verbose             = false                    if @verbose             == UNSET_VALUE
         end
 
         # Just like the normal configuration "validate" method except that

--- a/plugins/provisioners/ansible/provisioner/base.rb
+++ b/plugins/provisioners/ansible/provisioner/base.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
             end
           end
 
-          shell_command << "ansible-playbook"
+          shell_command << config.playbook_command
 
           shell_args = []
           @command_arguments.each do |arg|

--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -113,7 +113,7 @@ module VagrantPlugins
           prepare_environment_variables
 
           # Assemble the full ansible-playbook command
-          command = %w(ansible-playbook) << @command_arguments
+          command = [config.playbook_command] << @command_arguments
 
           # Add the raw arguments at the end, to give them the highest precedence
           command << config.raw_arguments if config.raw_arguments

--- a/test/unit/plugins/provisioners/ansible/config/guest_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/guest_test.rb
@@ -27,6 +27,7 @@ describe VagrantPlugins::Ansible::Config::Guest do
                             inventory_path
                             limit
                             playbook
+                            playbook_command
                             provisioning_path
                             raw_arguments
                             skip_tags

--- a/test/unit/plugins/provisioners/ansible/config/host_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/host_test.rb
@@ -26,6 +26,7 @@ describe VagrantPlugins::Ansible::Config::Host, :skip_windows => true do
                             inventory_path
                             limit
                             playbook
+                            playbook_command
                             raw_arguments
                             raw_ssh_args
                             skip_tags

--- a/test/unit/plugins/provisioners/ansible/config/shared.rb
+++ b/test/unit/plugins/provisioners/ansible/config/shared.rb
@@ -12,6 +12,7 @@ shared_examples_for 'options shared by both Ansible provisioners' do
     expect(subject.inventory_path).to be_nil
     expect(subject.limit).to be_nil
     expect(subject.playbook).to be_nil
+    expect(subject.playbook_command).to eql("ansible-playbook")
     expect(subject.raw_arguments).to be_nil
     expect(subject.skip_tags).to be_nil
     expect(subject.start_at_task).to be_nil

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -273,6 +273,18 @@ VF
       end
     end
 
+    describe "with playbook_command option" do
+      before do
+        config.playbook_command = "custom-ansible-playbook"
+      end
+
+      it "uses custom playbook_command to run playbooks" do
+        expect(Vagrant::Util::Subprocess).to receive(:execute).with { |*args|
+          expect(args[0]).to eq("custom-ansible-playbook")
+        }
+      end
+    end
+
     describe "with host_vars option" do
       it_should_create_and_use_generated_inventory
 

--- a/website/source/docs/provisioning/ansible_common.html.md
+++ b/website/source/docs/provisioning/ansible_common.html.md
@@ -78,6 +78,10 @@ Some of these options are for advanced usage only and should not be used unless 
 
     By default, this option is disabled and Vagrant generates an inventory based on the `Vagrantfile` information.
 
+- `playbook_command` (string) - The command used to run playbooks.
+
+   The default value is `ansible-playbook`
+
 - `galaxy_command` (template string) - The command pattern used to install Galaxy roles when `galaxy_role_file` is set.
 
     The following (optional) placeholders can be used in this command pattern:


### PR DESCRIPTION
The ansible-playbook command is currently hardcoded for the ansible and
ansible_local provisioners. This patch adds the config option
playbook_command to allow the user to change the command.

This may come in handy for people who want to use some kind of wrapper around ansible-playbook.
For example, I want to use vagrant to build an OpenStack test environment using openstack-ansible (see https://github.com/openstack/openstack-ansible). openstack-ansible installs a script at `/usr/local/bin/openstack-ansible` which acts as a wrapper around ansible-playbook and sets some environment variables and adds some arguments to ansible-playbook.
Having the possibility to specify openstack-ansible as playbook_command would make provisioning much more comfortable in this case.