### PR TITLE
Adding diff option for Ansible provisioner

### DIFF
--- a/plugins/provisioners/ansible/config/base.rb
+++ b/plugins/provisioners/ansible/config/base.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
         PLAYBOOK_COMMAND_DEFAULT = "ansible-playbook".freeze
 
         attr_accessor :config_file
+        attr_accessor :diff
         attr_accessor :extra_vars
         attr_accessor :galaxy_role_file
         attr_accessor :galaxy_roles_path
@@ -28,6 +29,7 @@ module VagrantPlugins
 
         def initialize
           @config_file         = UNSET_VALUE
+          @diff                = UNSET_VALUE
           @extra_vars          = UNSET_VALUE
           @galaxy_role_file    = UNSET_VALUE
           @galaxy_roles_path   = UNSET_VALUE
@@ -50,6 +52,7 @@ module VagrantPlugins
 
         def finalize!
           @config_file         = nil                      if @config_file         == UNSET_VALUE
+          @diff                = false                    if @diff                != true
           @extra_vars          = nil                      if @extra_vars          == UNSET_VALUE
           @galaxy_role_file    = nil                      if @galaxy_role_file    == UNSET_VALUE
           @galaxy_roles_path   = nil                      if @galaxy_roles_path   == UNSET_VALUE

--- a/plugins/provisioners/ansible/provisioner/base.rb
+++ b/plugins/provisioners/ansible/provisioner/base.rb
@@ -99,6 +99,7 @@ module VagrantPlugins
           @command_arguments << "--extra-vars=#{extra_vars_argument}" if config.extra_vars
           @command_arguments << "--sudo" if config.sudo
           @command_arguments << "--sudo-user=#{config.sudo_user}" if config.sudo_user
+          @command_arguments << "--diff" if config.diff
           @command_arguments << "#{verbosity_argument}" if verbosity_is_enabled?
           @command_arguments << "--vault-password-file=#{config.vault_password_file}" if config.vault_password_file
           @command_arguments << "--tags=#{Helpers::as_list_argument(config.tags)}" if config.tags

--- a/test/unit/plugins/provisioners/ansible/config/guest_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/guest_test.rb
@@ -17,6 +17,7 @@ describe VagrantPlugins::Ansible::Config::Guest do
 
   it "supports a list of options" do
     supported_options = %w( config_file
+                            diff
                             extra_vars
                             galaxy_command
                             galaxy_role_file

--- a/test/unit/plugins/provisioners/ansible/config/host_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/host_test.rb
@@ -16,6 +16,7 @@ describe VagrantPlugins::Ansible::Config::Host, :skip_windows => true do
     supported_options = %w( ask_sudo_pass
                             ask_vault_pass
                             config_file
+                            diff
                             extra_vars
                             force_remote_user
                             galaxy_command

--- a/test/unit/plugins/provisioners/ansible/config/shared.rb
+++ b/test/unit/plugins/provisioners/ansible/config/shared.rb
@@ -4,6 +4,7 @@ shared_examples_for 'options shared by both Ansible provisioners' do
     subject.finalize!
 
     expect(subject.config_file).to be_nil
+    expect(subject.diff).to be_false
     expect(subject.extra_vars).to be_nil
     expect(subject.galaxy_command).to eql("ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force")
     expect(subject.galaxy_role_file).to be_nil

--- a/website/source/docs/provisioning/ansible_common.html.md
+++ b/website/source/docs/provisioning/ansible_common.html.md
@@ -21,6 +21,10 @@ Some of these options are for advanced usage only and should not be used unless 
 
     By default, this option is not set, and Ansible will [search for a possible configuration file in some default locations](/docs/provisioning/ansible_intro.html#ANSIBLE_CONFIG).
 
+- `diff` (boolean) - Cause Ansible to show what changed on modules that support it.
+
+    The default value is `false`.
+
 - `extra_vars` (string or hash) - Pass additional variables (with highest priority) to the playbook.
 
     This parameter can be a path to a JSON or YAML file, or a hash.


### PR DESCRIPTION
This patch is adding support for the `--diff` command line option for the Ansible provisioner.