### PR TITLE
Harden VMCX support

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -38,18 +38,18 @@ module VagrantPlugins
           config_type = nil
           vm_dir.each_child do |f|
             if f.extname.downcase == '.xml'
+              @logger.debug("Found XML config...")
               config_path = f
               config_type = 'xml'
               break
             end
           end
 
-          # Only check for .vmcx if there is no XML found to not
-          # risk breaking older vagrant boxes that added an XML
-          # file manually
-          if config_type == nil
+          vmcx_support = env[:machine].provider.driver.execute("has_vmcx_support.ps1", {})
+          if vmcx_support
             vm_dir.each_child do |f|
               if f.extname.downcase == '.vmcx'
+                @logger.debug("Found VMCX config and support...")
                 config_path = f
                 config_type = 'vmcx'
                 break

--- a/plugins/providers/hyperv/scripts/has_vmcx_support.ps1
+++ b/plugins/providers/hyperv/scripts/has_vmcx_support.ps1
@@ -1,0 +1,11 @@
+# Include the following modules
+$Dir = Split-Path $script:MyInvocation.MyCommand.Path
+. ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
+
+# Windows version 10 and up have support for binary format
+$check = [System.Environment]::OSVersion.Version.Major -ge 10
+$result = @{
+    result = $check
+}
+
+Write-Output-Message $(ConvertTo-Json $result)


### PR DESCRIPTION
Vagrant now checks if your Windows version has support for VMCX and then uses the VMCX file.

The reason for this is because the support for [HyperV in Packer is now merged](https://github.com/mitchellh/packer/pull/2576), but, it always creates an XML file, I assume for backwards compatibility, which does make sense especially for Windows versions before 10 which are still used. Vagrant should prefer using the newer format when supported, even when the old XML format is available.

The check consists of checking if the Windows version is greater or equal to 10, since Windows 10, and Windows Server 2016 both use the binary format, and they won't change back to the old config in future releases I assume.

To test, I loaded up about 5 of the HyperV boxes on Atlas with 1.9.1 and with this branch. Everything went fine. In order to make possible future debugging easier I added the type of config that is loaded to the debug log.