### PR TITLE
Force path as preferred source on local install

### DIFF
--- a/test/unit/vagrant/util/subprocess_test.rb
+++ b/test/unit/vagrant/util/subprocess_test.rb
@@ -64,10 +64,11 @@ describe Vagrant::Util::Subprocess do
     end
     context "when subprocess is running" do
       it "should return true" do
-        sp = described_class.new("sleep", "0.2")
+        sp = described_class.new("sleep", "5")
         thread = Thread.new{ sp.execute }
         sleep(0.1)
         expect(sp.running?).to be_true
+        sp.stop
         thread.join
       end
     end


### PR DESCRIPTION
When installing a plugin from a local file and a plugin with the same name/version is available via remote source, it can end up as preferred for installation. Force the local path to always be preferred.