### PR TITLE
Quote ansible host variables

### DIFF
--- a/plugins/provisioners/ansible/provisioner/base.rb
+++ b/plugins/provisioners/ansible/provisioner/base.rb
@@ -148,7 +148,7 @@ module VagrantPlugins
           end
           s = nil
           if vars.is_a?(Hash)
-            s = vars.each.collect{ |k, v| "#{k}=#{v}" }.join(" ")
+            s = vars.each.collect{ |k, v| "#{k}=\"#{v}\"" }.join(" ")
           elsif vars.is_a?(Array)
             s = vars.join(" ")
           elsif vars.is_a?(String)

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -296,7 +296,7 @@ VF
         }
         expect(Vagrant::Util::Subprocess).to receive(:execute).with { |*args|
           inventory_content = File.read(generated_inventory_file)
-          expect(inventory_content).to match("^" + Regexp.quote(machine.name) + ".+http_port=80 maxRequestsPerChild=808")
+          expect(inventory_content).to match("^" + Regexp.quote(machine.name) + ".+http_port=\"80\" maxRequestsPerChild=\"808\"")
         }
       end
 


### PR DESCRIPTION
This allows using spaces in hash arguments.

I'm unsure if this is the proper fix or if it's needed in more places. Somebody more familiar with Vagrant and Ansible should check this.