### PR TITLE
redirect any output to stderr by /sbin/init to /dev/null when checking for upstart capability

### DIFF
--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -94,7 +94,7 @@ SCRIPT
 
           # Emit an upstart event if we can
           machine.communicate.sudo <<-SCRIPT
-if command -v /sbin/init && /sbin/init --version | grep upstart; then
+if command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT='#{expanded_guest_path}'
 fi
 SCRIPT

--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -89,7 +89,7 @@ module VagrantPlugins
 
           # Emit an upstart event if we can
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, "")
-            if command -v /sbin/init && /sbin/init --version | grep upstart; then
+            if command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
               /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guest_path}
             fi
           EOH

--- a/plugins/guests/linux/cap/nfs.rb
+++ b/plugins/guests/linux/cap/nfs.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
               mount -o #{mount_opts} #{ip}:#{host_path} #{guest_path}
               result=$?
               if test $result -eq 0; then
-                if test -x /sbin/initctl && command -v /sbin/init && /sbin/init --version | grep upstart; then
+                if test -x /sbin/initctl && command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
                   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guest_path}
                 fi
               else


### PR DESCRIPTION

This resolves vagrant issue #7368 as "/sbin/init --version" outputs error message if the "--version" command line option is not known, but as there is no tty the error message mentioned in #7368 is shown.