### PR TITLE
Update command.rb

### DIFF
--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'securerandom'
 
 module VagrantPlugins
   module CommandPackage


### PR DESCRIPTION
Issue #8159

Solution: add require statement

Problem:

while using:
```
$ vagrant package --base ${VIRTUALBOXNAME}
```
this error occurs:
```
/usr/share/rubygems-integration/all/gems/vagrant-1.9.0/plugins/commands/package/command.rb:59:in `package_base': uninitialized constant VagrantPlugins::CommandPackage::Command::SecureRandom (NameError)
Did you mean?  SecureRandom
        from /usr/share/rubygems-integration/all/gems/vagrant-1.9.0/plugins/commands/package/command.rb:42:in `execute'
        from /usr/share/rubygems-integration/all/gems/vagrant-1.9.0/lib/vagrant/cli.rb:42:in `execute'
        from /usr/share/rubygems-integration/all/gems/vagrant-1.9.0/lib/vagrant/environment.rb:274:in `cli'
        from /usr/share/rubygems-integration/all/gems/vagrant-1.9.0/bin/vagrant:118:in `<top (required)>'
        from /usr/bin/vagrant:22:in `load'
        from /usr/bin/vagrant:22:in `<main>'
```