### PR TITLE
Add `--up` option to provision command

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -552,6 +552,10 @@ module Vagrant
       error_key(:provisioner_winrm_unsupported)
     end
 
+    class ProvisionAutoUpFailure < VagrantError
+      error_key(:auto_up_failure, "vagrant.actions.vm.provision")
+    end
+
     class PluginGemNotFound < VagrantError
       error_key(:plugin_gem_not_found)
     end

--- a/plugins/commands/provision/command.rb
+++ b/plugins/commands/provision/command.rb
@@ -9,7 +9,6 @@ module VagrantPlugins
 
       def execute
         options = {}
-        options[:provision_types] = nil
 
         opts = OptionParser.new do |o|
           o.banner = "Usage: vagrant provision [vm-name] [--provision-with x,y,z]"
@@ -17,6 +16,10 @@ module VagrantPlugins
           o.on("--provision-with x,y,z", Array,
                     "Enable only certain provisioners, by type or by name.") do |list|
             options[:provision_types] = list.map { |type| type.to_sym }
+          end
+
+          o.on("--up", "Automatically transition VM to 'up' state") do |value|
+            options[:auto_up] = value
           end
         end
 
@@ -27,6 +30,20 @@ module VagrantPlugins
         # Go over each VM and provision!
         @logger.debug("'provision' each target VM...")
         with_target_vms(argv) do |machine|
+          if options[:auto_up] && machine.state.id != :running
+            @logger.debug("current machine state `#{machine.state.id}`. Attempting to bring up.")
+            case machine.state.id
+            when :not_created, :poweroff
+              machine.action(:up)
+            when :paused, :saved
+              machine.action(:resume)
+            else
+              raise Vagrant::Errors::ProvisionAutoUpFailure.new(
+                machine_name: machine.name,
+                machine_state: machine.state.short_description
+              )
+            end
+          end
           machine.action(:provision, options)
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1882,6 +1882,11 @@ en:
           disabled_by_sentinel: |-
             Machine already provisioned. Run `vagrant provision` or use the `--provision`
             flag to force provisioning. Provisioners marked to run always will still run.
+          auto_up_failure: |-
+            Unable to automatically transition machine from current state to `up` state.
+
+            Machine name: %{machine_name}
+            Machine state: %{machine_state}
         resume:
           resuming: Resuming suspended VM...
           unpausing: |-

--- a/test/unit/plugins/commands/provision/command_test.rb
+++ b/test/unit/plugins/commands/provision/command_test.rb
@@ -1,0 +1,111 @@
+require File.expand_path("../../../../base", __FILE__)
+
+require Vagrant.source_root.join("plugins/commands/provision/command")
+
+describe VagrantPlugins::CommandProvision::Command do
+  include_context "unit"
+  include_context "command plugin helpers"
+
+  let(:iso_env) { isolated_environment }
+  let(:env) do
+    iso_env.vagrantfile(<<-VF)
+      Vagrant.configure("2") do |config|
+        config.vm.box = "hashicorp/precise64"
+        config.vm.provision "shell", inline: "echo hi"
+      end
+    VF
+    iso_env.create_vagrant_env
+  end
+  let(:machine_state){ double("machine_state") }
+  let(:machine){ double("machine", state: machine_state) }
+
+  let(:argv){ [] }
+
+  subject { described_class.new(argv, env) }
+
+  describe "#execute" do
+    before do
+      allow(subject).to receive(:with_target_vms).and_yield(machine)
+    end
+
+    it "validates provisions default machine" do
+      expect(machine).to receive(:action).with(:provision, {})
+      subject.execute
+    end
+
+    context "with automatic up option enabled" do
+      let(:argv){ ['--up'] }
+
+      context "with machine in 'not_created' state" do
+        before do
+          allow(machine_state).to receive(:id).and_return(:not_created)
+          expect(machine).to receive(:action).with(:provision, :auto_up => true)
+        end
+
+        it "starts the machine before provision" do
+          expect(machine).to receive(:action).with(:up)
+          subject.execute
+        end
+      end
+
+      context "with machine in 'poweroff' state" do
+        before do
+          allow(machine_state).to receive(:id).and_return(:poweroff)
+          expect(machine).to receive(:action).with(:provision, :auto_up => true)
+        end
+
+        it "creates the machine before provision" do
+          expect(machine).to receive(:action).with(:up)
+          subject.execute
+        end
+      end
+
+      context "with machine in 'paused' state" do
+        before do
+          allow(machine_state).to receive(:id).and_return(:paused)
+          expect(machine).to receive(:action).with(:provision, :auto_up => true)
+        end
+
+        it "resumes the machine before provision" do
+          expect(machine).to receive(:action).with(:resume)
+          subject.execute
+        end
+      end
+
+      context "with machine in 'saved' state" do
+        before do
+          allow(machine_state).to receive(:id).and_return(:paused)
+          expect(machine).to receive(:action).with(:provision, :auto_up => true)
+        end
+
+        it "resumes the machine before provision" do
+          expect(machine).to receive(:action).with(:resume)
+          subject.execute
+        end
+      end
+
+      context "with the machine in 'running' state" do
+        before do
+          allow(machine_state).to receive(:id).and_return(:running)
+          expect(machine).to receive(:action).with(:provision, :auto_up => true)
+        end
+
+        it "does not change machine state before provision" do
+          subject.execute
+        end
+      end
+
+      context "with machine in busy state" do
+        before do
+          allow(machine_state).to receive(:id).and_return(:halting)
+        end
+
+        it "does not change machine state before provision" do
+          expect(machine).to receive(:name).and_return('default')
+          expect(machine_state).to receive(:short_description).and_return('Halting')
+          expect{ subject.execute }.to raise_error Vagrant::Errors::ProvisionAutoUpFailure
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This option will attempt to transition a machine in a non-running state
to a running state, if possible, prior to provisioning.

Fixes: #6604