### PR TITLE
port forwarding rule name

### DIFF
--- a/website/source/docs/networking/forwarded_ports.html.md
+++ b/website/source/docs/networking/forwarded_ports.html.md
@@ -62,6 +62,9 @@ there are more detailed examples of using these options.
 * `protocol` (string) - Either "udp" or "tcp". This specifies the protocol
   that will be allowed through the forwarded port. By default this is "tcp".
 
+* `id` (string) - Name of the rule (can be visible in VirtualBox). By 
+  default this is "protocol""guest" (exemple : "tcp123").
+
 ## Forwarded Port Protocols
 
 By default, any defined port will only forward the TCP protocol. As an optional


### PR DESCRIPTION
To identify rules, we can name them using the id parameter.
It prevent from adding lots of comments in the Vagrant file and to have un-named rules in your VirtualBox port lists.

It is very important when you have a lot ogf rule to identify witch one you want to edit.

For example:
config.vm.network "forwarded_port", guest: 80  , host: 8080 , id:"http-proxy"