### PR TITLE
Logger and error outputs

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -264,6 +264,9 @@ if Vagrant.plugins_init?
     Vagrant::Bundler.instance.init!(plugins)
   rescue Exception => e
     global_logger.error("Plugin initialization error - #{e.class}: #{e}")
+    e.backtrace.each do |backtrace_line|
+      global_logger.debug(backtrace_line)
+    end
     raise Vagrant::Errors::PluginInitError, message: e.to_s
   end
 end
@@ -330,6 +333,10 @@ if Vagrant.plugins_enabled?
       ::Bundler.require(:plugins)
     end
   rescue Exception => e
+    global_logger.error("Plugin loading error: #{e.class} - #{e}")
+    e.backtrace.each do |backtrace_line|
+      global_logger.debug(backtrace_line)
+    end
     raise Vagrant::Errors::PluginLoadError, message: e.to_s
   end
 end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1647,7 +1647,13 @@ en:
         repair_complete: |-
           Installed plugins successfully repaired!
         repair_failed: |-
-          Failed to automatically repair installed Vagrant plugins. Failure message:
+          Failed to automatically repair installed Vagrant plugins. To fix this
+          problem remove all user installed plugins and reinstall. Vagrant can
+          do this for you automatically by running the following command:
+
+            vagrant plugin expunge --reinstall
+
+          Failure message received during repair:
 
           %{message}
       snapshot:


### PR DESCRIPTION
Provide better error messages and context around plugin errors. Include original exception information and full backtrace in logger output.