### PR TITLE
Fix quotes

### DIFF
--- a/plugins/guests/linux/guest.rb
+++ b/plugins/guests/linux/guest.rb
@@ -7,13 +7,13 @@ module VagrantPlugins
       def detect?(machine)
         machine.communicate.test <<-EOH.gsub(/^ */, '')
           if test -r /etc/os-release; then
-            source /etc/os-release && test x#{self.class.const_get(:GUEST_DETECTION_NAME)} = x$ID && exit
+            source /etc/os-release && test 'x#{self.class.const_get(:GUEST_DETECTION_NAME)}' = "x$ID" && exit
           fi
           if test -x /usr/bin/lsb_release; then
-            /usr/bin/lsb_release -i 2>/dev/null | grep -qi #{self.class.const_get(:GUEST_DETECTION_NAME)} && exit
+            /usr/bin/lsb_release -i 2>/dev/null | grep -qi '#{self.class.const_get(:GUEST_DETECTION_NAME)}' && exit
           fi
           if test -r /etc/issue; then
-            cat /etc/issue | grep -qi #{self.class.const_get(:GUEST_DETECTION_NAME)} && exit
+            cat /etc/issue | grep -qi '#{self.class.const_get(:GUEST_DETECTION_NAME)}' && exit
           fi
           exit 1
         EOH


### PR DESCRIPTION
We use boot2docker.

Succeed in Vagrant 1.8.6.
```
DEBUG guest: Trying: tinycore
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: cat /etc/issue | grep 'Core Linux' (sudo=false)
DEBUG ssh: Exit status: 0
 INFO guest: Detected: tinycore!
```

Fails in Vagrant 1.9.0 and 1.8.7.
```
DEBUG guest: Trying: tinycore
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: if test -r /etc/os-release; then
source /etc/os-release && test xCore Linux = x$ID && exit
fi
if test -x /usr/bin/lsb_release; then
/usr/bin/lsb_release -i 2>/dev/null | grep -qi Core Linux && exit
fi
if test -r /etc/issue; then
cat /etc/issue | grep -qi Core Linux && exit
fi
exit 1
 (sudo=false)
DEBUG ssh: stderr: sh: Linux: unknown operand

DEBUG ssh: stderr: grep: Linux: No such file or directory

DEBUG ssh: Exit status: 1
```

Corrected execution result.
```
DEBUG guest: Trying: tinycore
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: if test -r /etc/os-release; then
source /etc/os-release && test 'xCore Linux' = "x$ID" && exit
fi
if test -x /usr/bin/lsb_release; then
/usr/bin/lsb_release -i 2>/dev/null | grep -qi 'Core Linux' && exit
fi
if test -r /etc/issue; then
cat /etc/issue | grep -qi 'Core Linux' && exit
fi
exit 1
 (sudo=false)
DEBUG ssh: Exit status: 0
 INFO guest: Detected: tinycore!
```