### PR TITLE
Plugin handling updates

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -238,6 +238,11 @@ module Vagrant
         if plugin_source = info.delete("local_source")
           installer_set.add_local(plugin_source.spec.name, plugin_source.spec, plugin_source)
         end
+        Array(info["sources"]).each do |source|
+          if !Gem.sources.include?(source)
+            Gem.sources << source
+          end
+        end
         Gem::Dependency.new(name, gem_version)
       end
 

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -146,7 +146,7 @@ module Vagrant
           'local_source' => plugin_source
         }
       }
-      internal_install(plugin_info, {})
+      internal_install(plugin_info, {}, local_install: true)
       plugin_source.spec
     end
 
@@ -224,8 +224,10 @@ module Vagrant
 
     def internal_install(plugins, update, **extra)
 
-      update = {} unless update.is_a?(Hash)
+      # Only clear Gem sources if not performing local install
+      Gem.sources.clear if !extra[:local_install]
 
+      update = {} unless update.is_a?(Hash)
       installer_set = Gem::Resolver::InstallerSet.new(:both)
 
       # Generate all required plugin deps

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -139,14 +139,15 @@ module Vagrant
     #
     # @param [String] path Path to a local gem file.
     # @return [Gem::Specification]
-    def install_local(path)
+    def install_local(path, opts={})
       plugin_source = Gem::Source::SpecificFile.new(path)
       plugin_info = {
         plugin_source.spec.name => {
-          'local_source' => plugin_source
+          "local_source" => plugin_source,
+          "sources" => opts.fetch(:sources, Gem.sources.map(&:to_s))
         }
       }
-      internal_install(plugin_info, {}, local_install: true)
+      internal_install(plugin_info, {})
       plugin_source.spec
     end
 
@@ -223,9 +224,8 @@ module Vagrant
     protected
 
     def internal_install(plugins, update, **extra)
-
-      # Only clear Gem sources if not performing local install
-      Gem.sources.clear if !extra[:local_install]
+      # Only allow defined Gem sources
+      Gem.sources.clear
 
       update = {} unless update.is_a?(Hash)
       installer_set = Gem::Resolver::InstallerSet.new(:both)

--- a/lib/vagrant/plugin/manager.rb
+++ b/lib/vagrant/plugin/manager.rb
@@ -44,7 +44,7 @@ module Vagrant
         local = false
         if name =~ /\.gem$/
           # If this is a gem file, then we install that gem locally.
-          local_spec = Vagrant::Bundler.instance.install_local(name)
+          local_spec = Vagrant::Bundler.instance.install_local(name, opts)
           name       = local_spec.name
           opts[:version] = local_spec.version.to_s
         end

--- a/lib/vagrant/plugin/manager.rb
+++ b/lib/vagrant/plugin/manager.rb
@@ -126,8 +126,14 @@ module Vagrant
             system[k] = v.merge("system" => true)
           end
         end
+        plugin_list = system.merge(@user_file.installed_plugins)
 
-        system.merge(@user_file.installed_plugins)
+        # Sort plugins by name
+        Hash[
+          plugin_list.map{|plugin_name, plugin_info|
+            [plugin_name, plugin_info]
+          }.sort_by(&:first)
+        ]
       end
 
       # This returns the list of plugins that are installed as

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -49,7 +49,7 @@ module Vagrant
   #
   # @return [Boolean]
   def self.plugins_enabled?
-    !ENV["VAGRANT_NO_PLUGINS"] && $vagrant_bundler_runtime
+    !ENV["VAGRANT_NO_PLUGINS"]
   end
 
   # Whether or not super quiet mode is enabled. This is ill-advised.

--- a/plugins/commands/plugin/command/mixin_install_opts.rb
+++ b/plugins/commands/plugin/command/mixin_install_opts.rb
@@ -13,15 +13,6 @@ module VagrantPlugins
             options[:entry_point] = entry_point
           end
 
-          # @deprecated
-          o.on("--plugin-prerelease",
-               "Allow prerelease versions of this plugin.") do |plugin_prerelease|
-            puts "--plugin-prelease is deprecated and will be removed in the next"
-            puts "version of Vagrant. It has no effect now. Use the '--plugin-version'"
-            puts "flag to get a specific pre-release version."
-            puts
-          end
-
           o.on("--plugin-clean-sources",
             "Remove all plugin sources defined so far (including defaults)") do |clean|
             options[:plugin_sources] = [] if clean

--- a/test/unit/vagrant/plugin/manager_test.rb
+++ b/test/unit/vagrant/plugin/manager_test.rb
@@ -66,14 +66,10 @@ describe Vagrant::Plugin::Manager do
       local_spec.name = "bar"
       local_spec.version = version
 
-      expect(bundler).to receive(:install_local).with(name).
+      expect(bundler).to receive(:install_local).with(name, {}).
         ordered.and_return(local_spec)
 
-      expect(bundler).to receive(:install).once.with { |plugins, local|
-        expect(plugins).to have_key("bar")
-        expect(plugins["bar"]["gem_version"]).to eql("#{version}")
-        expect(local).to be_true
-      }.ordered.and_return([local_spec])
+      expect(bundler).not_to receive(:install)
 
       subject.install_plugin(name)
 


### PR DESCRIPTION
Updates to plugin handling:

* Support plugin auto-loading with fallback to `/` style name loading
* Restrict valid Gem sources to only list provided
* Properly install local gems with remote dependencies
* Remove deprecated `--plugin-prerelease` option
* Add debug logging output to `Vagrant::Bundler`