### PR TITLE
Only match interfaces without special characters

### DIFF
--- a/plugins/guests/linux/cap/network_interfaces.rb
+++ b/plugins/guests/linux/cap/network_interfaces.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
           resorted_ifaces = []
           resorted_ifaces += ifaces.find_all do |iface|
             POSSIBLE_ETHERNET_PREFIXES.any?{|prefix| iface.start_with?(prefix)} &&
-              !iface.include?(':')
+              iface.match(/^[a-zA-Z0-9]+$/)
           end
           resorted_ifaces += ifaces - resorted_ifaces
           ifaces = resorted_ifaces

--- a/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
+++ b/test/unit/plugins/guests/linux/cap/network_interfaces_test.rb
@@ -69,6 +69,12 @@ describe "VagrantPlugins::GuestLinux::Cap::NetworkInterfaces" do
       expect(result).to eq(["eth0", "eth1", "eth2", "bridge0", "docker0", "docker1", "eth0:0"])
     end
 
+    it "does not include ethernet devices aliases within prefix device listing with dot separators" do
+      expect(comm).to receive(:sudo).and_yield(:stdout, "eth1\neth2\ndocker0\nbridge0\neth0\ndocker1\neth0.1@eth0")
+      result = cap.network_interfaces(machine)
+      expect(result).to eq(["eth0", "eth1", "eth2", "bridge0", "docker0", "docker1", "eth0.1@eth0"])
+    end
+
     it "properly sorts non-consistent device name formats" do
       expect(comm).to receive(:sudo).and_yield(:stdout, "eth0\neth1\ndocker0\nveth437f7f9\nveth06b3e44\nveth8bb7081")
       result = cap.network_interfaces(machine)


### PR DESCRIPTION
As pointed out in referenced fixed issue, the alias naming is not consistent and filtering via `:` character alone is insufficient. This updates to only match interfaces that lack special characters when filtering sorted interfaces to the top of the list.

Fixes: #7988