### PR TITLE
Hyper-V VMCX: Setting memory too low or high makes the import script fail.

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -36,7 +36,7 @@ $generation = $vmConfig.VM.Generation
 if (!$vmname) {
     # Get the name of the vm
     $vm_name = $vmconfig.VM.VMName
-}else {
+} else {
     $vm_name = $vmname
 }
 
@@ -86,15 +86,18 @@ if (!$switchname) {
     $switchname = (Get-VMNetworkAdapter -VM $vmConfig.VM).SwitchName
 }
 
-Connect-VMNetworkAdapter -VMNetworkAdapter (Get-VMNetworkAdapter -VM $vmConfig.VM) -SwitchName $switchname
-Set-VM -VM $vmConfig.VM -NewVMName $vm_name -MemoryStartupBytes $MemoryStartupBytes
-Set-VM -VM $vmConfig.VM -ErrorAction "Stop" -ProcessorCount $processors
+$vmNetworkAdapter = Get-VMNetworkAdapter -VM $vmConfig.VM
+Connect-VMNetworkAdapter -VMNetworkAdapter $vmNetworkAdapter -SwitchName $switchname
+Set-VM -VM $vmConfig.VM -NewVMName $vm_name
+Set-VM -VM $vmConfig.VM -ErrorAction "Stop"
+Set-VM -VM $vmConfig.VM -ProcessorCount $processors
 
-If ($dynamicmemory) {
+if ($dynamicmemory) {
     Set-VM -VM $vmConfig.VM -DynamicMemory
-    Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -MemoryMaximumBytes $MemoryMaximumBytes
+    Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -MemoryMaximumBytes $MemoryMaximumBytes -MemoryStartupBytes $MemoryStartupBytes
 } else {
-    Set-VM -VM $vmConfig.VM -StaticMemory    
+    Set-VM -VM $vmConfig.VM -StaticMemory
+    Set-VM -VM $vmConfig.VM -MemoryStartupBytes $MemoryStartupBytes
 }
 
 if ($notes) {


### PR DESCRIPTION
When you set the memory of a HyperV machine to something lower than the original range it fails. 

This is because it sets the current memory before adjusting the range, which makes the command invalid.