### PR TITLE
Detect load failure within solution set and retry if found

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -330,6 +330,20 @@ module Vagrant
         # again, just reverse order on failure and attempt again.
         if retried
           @logger.error("Failed to load solution set - #{e.class}: #{e}")
+          matcher = e.message.match(/Could not find '(?<gem_name>[^']+)'/)
+          if matcher && !matcher["gem_name"].empty?
+            desired_activation_request = solution.detect do |request|
+              request.name == matcher["gem_name"]
+            end
+            if desired_activation_request && !desired_activation_request.full_spec.activated?
+              activation_request = desired_activation_request
+              @logger.warn("Found misordered activation request for #{desired_activation_request.full_name}. Moving to solution HEAD.")
+              solution.delete(desired_activation_request)
+              solution.unshift(desired_activation_request)
+              retry
+            end
+          end
+
           raise
         else
           @logger.debug("Failed to load solution set. Retrying with reverse order.")


### PR DESCRIPTION
Installation solution sets in 2.2.5 can end up out of order (not seen
in 2.3.1) causing LoadErrors when the specification is in the solution
set during validation. This detects the missing spec within the solution
and if found will move spec to the start of the solution set and retry
solution activation.