### PR TITLE
Warn about changes to CWD on every machine action

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -170,6 +170,8 @@ module Vagrant
       # Extra env keys are the remaining opts
       extra_env = opts.dup
 
+      check_cwd
+
       # Create a deterministic ID for this machine
       vf = nil
       vf = @env.vagrantfile_name[0] if @env.vagrantfile_name
@@ -558,6 +560,26 @@ module Vagrant
     def uid_file
       return nil if !@data_dir
       @data_dir.join("creator_uid")
+    end
+
+    def check_cwd
+      vagrant_cwd_filepath = @data_dir.join('vagrant_cwd')
+      vagrant_cwd = if File.exist?(vagrant_cwd_filepath)
+        File.read(vagrant_cwd_filepath).chomp
+      end
+
+      if vagrant_cwd
+        if vagrant_cwd != @env.cwd.to_s
+          ui.warn(I18n.t(
+            'vagrant.moved_cwd',
+            old_wd:     vagrant_cwd,
+            current_wd: @env.cwd.to_s))
+
+          File.write(vagrant_cwd_filepath, @env.cwd)
+        end
+      else
+        File.write(vagrant_cwd_filepath, @env.cwd)
+      end
     end
   end
 end

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -170,7 +170,7 @@ module Vagrant
       # Extra env keys are the remaining opts
       extra_env = opts.dup
 
-      check_cwd
+      check_cwd # Warns the UI if the machine was last used on a different dir
 
       # Create a deterministic ID for this machine
       vf = nil

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -162,6 +162,10 @@ en:
       description of what they do.
 
       %{list}
+    moved_cwd: |-
+      This machine used to live in %{old_wd} but it's now at %{current_wd}.
+      Please change the name of the machine if you want to run it as a different
+      machine.
     guest_deb_installing_smb: |-
       Installing SMB "mount.cifs"...
     global_status_footer: |-

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -307,6 +307,28 @@ describe Vagrant::Machine do
       expect { instance.action(action_name) }.
         to raise_error(Vagrant::Errors::UnimplementedProviderAction)
     end
+
+    it 'should warn if the machine was last run under a different directory' do
+      action_name  = :up
+      callable     = lambda { |_env| }
+      original_cwd = env.cwd.to_s
+
+      allow(provider).to receive(:action).with(action_name).and_return(callable)
+      allow(subject.ui).to receive(:warn)
+
+      instance.action(action_name)
+
+      expect(subject.ui).to_not have_received(:warn)
+
+      # Whenever the machine is run on a different directory, the user is warned
+      allow(env).to receive(:cwd).and_return('/a/new/path')
+      instance.action(action_name)
+
+      expect(subject.ui).to have_received(:warn) do |warn_msg|
+        expect(warn_msg).to include(original_cwd)
+        expect(warn_msg).to include('/a/new/path')
+      end
+    end
   end
 
   describe "#action_raw" do


### PR DESCRIPTION
This is an attempt to implement https://github.com/mitchellh/vagrant/issues/3921 @chrisroberts could you please take a look?

Whenever the path where the machine was first created changes, Vagrant will now show just one warning when an action is run on the machine. The idea is that if a user copies the machine over to a different directory with the intention of running two different machines, this warning will now help the user determine how to make that work.

This PR lacks tests, I'll add those once we can agree on a correct implementation.