### PR TITLE
Fix `service network restart` on RHEL-7 / Fedora

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -31,8 +31,12 @@ module VagrantPlugins
                 sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
               }
 
-              # Restart network
-              service network restart
+              # Restart network (through NetworkManager if running)
+              if service NetworkManager status 2>&1 | grep -q running; then
+                service NetworkManager restart
+              else
+                service network restart
+              fi
             EOH
           end
         end

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
 
             # Add the new interface and bring it back up
             final_path = "#{network_scripts_dir}/ifcfg-#{network[:device]}"
-            commands << <<-EOH.gsub(/^ */, '')
+            commands << <<-EOH.gsub(/^ {14}/, '')
               # Down the interface before munging the config file. This might
               # fail if the interface is not actually set up yet so ignore
               # errors.
@@ -48,9 +48,13 @@ module VagrantPlugins
             EOH
           end
 
-          commands << <<-EOH.gsub(/^ */, '')
-            # Restart network
-            service network restart
+          commands << <<-EOH.gsub(/^ {12}/, '')
+            # Restart network (through NetworkManager if running)
+            if service NetworkManager status 2>&1 | grep -q running; then
+              service NetworkManager restart
+            else
+              service network restart
+            fi
           EOH
 
           comm.sudo(commands.join("\n"))


### PR DESCRIPTION
RHEL-7 / Current Fedora versions tend to use NetworkManager for configuring the networks, and `service network restart` might fail.
If the `NetworkManager` service is running, we should restart it, otherwise we try restarting `network`.

The issue was introduced in `v1.8.7`.

See #7994.