### PR TITLE
Vagrant: Modifying CLI Documentation.

### DIFF
--- a/website/source/docs/cli/up.html.md
+++ b/website/source/docs/cli/up.html.md
@@ -35,7 +35,7 @@ on a day-to-day basis.
 * `--provider x` - Bring the machine up with the given
   [provider](/docs/providers/). By default this is "virtualbox".
 
-* `--provision` - Force the provisioners to run.
+* `--[no-]provision` - Force the provisioners to run.
 
 * `--provision-with x,y,z` - This will only run the given provisioners. For
   example, if you have a `:shell` and `:chef_solo` provisioner and run

--- a/website/source/docs/cli/up.html.md
+++ b/website/source/docs/cli/up.html.md
@@ -35,7 +35,7 @@ on a day-to-day basis.
 * `--provider x` - Bring the machine up with the given
   [provider](/docs/providers/). By default this is "virtualbox".
 
-* `--[no-]provision` - Force the provisioners to run.
+* `--[no-]provision` - Force, or prevent, the provisioners to run.
 
 * `--provision-with x,y,z` - This will only run the given provisioners. For
   example, if you have a `:shell` and `:chef_solo` provisioner and run


### PR DESCRIPTION
Found that some info on the cli documentation did not line up (other mentions of no- usage, but not on provision, which is an option.)

Was also considering adding links to the in depth pages so users could find information quicker, similar to "providers", as the cli documentation is usually a hub for first-time users. Please let me know if you would like me to add this as well.