### PR TITLE
Named synced folders

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -201,6 +201,7 @@ module VagrantPlugins
       #   folder.
       # @param [Hash] options Additional options.
       def synced_folder(hostpath, guestpath, options=nil)
+        name = (options && options.delete(:name)) || guestpath
         if Vagrant::Util::Platform.windows?
           # On Windows, Ruby just uses normal '/' for path seps, so
           # just replace normal Windows style seps with Unix ones.
@@ -217,7 +218,7 @@ module VagrantPlugins
         # Make sure the type is a symbol
         options[:type] = options[:type].to_sym if options[:type]
 
-        @__synced_folders[options[:guestpath]] = options
+        @__synced_folders[name] = options
       end
 
       # Define a way to access the machine via a network. This exposes a
@@ -626,7 +627,7 @@ module VagrantPlugins
           # If the shared folder is disabled then don't worry about validating it
           next if options[:disabled]
 
-          guestpath = Pathname.new(options[:guestpath])
+          guestpath = Pathname.new(options[:guestpath]) if options[:guestpath]
           hostpath  = Pathname.new(options[:hostpath]).expand_path(machine.env.root_path)
 
           if guestpath.to_s != ""

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -201,14 +201,25 @@ module VagrantPlugins
       #   folder.
       # @param [Hash] options Additional options.
       def synced_folder(hostpath, guestpath, options=nil)
-        name = (options && options.delete(:name)) || guestpath
         if Vagrant::Util::Platform.windows?
           # On Windows, Ruby just uses normal '/' for path seps, so
           # just replace normal Windows style seps with Unix ones.
           hostpath = hostpath.to_s.gsub("\\", "/")
         end
 
+        if guestpath.is_a?(Hash)
+          options = guestpath
+          guestpath = nil
+        end
+
         options ||= {}
+
+        if options.has_key?(:name)
+          synced_folder_name = options.delete(:name)
+        else
+          synced_folder_name = guestpath
+        end
+
         options[:guestpath] = guestpath.to_s.gsub(/\/$/, '')
         options[:hostpath]  = hostpath
         options[:disabled]  = false if !options.key?(:disabled)
@@ -218,7 +229,7 @@ module VagrantPlugins
         # Make sure the type is a symbol
         options[:type] = options[:type].to_sym if options[:type]
 
-        @__synced_folders[name] = options
+        @__synced_folders[synced_folder_name] = options
       end
 
       # Define a way to access the machine via a network. This exposes a

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -534,6 +534,21 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       subject.finalize!
       assert_valid
     end
+
+    it "allows providing custom name via options" do
+      subject.synced_folder(".", "/vagrant", name: "my-vagrant-folder")
+      sf = subject.synced_folders
+      expect(sf).to have_key("my-vagrant-folder")
+      expect(sf["my-vagrant-folder"][:guestpath]).to eq("/vagrant")
+      expect(sf["my-vagrant-folder"][:hostpath]).to eq(".")
+    end
+
+    it "allows providing custom name without guest path" do
+      subject.synced_folder(".", name: "my-vagrant-folder")
+      sf = subject.synced_folders
+      expect(sf).to have_key("my-vagrant-folder")
+      expect(sf["my-vagrant-folder"][:hostpath]).to eq(".")
+    end
   end
 
   describe "#usable_port_range" do


### PR DESCRIPTION
This builds off #6836 to make the `guestpath` parameter optional and includes test coverage on named usage.

Fixes: #6836