### PR TITLE
HyperV inaccurate winrm address - issue-7983

### DIFF
--- a/plugins/communicators/winrm/helper.rb
+++ b/plugins/communicators/winrm/helper.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
         return addr if addr
 
         ssh_info = machine.ssh_info
-        raise Errors::WinRMNotReady if !ssh_info
+        raise Errors::WinRMNotReady if !ssh_info || ssh_info[:host].empty?
         return ssh_info[:host]
       end
 

--- a/test/unit/plugins/communicators/winrm/helper_test.rb
+++ b/test/unit/plugins/communicators/winrm/helper_test.rb
@@ -36,6 +36,12 @@ describe VagrantPlugins::CommunicatorWinRM::Helper do
       expect { subject.winrm_address(machine) }.
         to raise_error(VagrantPlugins::CommunicatorWinRM::Errors::WinRMNotReady)
     end
+
+    it "raise an exception if it detects an empty host ip" do
+      machine.stub(ssh_info: { host: "" })
+      expect { subject.winrm_address(machine) }.
+        to raise_error(VagrantPlugins::CommunicatorWinRM::Errors::WinRMNotReady)
+    end
   end
 
   describe ".winrm_info" do


### PR DESCRIPTION
 Helper now throws WinRMNotReady exception is host ip is reported as an empty string

This was causing issues when provisioning win2012 r2 boxes in hyper-v. Sometimes hyper-v would report and empty string as the host address #in the winrm data to vagrant then vagrant would try to winrm to the machine with an ip of 0.0.0.0. This would cause sporadic failures when provisioning.

See #7983 for more information.
