### PR TITLE
Guests/linux detection

### DIFF
--- a/plugins/guests/debian/guest.rb
+++ b/plugins/guests/debian/guest.rb
@@ -4,7 +4,17 @@ module VagrantPlugins
   module GuestDebian
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("cat /etc/issue | grep 'Debian'")
+        machine.communicate.test <<-EOH.gsub(/^ {10}/, "")
+          if test -r /etc/os-release; then
+            source /etc/os-release && test xdebian = x$ID
+          elif test -x /usr/bin/lsb_release; then
+            /usr/bin/lsb_release -i 2>/dev/null | grep -q Debian
+          elif test -r /etc/issue; then
+            cat /etc/issue | grep 'Debian'
+          else
+            exit 1
+          fi
+        EOH
       end
     end
   end

--- a/plugins/guests/debian/guest.rb
+++ b/plugins/guests/debian/guest.rb
@@ -1,21 +1,10 @@
-require "vagrant"
+require_relative '../linux/guest'
 
 module VagrantPlugins
   module GuestDebian
-    class Guest < Vagrant.plugin("2", :guest)
-      def detect?(machine)
-        machine.communicate.test <<-EOH.gsub(/^ {10}/, "")
-          if test -r /etc/os-release; then
-            source /etc/os-release && test xdebian = x$ID
-          elif test -x /usr/bin/lsb_release; then
-            /usr/bin/lsb_release -i 2>/dev/null | grep -q Debian
-          elif test -r /etc/issue; then
-            cat /etc/issue | grep 'Debian'
-          else
-            exit 1
-          fi
-        EOH
-      end
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "debian".freeze
     end
   end
 end

--- a/plugins/guests/linux/guest.rb
+++ b/plugins/guests/linux/guest.rb
@@ -1,8 +1,22 @@
 module VagrantPlugins
   module GuestLinux
     class Guest < Vagrant.plugin("2", :guest)
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "linux".freeze
+
       def detect?(machine)
-        machine.communicate.test("uname -s | grep 'Linux'")
+        machine.communicate.test <<-EOH.gsub(/^ */, '')
+          if test -r /etc/os-release; then
+            source /etc/os-release && test x#{self.class.const_get(:GUEST_DETECTION_NAME)} = x$ID && exit
+          fi
+          if test -x /usr/bin/lsb_release; then
+            /usr/bin/lsb_release -i 2>/dev/null | grep -qi #{self.class.const_get(:GUEST_DETECTION_NAME)} && exit
+          fi
+          if test -r /etc/issue; then
+            cat /etc/issue | grep -qi #{self.class.const_get(:GUEST_DETECTION_NAME)} && exit
+          fi
+          exit 1
+        EOH
       end
     end
   end

--- a/plugins/guests/mint/guest.rb
+++ b/plugins/guests/mint/guest.rb
@@ -1,9 +1,10 @@
+require_relative '../linux/guest'
+
 module VagrantPlugins
   module GuestMint
-    class Guest < Vagrant.plugin("2", :guest)
-      def detect?(machine)
-        machine.communicate.test("cat /etc/issue | grep 'Linux Mint'")
-      end
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "Linux Mint".freeze
     end
   end
 end

--- a/plugins/guests/tinycore/guest.rb
+++ b/plugins/guests/tinycore/guest.rb
@@ -1,11 +1,10 @@
-require "vagrant"
+require_relative '../linux/guest'
 
 module VagrantPlugins
   module GuestTinyCore
-    class Guest < Vagrant.plugin("2", :guest)
-      def detect?(machine)
-        machine.communicate.test("cat /etc/issue | grep 'Core Linux'")
-      end
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "Core Linux".freeze
     end
   end
 end

--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -1,24 +1,10 @@
+require_relative '../linux/guest'
+
 module VagrantPlugins
   module GuestUbuntu
-    class Guest < Vagrant.plugin("2", :guest)
-      def detect?(machine)
-        # This command detects if we are running on Ubuntu. /etc/os-release is
-        # available on modern Ubuntu versions, but does not exist on 14.04 and
-        # previous versions, so we fall back to lsb_release.
-        #
-        #   GH-7524
-        #   GH-7625
-        #
-        machine.communicate.test <<-EOH.gsub(/^ {10}/, "")
-          if test -r /etc/os-release; then
-            source /etc/os-release && test xubuntu = x$ID
-          elif test -x /usr/bin/lsb_release; then
-            /usr/bin/lsb_release -i 2>/dev/null | grep -q Ubuntu
-          else
-            exit 1
-          fi
-        EOH
-      end
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "ubuntu".freeze
     end
   end
 end


### PR DESCRIPTION
This builds off the changeset in #7827 and provides a generic `detect?` method for linux style hosts which can be subclassed and customized via constant value. This allows for consistent detection implementations across many guests that only vary by name.