### PR TITLE
Prevent generating environment variables with invalid empty names

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -226,7 +226,9 @@ module Vagrant
       ENV.each do |k,v|
         if k.start_with?("VAGRANT_OLD_ENV")
           key = k.sub(/^VAGRANT_OLD_ENV_/, "")
-          h[key] = v
+          if !key.empty?
+            h[key] = v
+          end
         end
       end
     end

--- a/test/unit/vagrant/util/env_test.rb
+++ b/test/unit/vagrant/util/env_test.rb
@@ -1,0 +1,43 @@
+require File.expand_path("../../../base", __FILE__)
+
+require 'vagrant/util/env'
+
+describe Vagrant::Util::Env do
+  context "with valid environment variables" do
+    before do
+      ENV["VAGRANT_TEST"] = "1"
+    end
+
+    after do
+      ENV.delete("VAGRANT_TEST")
+    end
+
+    it "should execute block with original environment variables" do
+      Vagrant::Util::Env.with_original_env do
+        expect(ENV["VAGRANT_TEST"]).to be_nil
+      end
+    end
+
+    it "should replace environment variables after executing block" do
+      Vagrant::Util::Env.with_original_env do
+        expect(ENV["VAGRANT_TEST"]).to be_nil
+      end
+      expect(ENV["VAGRANT_TEST"]).to eq("1")
+    end
+  end
+
+  context "with invalid environment variables" do
+    it "should not attempt to restore invalid environment variable" do
+      invalid_vars = ENV.to_hash.merge("VAGRANT_OLD_ENV_" => "INVALID")
+      mock = expect(ENV).to receive(:each)
+      invalid_vars.each do |k,v|
+        mock.and_yield(k, v)
+      end
+      expect do
+        Vagrant::Util::Env.with_original_env do
+          expect(ENV["VAGRANT_TEST"]).to be_nil
+        end
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Fixes: #8126