### PR TITLE
link to tip section about looping over VM definitions

### DIFF
--- a/website/source/docs/multi-machine/index.html.md
+++ b/website/source/docs/multi-machine/index.html.md
@@ -85,6 +85,9 @@ The provisioners in this case will output "A", then "C", then "B". Notice
 that "B" is last. That is because the ordering is outside-in, in
 the order of the file.
 
+If you want to apply a slightly different configuration to multiple machines,
+see [this tip](/docs/vagrantfile/tips.html#loop-over-vm-definitions).
+
 ## Controlling Multiple Machines
 
 The moment more than one machine is defined within a Vagrantfile, the


### PR DESCRIPTION
Users learning about multi-machine definitions will likely be interested in the linked tip...this connects the two pages.