### PR TITLE
guests/redhat: Force NetworkManager to reload device configurations

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -40,13 +40,11 @@ module VagrantPlugins
               # Down the interface before munging the config file. This might
               # fail if the interface is not actually set up yet so ignore
               # errors.
-              /sbin/ifdown '#{network[:device]}' || true
-
+              /sbin/ifdown '#{network[:device]}'
               # Move new config into place
               mv -f '#{remote_path}' '#{final_path}'
-
-              # Bring the interface up
-              ARPCHECK=no /sbin/ifup '#{network[:device]}'
+              # attempt to force network manager to reload configurations
+              nmcli c reload || true
             EOH
           end
 

--- a/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
@@ -56,9 +56,10 @@ describe "VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks" do
 
       cap.configure_networks(machine, [network_1, network_2])
       expect(comm.received_commands[0]).to match(/\/sbin\/ifdown 'eth1'/)
-      expect(comm.received_commands[0]).to match(/\/sbin\/ifup 'eth1'/)
+      expect(comm.received_commands[0]).to match(/ifcfg-eth1/)
       expect(comm.received_commands[0]).to match(/\/sbin\/ifdown 'eth2'/)
-      expect(comm.received_commands[0]).to match(/\/sbin\/ifup 'eth2'/)
+      expect(comm.received_commands[0]).to match(/ifcfg-eth2/)
+      expect(comm.received_commands[0]).to match(/nmcli c reload/)
     end
   end
 end


### PR DESCRIPTION
When configuring network devices force NetworkManager to reload new
configuration files as they appear. This prevents NetworkManager from
attempting to continue managing devices on initial start up.