### PR TITLE
Debug Documentation - &> is not valid on Windows

### DIFF
--- a/website/source/docs/other/debugging.html.md
+++ b/website/source/docs/other/debugging.html.md
@@ -58,9 +58,14 @@ option. For example:
 $ vagrant up --debug
 ```
 
-If you are saving the output to a file, you may need to redirect stderr and
+On Linux and Mac, if you are saving the output to a file, you may need to redirect stderr and
 stdout using `&>`:
 
 ```
 $ vagrant up --debug &> vagrant.log
+```
+
+On Windows: 
+```
+$ vagrant up --debug > vagrant.log 2>&1
 ```


### PR DESCRIPTION
The command "vagrant up --debug &> vagrant.log" is not valid on Windows.
On Windows, you need to do: vagrant up --debug > vagrant.log 2>&1