### PR TITLE
Correctly apply mode and labels to RHEL network-scripts

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -41,9 +41,16 @@ module VagrantPlugins
               # fail if the interface is not actually set up yet so ignore
               # errors.
               /sbin/ifdown '#{network[:device]}'
+
               # Move new config into place
               mv -f '#{remote_path}' '#{final_path}'
-              # attempt to force network manager to reload configurations
+
+              # Apply correct permissions
+              chown root:root '#{final_path}'
+              chmod 644 '#{final_path}'
+              chcon -u system_u -r object_r -t net_conf_t '#{final_path}'
+
+              # Attempt to force network manager to reload configurations
               nmcli c reload || true
             EOH
           end


### PR DESCRIPTION
When configuring network interfaces on RHEL-based systems, ensure that the permissions and SELinux labels are what they should be.