### PR TITLE
Add documentation for ssl_peer_verification

### DIFF
--- a/website/source/docs/vagrantfile/winrm_settings.html.md
+++ b/website/source/docs/vagrantfile/winrm_settings.html.md
@@ -51,6 +51,10 @@ to use port 4567 to talk to the guest if there is no other option.
 
 <hr>
 
+`config.winrm.ssl_peer_verification` - Whether to validate the SSL certificate. Set to `false` if you are using a self-signed certificate. The default is `:negotiate`.
+
+<hr>
+
 `config.winrm.transport` - The transport used for WinRM communication. Valid settings include: `:negotiate`, `ssl`, and `:plaintext`. The default is `:negotiate`.
 
 <hr>


### PR DESCRIPTION
I was searching for how to use a self-signed certificate with winrm, but I only found this mentioned in a PR.