### PR TITLE
Update vagrant gem dependencies

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
   s.add_dependency "net-ssh", "~> 3.0.1"
   s.add_dependency "net-sftp", "~> 2.1"
-  s.add_dependency "net-scp", "~> 1.1.0"
+  s.add_dependency "net-scp", "~> 1.2.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "rest-client", ">= 1.6.0", "< 3.0"
   s.add_dependency "wdm", "~> 0.1.0"


### PR DESCRIPTION
Alot of other gems (train, kitchen, etc depend on net-scp ~>1.2.0) and will not work without this one being bumped. net-scp 1.1.0 is _extremely_ old.