### PR TITLE
guests/arch: fix configuring multiple network interfaces fails

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -39,7 +39,7 @@ module VagrantPlugins
               comm.upload(f.path, remote_path)
             end
 
-            commands << <<-EOH.gsub(/^ {14}/, '')
+            commands << <<-EOH.gsub(/^ {14}/, '').rstrip
               # Configure #{network[:device]}
               mv '#{remote_path}' '/etc/netctl/#{network[:device]}' &&
               ip link set '#{network[:device]}' down &&


### PR DESCRIPTION
Vagrant fails to configure multiple network interfaces for Arch Linux guests due to the syntax error in the generated command for the network configuration:

```
# Configure eth1
mv '/tmp/vagrant-network-eth1-1483336033-0' '/etc/netctl/eth1' &&
ip link set 'eth1' down &&
netctl restart 'eth1' &&
netctl enable 'eth1'
 &&
# Configure eth2
mv '/tmp/vagrant-network-eth2-1483336034-1' '/etc/netctl/eth2' &&
ip link set 'eth2' down &&
netctl restart 'eth2' &&
netctl enable 'eth2'


Stdout from the command:

ln -s '/etc/systemd/system/netctl@eth1.service' '/etc/systemd/system/multi-user.target.wants/netctl@eth1.service'


Stderr from the command:

bash: line 9: syntax error near unexpected token `&&'
bash: line 9: ` && '
```

This PR strips the newline before `&&` that causes the syntax error.