### PR TITLE
Allow optional pip args via optional `pip_args`

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module Arch
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode == :pip
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -8,17 +8,17 @@ module VagrantPlugins
           module AnsibleInstall
 
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if (install_mode == :pip)
-                ansible_pip_install machine, ansible_version
+                ansible_pip_install machine, ansible_version, pip_args
               else
                 ansible_apt_install machine
               end
             end
 
-            def self.ansible_pip_install(machine, ansible_version)
+            def self.ansible_pip_install(machine, ansible_version, pip_args)
               pip_setup machine
-              Pip::pip_install machine, "ansible", ansible_version
+              Pip::pip_install machine, "ansible", ansible_version, pip_args
             end
 
             private

--- a/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
@@ -8,12 +8,12 @@ module VagrantPlugins
         module Fedora
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               rpm_package_manager = Facts::rpm_package_manager(machine)
 
               if install_mode == :pip
                 pip_setup machine
-                Pip::pip_install machine, "ansible", ansible_version
+                Pip::pip_install machine, "ansible", ansible_version, pip_args
               else
                 machine.communicate.sudo "#{rpm_package_manager} -y install ansible"
               end

--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
       module Guest
         module Pip
 
-          def self.pip_install(machine, package, version = "", upgrade = true)
+          def self.pip_install(machine, package, version = "", pip_args = "", upgrade = true)
             upgrade_arg = "--upgrade " if upgrade
             version_arg = ""
 
@@ -13,7 +13,7 @@ module VagrantPlugins
               version_arg = "==#{version}"
             end
 
-            machine.communicate.sudo "pip install #{upgrade_arg}#{package}#{version_arg}"
+            machine.communicate.sudo "pip install #{pip_args} #{upgrade_arg}#{package}#{version_arg}"
           end
 
           def self.get_pip(machine)

--- a/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
@@ -8,10 +8,10 @@ module VagrantPlugins
         module RedHat
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode == :pip
                 pip_setup machine
-                Pip::pip_install machine, "ansible", ansible_version
+                Pip::pip_install machine, "ansible", ansible_version, pip_args
               else
                 ansible_rpm_install machine
               end

--- a/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
@@ -7,9 +7,9 @@ module VagrantPlugins
         module Ubuntu
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode == :pip
-                Debian::AnsibleInstall::ansible_pip_install machine, ansible_version
+                Debian::AnsibleInstall::ansible_pip_install machine, ansible_version, pip_args
               else
                 ansible_apt_install machine
               end

--- a/plugins/provisioners/ansible/config/guest.rb
+++ b/plugins/provisioners/ansible/config/guest.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
         attr_accessor :tmp_path
         attr_accessor :install
         attr_accessor :install_mode
+        attr_accessor :pip_args
         attr_accessor :version
 
         def initialize
@@ -17,6 +18,7 @@ module VagrantPlugins
 
           @install           = UNSET_VALUE
           @install_mode      = UNSET_VALUE
+          @pip_args          = UNSET_VALUE
           @provisioning_path = UNSET_VALUE
           @tmp_path          = UNSET_VALUE
           @version           = UNSET_VALUE
@@ -27,6 +29,7 @@ module VagrantPlugins
 
           @install           = true                   if @install           == UNSET_VALUE
           @install_mode      = :default               if @install_mode      == UNSET_VALUE
+          @pip_args          = ""                     if @pip_args          == UNSET_VALUE
           @provisioning_path = "/vagrant"             if provisioning_path  == UNSET_VALUE
           @tmp_path          = "/tmp/vagrant-ansible" if tmp_path           == UNSET_VALUE
           @version           = ""                     if @version           == UNSET_VALUE

--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -49,7 +49,7 @@ module VagrantPlugins
              (config.version.to_s.to_sym == :latest ||
               !@machine.guest.capability(:ansible_installed, config.version))
             @machine.ui.detail I18n.t("vagrant.provisioners.ansible.installing")
-            @machine.guest.capability(:ansible_install, config.install_mode, config.version)
+            @machine.guest.capability(:ansible_install, config.install_mode, config.version, config.pip_args)
           end
 
           # Check that Ansible Playbook command is available on the guest

--- a/test/unit/plugins/provisioners/ansible/config/guest_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/guest_test.rb
@@ -27,6 +27,7 @@ describe VagrantPlugins::Ansible::Config::Guest do
                             install_mode
                             inventory_path
                             limit
+                            pip_args
                             playbook
                             playbook_command
                             provisioning_path

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -79,6 +79,9 @@ This section lists the _specific_ options for the Ansible Local provisioner. In 
 
     The default value is `:default`, and any invalid value for this option will silently fall back to the default value.
 
+- `pip_args` (string) - When Ansible is installed via pip this option allows the defition of additional pip arguments to be passed along on the
+command line (for example, [--index-url](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i)).
+
 - `provisioning_path` (string) - An absolute path on the guest machine where the Ansible files are stored. The `ansible-galaxy` and `ansible-playbook` commands are executed from this directory. This is the location to place an [ansible.cfg](http://docs.ansible.com/ansible/intro_configuration.html) file, in case you need it.
 
     The default value is `/vagrant`.


### PR DESCRIPTION
When using `install_mode = pip` for the version we're currently locked to, it fails due to some compilation errors on dependent libraries. This actually isn't needed since we have wheels for the dependencies in our own internal resolver but vagrant doesn't provide a good way to define `--index-url`. This PR resolves that. 

```
  n.vm.provision :ansible_local do |ansible|
    ansible.version = "2.1.1.0"
    ansible.install_mode = "pip"
    ansible.pip_args = "--install-url https://pypi.internal"
    ansible.playbook = "main.yml"
    ansible.provisioning_path = "/vagrant/ansible"
    ansible.galaxy_roles_path = THIRD_PARTY_ROLES_DIR
    ansible.galaxy_role_file = "#{ANSIBLE_ROOT_DIR}/third-party-roles.yml"
    ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} #{GALAXY_FORCE_OPTION}"
    ansible.sudo = true
    ansible.skip_tags = ['configure']
    ansible.extra_vars = ANSIBLE_INSTALL_VARS_ABSOLUTE
    ansible.raw_arguments =  ANSIBLE_RAW_ARGUMENTS
  end

```