### PR TITLE
provisioners/salt: Synchronize config defaults with documentation

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -74,12 +74,6 @@ module VagrantPlugins
       end
 
       def finalize!
-        @minion_config      = nil if @minion_config == UNSET_VALUE
-        @minion_key         = nil if @minion_key == UNSET_VALUE
-        @minion_pub         = nil if @minion_pub == UNSET_VALUE
-        @master_config      = nil if @master_config == UNSET_VALUE
-        @master_key         = nil if @master_key == UNSET_VALUE
-        @master_pub         = nil if @master_pub == UNSET_VALUE
         @grains_config      = nil if @grains_config == UNSET_VALUE
         @run_highstate      = nil if @run_highstate == UNSET_VALUE
         @run_overstate      = nil if @run_overstate == UNSET_VALUE
@@ -102,6 +96,15 @@ module VagrantPlugins
         @version            = nil if @version == UNSET_VALUE
         @run_service        = nil if @run_service == UNSET_VALUE
         @master_id          = nil if @master_id == UNSET_VALUE
+
+        # NOTE: Optimistic defaults are set in the provisioner. UNSET_VALUEs
+        # are converted there to allow proper detection of unset values.
+        # @minion_config      = nil if @minion_config == UNSET_VALUE
+        # @minion_key         = nil if @minion_key == UNSET_VALUE
+        # @minion_pub         = nil if @minion_pub == UNSET_VALUE
+        # @master_config      = nil if @master_config == UNSET_VALUE
+        # @master_key         = nil if @master_key == UNSET_VALUE
+        # @master_pub         = nil if @master_pub == UNSET_VALUE
       end
 
       def pillar(data)
@@ -111,14 +114,14 @@ module VagrantPlugins
 
       def validate(machine)
         errors = _detected_errors
-        if @minion_config
+        if @minion_config && @minion_config != UNSET_VALUE
           expanded = Pathname.new(@minion_config).expand_path(machine.env.root_path)
           if !expanded.file?
             errors << I18n.t("vagrant.provisioners.salt.minion_config_nonexist", missing_config_file: expanded)
           end
         end
 
-        if @master_config
+        if @master_config && @master_config != UNSET_VALUE
           expanded = Pathname.new(@master_config).expand_path(machine.env.root_path)
           if !expanded.file?
             errors << I18n.t("vagrant.provisioners.salt.master_config_nonexist",  missing_config_file: expanded)

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -3,7 +3,20 @@ require 'json'
 module VagrantPlugins
   module Salt
     class Provisioner < Vagrant.plugin("2", :provisioner)
+
+      # Default path values to set within configuration only
+      # if configuration value is unset and local path exists
+      OPTIMISTIC_PATH_DEFAULTS = Hash[[
+        "minion_config", "salt/minion",
+        "minion_key", "salt/key/minion.key",
+        "minion_pub", "salt/key/minion.pub",
+        "master_config", "salt/master",
+        "master_key", "salt/key/master.key",
+        "master_pub", "salt/key/master.pub"
+      ].map(&:freeze)].freeze
+
       def provision
+        set_default_configs
         upload_configs
         upload_keys
         run_bootstrap_script
@@ -238,19 +251,19 @@ module VagrantPlugins
           bootstrap_path = get_bootstrap
           if @machine.config.vm.communicator == :winrm
             if @config.version
-              options += " -version %s" % @config.version            
+              options += " -version %s" % @config.version
             end
             if @config.run_service
               @machine.env.ui.info "Salt minion will be stopped after installing."
-              options += " -runservice %s" % @config.run_service            
+              options += " -runservice %s" % @config.run_service
             end
             if @config.minion_id
               @machine.env.ui.info "Setting minion to @config.minion_id."
-              options += " -minion %s" % @config.minion_id            
+              options += " -minion %s" % @config.minion_id
             end
             if @config.master_id
               @machine.env.ui.info "Setting master to @config.master_id."
-              options += " -master %s" % @config.master_id            
+              options += " -master %s" % @config.master_id
             end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else
@@ -388,6 +401,16 @@ module VagrantPlugins
           cmd = "salt-run -l info state.orchestrate #{orchestration}"
           @machine.env.ui.info "Calling #{cmd}... (this may take a while)"
           @machine.communicate.sudo(cmd, &log_output)
+        end
+      end
+
+      # Sets optimistic default values into config
+      def set_default_configs
+        OPTIMISTIC_PATH_DEFAULTS.each do |config_key, config_default|
+          if config.send(config_key) == Config::UNSET_VALUE
+            config_value = File.exist?(expanded_path(config_default)) ? config_default : nil
+            config.send("#{config_key}=", config_value)
+          end
         end
       end
     end

--- a/website/source/docs/provisioning/salt.html.md
+++ b/website/source/docs/provisioning/salt.html.md
@@ -62,7 +62,7 @@ on this machine. Not supported on Windows guest machines.
 * `install_type`  (stable | git | daily | testing) - Whether to install from a
 distribution's stable package manager, git tree-ish, daily ppa, or testing repository.
 
-* `install_args` (develop) - When performing a git install, you can specify a branch, tag, or any treeish. Not supported on Windows.
+* `install_args` (string, default: "develop") - When performing a git install, you can specify a branch, tag, or any treeish. Not supported on Windows.
 
 * `always_install`   (boolean) - Installs salt binaries even
  if they are already detected, default `false`
@@ -80,11 +80,11 @@ These only make sense when `no_minion` is `false`.
 * `minion_config`    (string, default: "salt/minion") - Path to
 a custom salt minion config file.
 
-* `minion_key`  (string) - Path to your minion key
+* `minion_key`  (string, default: "salt/key/minion.key") - Path to your minion key
 
 * `minion_id`  (string) - Unique identifier for minion. Used for masterless and preseeding keys.
 
-* `minion_pub`  (salt/key/minion.pub) - Path to your minion
+* `minion_pub`  (string, default: "salt/key/minion.pub") - Path to your minion
 public key
 
 * `grains_config`  (string) - Path to a custom salt grains file. On Windows, the minion needs `ipc_mode: tcp` set otherwise it will [fail to communicate](https://github.com/saltstack/salt/issues/22796) with the master.
@@ -97,9 +97,9 @@ These only make sense when `install_master` is `true`. Not supported on Windows 
 * `master_config` (string, default: "salt/master")
   Path to a custom salt master config file.
 
-* `master_key` (salt/key/master.pem) - Path to your master key.
+* `master_key` (string, default: "salt/key/master.pem") - Path to your master key.
 
-* `master_pub` (salt/key/master.pub) - Path to your master public key.
+* `master_pub` (string, default: "salt/key/master.pub") - Path to your master public key.
 
 * `seed_master`  (dictionary) - Upload keys to master, thereby
 pre-seeding it before use. Example: `{minion_name:/path/to/key.pub}`


### PR DESCRIPTION
Makes the salt provisioner act as documentation states. Due to provisioner behavior, default values are conditionally set if local path exists.

Fixes #6624 