### PR TITLE
Allow VAGRANT_DOTFILE_PATH to be expanded as expected.

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -160,8 +160,8 @@ module Vagrant
       # it is expanded relative to the root path. Otherwise, we use the
       # default (which is also expanded relative to the root path).
       if !root_path.nil?
-        if !(ENV["VAGRANT_DOTFILE_PATH"] or "").empty? && !opts[:child]
-          opts[:local_data_path] ||= root_path.join(ENV["VAGRANT_DOTFILE_PATH"])
+        if !ENV["VAGRANT_DOTFILE_PATH"].to_s.empty? && !opts[:child]
+          opts[:local_data_path] ||= Pathname.new(File.expand_path(ENV["VAGRANT_DOTFILE_PATH"], root_path))
         else
           opts[:local_data_path] ||= root_path.join(DEFAULT_LOCAL_DATA)
         end

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -1023,6 +1023,16 @@ VF
       end
     end
 
+    context "with environmental variable VAGRANT_DOTFILE_PATH set with tilde" do
+      it "is set relative to the user's home directory" do
+        with_temp_env("VAGRANT_DOTFILE_PATH" => "~/.vagrant") do
+          instance = env.create_vagrant_env
+          expect(instance.cwd).to eq(env.workdir)
+          expect(instance.local_data_path.to_s).to eq(File.join(Dir.home, ".vagrant"))
+        end
+      end
+    end
+
     describe "upgrading V1 dotfiles" do
       let(:v1_dotfile_tempfile) do
         Tempfile.new("vagrant-upgrade-dotfile").tap do |f|


### PR DESCRIPTION
This allows custom paths that include special characters like `~`
to be properly expanded instead of resulting in joined root path
with special characters included.

Fixes: #8108 