### PR TITLE
Provide nice error output when plugin initialization fails

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -254,23 +254,9 @@ end
 if Vagrant.plugins_init?
   begin
     Vagrant::Bundler.instance.init!(plugins)
-  rescue Gem::ConflictError, Gem::DependencyError => e
-    $stderr.puts "Vagrant experienced a version conflict with some installed plugins!"
-    $stderr.puts "This usually happens if you recently upgraded Vagrant. As part of the"
-    $stderr.puts "upgrade process, some existing plugins are no longer compatible with"
-    $stderr.puts "this version of Vagrant. The recommended way to fix this is to remove"
-    $stderr.puts "your existing plugins and reinstall them one-by-one. To remove all"
-    $stderr.puts "plugins:"
-    $stderr.puts ""
-    $stderr.puts "    vagrant expunge"
-    $stderr.puts ""
-    $stderr.puts "Note if you have an alternate VAGRANT_HOME environmental variable"
-    $stderr.puts "set, the folders above will be in that directory rather than your"
-    $stderr.puts "user's home directory."
-    $stderr.puts ""
-    $stderr.puts "The error message is shown below:\n\n"
-    $stderr.puts e.message
-    exit 1
+  rescue Exception => e
+    global_logger.error("Plugin initialization error - #{e.class}: #{e}")
+    raise Vagrant::Errors::PluginInitError, message: e.to_s
   end
 end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -982,6 +982,15 @@ en:
         by contacting a plugin author to see if they can address the conflict.
 
         %{conflicts}
+      plugin_init_error: |-
+        The plugins failed to initialize correctly. If Vagrant was recently
+        updated, this error may be due to incompatible versions of dependencies.
+        To fix this problem please remove and re-install all plugins. Vagrant can
+        attempt to do this automatically by running:
+
+          vagrant plugin expunge --reinstall
+
+        Error message given during initialization: %{message}
       plugin_load_error: |-
         The plugins failed to load properly. The error message given is
         shown below.


### PR DESCRIPTION
Include extra logging during initialization to display error if encountered
and solution set prior to performing activations.