### PR TITLE
Set base directory to parent directory within plugin specs

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -398,6 +398,7 @@ module Vagrant
         end
 
         spec.full_gem_path = File.expand_path(directory)
+        spec.base_dir = File.dirname(spec.base_dir)
 
         @specs[spec.name] ||= []
         @specs[spec.name] << spec


### PR DESCRIPTION
This adjustment allows for extensions to be properly discovered after
plugin gem specifications have been activated and prevent warning messages.

Fixes: #8190, #8147