### PR TITLE
Revert "Fix `service network restart` on RHEL-7 / Fedora"

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -31,12 +31,8 @@ module VagrantPlugins
                 sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
               }
 
-              # Restart network (through NetworkManager if running)
-              if service NetworkManager status 2>&1 | grep -q running; then
-                service NetworkManager restart
-              else
-                service network restart
-              fi
+              # Restart network
+              service network restart
             EOH
           end
         end

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
 
             # Add the new interface and bring it back up
             final_path = "#{network_scripts_dir}/ifcfg-#{network[:device]}"
-            commands << <<-EOH.gsub(/^ {14}/, '')
+            commands << <<-EOH.gsub(/^ */, '')
               # Down the interface before munging the config file. This might
               # fail if the interface is not actually set up yet so ignore
               # errors.
@@ -48,13 +48,9 @@ module VagrantPlugins
             EOH
           end
 
-          commands << <<-EOH.gsub(/^ {12}/, '')
-            # Restart network (through NetworkManager if running)
-            if service NetworkManager status 2>&1 | grep -q running; then
-              service NetworkManager restart
-            else
-              service network restart
-            fi
+          commands << <<-EOH.gsub(/^ */, '')
+            # Restart network
+            service network restart
           EOH
 
           comm.sudo(commands.join("\n"))


### PR DESCRIPTION
Fix theses bugs : 
https://github.com/mitchellh/vagrant/issues/8142 https://github.com/mitchellh/vagrant/issues/8096

For RHEL7 and Fedora 25 `/etc/init.d/network restart` already  shutdown interfaces and restart NM if needed.

In start() :
```
        if [ "$(LANG=C nmcli -t --fields running general status 2>/dev/null)" = "running" ]; then
                nmcli connection reload
        fi

```

In stop() :

```
       for i in $vpninterfaces $xdslinterfaces $bridgeinterfaces $vlaninterfaces $remaining; do
                unset DEVICE TYPE
                (. ./ifcfg-$i
                if [ -z "$DEVICE" ] ; then DEVICE="$i"; fi

                if ! check_device_down $DEVICE; then
                   action $"Shutting down interface $i: " ./ifdown $i boot
                   [ $? -ne 0 ] && rc=1
                fi
                )
        done
```
Where $remaining include all "others" interfaces including eth*

It work for `NM_CONTROLLED=X` where X = yes or no 

This reverts commit 166d10d4e16836e908be0bd94c2f671cac2b38b4.