### PR TITLE
Remove requirements on path without space as issue was fixed in Ruby

### DIFF
--- a/plugins/commands/plugin/action/install_gem.rb
+++ b/plugins/commands/plugin/action/install_gem.rb
@@ -19,14 +19,6 @@ module VagrantPlugins
           sources     = env[:plugin_sources]
           version     = env[:plugin_version]
 
-          # If we're on Windows and the user data path has a space in it,
-          # then things won't work because of a Ruby bug.
-          if Vagrant::Util::Platform.windows?
-            if Vagrant.user_data_path.to_s.include?(" ")
-              raise Vagrant::Errors::PluginInstallSpace
-            end
-          end
-
           # Install the gem
           plugin_name_label = plugin_name
           plugin_name_label += " --version '#{version}'" if version


### PR DESCRIPTION
I was unable to test it locally because I can't manage to build Vagrant.

The problem mentioned by Vagrant is supposed to be fixed on Ruby side for a very long time: https://bugs.ruby-lang.org/issues/7036
