### PR TITLE
Add link to Atlas signup form

### DIFF
--- a/plugins/commands/login/locales/en.yml
+++ b/plugins/commands/login/locales/en.yml
@@ -21,7 +21,7 @@ en:
       are never stored on disk locally.
 
       If you do not have an Atlas account, sign up at
-      https://atlas.hashicorp.com.
+      https://atlas.hashicorp.com/account/new.
     invalid_login: |-
       Invalid username or password. Please try again.
     invalid_token: |-


### PR DESCRIPTION
The Atlas website doesn't have a Signup button anywhere.

Every new developer at our company asked me "how do I actually signup for Atlas?"

To make it easier for everybody, I changed the url so that developers can start right away :)