### PR TITLE
Delete empty keys from ENV

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -227,6 +227,12 @@ module Vagrant
         if k.start_with?("VAGRANT_OLD_ENV")
           key = k.sub(/^VAGRANT_OLD_ENV_/, "")
           h[key] = v
+          if key.length==0          
+            h.delete(key)
+          end
+        end
+        if k.length==0          
+          h.delete(k)
         end
       end
     end


### PR DESCRIPTION
An ENV with a value with empty key "" stops vagrant: the solution i've found is to remove all key/value pairs with a key length of 0 chars.