### PR TITLE
enhance untar_failure message

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1975,8 +1975,9 @@ en:
         unpackage:
           untar_failure: |-
             The box failed to unpackage properly. Please verify that the box
-            file you're trying to add is not corrupted and try again. The
-            output from attempting to unpackage (if any):
+            file you're trying to add is not corrupted and that enough disk space
+            is available and then try again. 
+            The output from attempting to unpackage (if any):
 
             %{output}
         add:


### PR DESCRIPTION
Hi,

I was trying to set up Laravel using vagrant 1.9.0 on a Windows 7 64-bit system (command vagrant box add laravel/homestead).

I then was faced with the following error message:
            The box failed to unpackage properly. Please verify that the box
            file you're trying to add is not corrupted and then try again. 
            The output from attempting to unpackage (if any):
...

My problem was that I didn't have enough disk space.

So my suggestion is to extend the above message to contain a hint that the user also has to check the system space. This might save users some hassle on trying to track down the problem.

(See also issue 3869)