### PR TITLE
Add proper path translation for WSL (Windows Subsystem for Linux) installations

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -28,7 +28,7 @@ module Vagrant
       def self.check_key_permissions(key_path)
         # Don't do anything if we're on Windows, since Windows doesn't worry
         # about key permissions.
-        return if Platform.windows?
+        return if Platform.windows? || Platform.wsl?
 
         LOGGER.debug("Checking key permissions: #{key_path}")
         stat = key_path.stat


### PR DESCRIPTION
This patch allows you to run vagrant inside of Ubuntu on WSL if you do the following (inspiration from https://github.com/Microsoft/BashOnWindows/issues/733):

1. Be running a build of Windows that supports running Windows programs inside of WSL (build 14951 or higher).
2. Install the WINDOWS version of Virtualbox.
3. Symlink VBoxManage to the expected path in Linux:
`sudo ln -s "/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe" /usr/bin/VBoxManage`.

This patch provides the proper path translation for WSL's mounting scheme, similar to the cygwin one I took inspiration from.

This should fix  #7731 or at least much of it as well as Microsoft/BashOnWindows#733