### PR TITLE
Fix broken OS detection for IDs with space

### DIFF
--- a/plugins/guests/linux/guest.rb
+++ b/plugins/guests/linux/guest.rb
@@ -7,13 +7,13 @@ module VagrantPlugins
       def detect?(machine)
         machine.communicate.test <<-EOH.gsub(/^ */, '')
           if test -r /etc/os-release; then
-            source /etc/os-release && test x#{self.class.const_get(:GUEST_DETECTION_NAME)} = x$ID && exit
+            source /etc/os-release && test 'x#{self.class.const_get(:GUEST_DETECTION_NAME)}' = x$ID && exit
           fi
           if test -x /usr/bin/lsb_release; then
-            /usr/bin/lsb_release -i 2>/dev/null | grep -qi #{self.class.const_get(:GUEST_DETECTION_NAME)} && exit
+            /usr/bin/lsb_release -i 2>/dev/null | grep -qi '#{self.class.const_get(:GUEST_DETECTION_NAME)}' && exit
           fi
           if test -r /etc/issue; then
-            cat /etc/issue | grep -qi #{self.class.const_get(:GUEST_DETECTION_NAME)} && exit
+            cat /etc/issue | grep -qi '#{self.class.const_get(:GUEST_DETECTION_NAME)}' && exit
           fi
           exit 1
         EOH


### PR DESCRIPTION
Guest detection logic was changed in GH-7887, however it breaks if
`GUEST_DETECTION_NAME` contains a space.

Example:
```bash
$ if test -r /etc/os-release; then source /etc/os-release && test xLinux Mint = x$ID && exit; fi
bash: test: too many arguments
```