### PR TITLE
Explicitly require name_tuple

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -6,6 +6,7 @@ require "fileutils"
 
 require "rubygems/package"
 require "rubygems/uninstaller"
+require "rubygems/name_tuple"
 
 require_relative "shared_helpers"
 require_relative "version"


### PR DESCRIPTION
This does not get automatically loaded before usage so ensure
it is properly loaded for plugin usage.

Fixes: #8069