### PR TITLE
Update snapshot save documentation

### DIFF
--- a/website/source/docs/cli/snapshot.html.md
+++ b/website/source/docs/cli/snapshot.html.md
@@ -58,7 +58,7 @@ the pushed state.
 
 # Snapshot Save
 
-**Command: `vagrant snapshot save NAME`**
+**Command: `vagrant snapshot save [vm-name] NAME`**
 
 This command saves a new named snapshot. If this command is used, the
 `push` and `pop` subcommands cannot be safely used.


### PR DESCRIPTION
Prior to this commit, the snapshot save command did not have the vm_name as part of the command.  

After this commit, the snapshot save command docs match the CLI --help.
