### PR TITLE
Add validate command

### DIFF
--- a/plugins/commands/validate/command.rb
+++ b/plugins/commands/validate/command.rb
@@ -1,0 +1,31 @@
+require 'optparse'
+
+module VagrantPlugins
+  module CommandValidate
+    class Command < Vagrant.plugin("2", :command)
+      def self.synopsis
+        "validates the Vagrantfile"
+      end
+
+      def execute
+        opts = OptionParser.new do |o|
+          o.banner = "Usage: vagrant validate"
+        end
+
+        # Parse the options
+        argv = parse_options(opts)
+        return if !argv
+
+        # Validate the configuration
+        @env.machine(@env.machine_names.first, @env.default_provider).action_raw(
+          :config_validate,
+          Vagrant::Action::Builtin::ConfigValidate)
+
+        @env.ui.info(I18n.t("vagrant.commands.validate.success"))
+
+        # Success, exit status 0
+        0
+      end
+    end
+  end
+end

--- a/plugins/commands/validate/plugin.rb
+++ b/plugins/commands/validate/plugin.rb
@@ -1,0 +1,17 @@
+require "vagrant"
+
+module VagrantPlugins
+  module CommandValidate
+    class Plugin < Vagrant.plugin("2")
+      name "validate command"
+      description <<-DESC
+      The `validate` command validates the Vagrantfile.
+      DESC
+
+      command("validate") do
+        require File.expand_path("../command", __FILE__)
+        Command
+      end
+    end
+  end
+end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1726,6 +1726,9 @@ en:
       up:
         upping: |-
           Bringing machine '%{name}' up with '%{provider}' provider...
+      validate:
+        success: |-
+          Vagrantfile validated successfully.
 
 #-------------------------------------------------------------------------------
 # Translations for Vagrant middleware actions

--- a/test/unit/plugins/commands/validate/command_test.rb
+++ b/test/unit/plugins/commands/validate/command_test.rb
@@ -1,0 +1,52 @@
+require_relative "../../../base"
+require_relative "../../../../../plugins/commands/validate/command"
+
+describe VagrantPlugins::CommandValidate::Command do
+  include_context "unit"
+  include_context "command plugin helpers"
+
+  let(:iso_env) do
+    isolated_environment
+  end
+
+  let(:env) do
+    iso_env.create_vagrant_env
+  end
+
+  let(:argv)   { [] }
+
+  before(:all) do
+    I18n.load_path << Vagrant.source_root.join("plugins/commands/port/locales/en.yml")
+    I18n.reload!
+  end
+
+  subject { described_class.new(argv, env) }
+
+  describe "#execute" do
+    it "validates correct Vagrantfile" do
+      iso_env.vagrantfile(<<-EOH)
+        Vagrant.configure("2") do |config|
+          config.vm.box = "hashicorp/precise64"
+        end
+      EOH
+
+      expect(env.ui).to receive(:info).with { |message, _|
+        expect(message).to include("Vagrantfile validated successfully.")
+      }
+
+      expect(subject.execute).to eq(0)
+    end
+
+    it "validates the configuration" do
+      iso_env.vagrantfile <<-EOH
+        Vagrant.configure("2") do |config|
+          config.vm.bix = "hashicorp/precise64"
+        end
+      EOH
+
+      expect { subject.execute }.to raise_error(Vagrant::Errors::ConfigInvalid) { |err|
+        expect(err.message).to include("The following settings shouldn't exist: bix")
+      }
+    end
+  end
+end

--- a/website/source/docs/cli/validate.html.md
+++ b/website/source/docs/cli/validate.html.md
@@ -6,7 +6,7 @@ description: |-
   The "vagrant validate" command is used to validate your Vagrantfile.
 ---
 
-# Up
+# Validate
 
 **Command: `vagrant validate`**
 

--- a/website/source/docs/cli/validate.html.md
+++ b/website/source/docs/cli/validate.html.md
@@ -1,0 +1,20 @@
+---
+layout: "docs"
+page_title: "vagrant validate - Command-Line Interface"
+sidebar_current: "cli-validate"
+description: |-
+  The "vagrant validate" command is used to validate your Vagrantfile.
+---
+
+# Up
+
+**Command: `vagrant validate`**
+
+This command validates your [Vagrantfile](/docs/vagrantfile/).
+
+## Examples
+
+```sh
+$ vagrant validate
+Vagrantfile validated successfully.
+```

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -62,6 +62,7 @@
             <li<%= sidebar_current("cli-status") %>><a href="/docs/cli/status.html">status</a></li>
             <li<%= sidebar_current("cli-suspend") %>><a href="/docs/cli/suspend.html">suspend</a></li>
             <li<%= sidebar_current("cli-up") %>><a href="/docs/cli/up.html">up</a></li>
+            <li<%= sidebar_current("cli-validate") %>><a href="/docs/cli/validate.html">validate</a></li>
             <li<%= sidebar_current("cli-version") %>><a href="/docs/cli/version.html">version</a></li>
             <li<%= sidebar_current("cli-nonprimary") %>><a href="/docs/cli/non-primary.html">More Commands</a></li>
             <li<%= sidebar_current("cli-machinereadable") %>><a href="/docs/cli/machine-readable.html">Machine Readable Output</a></li>


### PR DESCRIPTION
The `validate` command simply validates your `Vagrantfile`:

Successful validation:

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "debian/jessie64"
end
```

```sh
$ vagrant validate
Vagrantfile validated successfully.
```

Failed validation:

```ruby
Vagrant.configure("2") do |config|
  config.vm.bix = "debian/jessie64"
end
```

```sh
$ vagrant validate
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* The following settings shouldn't exist: bix
* A box must be specified.
```

This command is added in response to issue #8151.