### PR TITLE
Fix vagrant bash completion when path have spaces

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -71,9 +71,9 @@ _vagrant() {
             ;;
             "up")
               vagrant_state_file=$(__vagrantinvestigate) || return 1
-              if [[ -d $vagrant_state_file ]]
+              if [[ -d "${vagrant_state_file}" ]]
               then
-                local vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+                local vm_list=$(find "${vagrant_state_file}/machines" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               fi
               local up_commands="--no-provision"
               COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
@@ -81,12 +81,12 @@ _vagrant() {
             ;;
             "ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config")
               vagrant_state_file=$(__vagrantinvestigate) || return 1
-      	      if [[ -f $vagrant_state_file ]]
+              if [[ -f "${vagrant_state_file}" ]]
               then
-		            running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
-      	      else
-		            running_vm_list=$(find $vagrant_state_file -type f -name "id" | awk -F"/" '{print $(NF-2)}')
-      	      fi
+                running_vm_list=$(grep 'active' "${vagrant_state_file}" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
+              else
+                running_vm_list=$(find "${vagrant_state_file}" -type f -name "id" | awk -F"/" '{print $(NF-2)}')
+              fi
               COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
               return 0
             ;;
@@ -121,9 +121,9 @@ _vagrant() {
         "up")
           if [ "$prev" == "--no-provision" ]
           then
-            if [[ -d $vagrant_state_file ]]
+            if [[ -d "${vagrant_state_file}" ]]
             then
-              local vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+              local vm_list=$(find "${vagrant_state_file}/machines" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
             fi
             COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
             return 0


### PR DESCRIPTION
# Problem

Using bash completion in a path that have spaces, for instance _*/User/pmaques/My_ Vagrant/*_ will fails with some lines of folder not found.