### PR TITLE
website: make linked clones work w/ 1.8.0 & newer

### DIFF
--- a/website/source/docs/virtualbox/configuration.html.md
+++ b/website/source/docs/virtualbox/configuration.html.md
@@ -63,7 +63,7 @@ To have backward compatibility:
 
 ```ruby
 config.vm.provider 'virtualbox' do |v|
-  v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+  v.linked_clone = true if Vagrant::VERSION >= '1.8.0'
 end
 ```
 


### PR DESCRIPTION
The previous code only worked on Vagrant 1.8.x, but not on 1.9.x or newer.