### PR TITLE
Support spec prerelease matching

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -280,7 +280,10 @@ module Vagrant
       # as we know the dependencies are satisfied and it will attempt to validate a gem's
       # dependencies are satisified by gems in the install directory (which will likely not
       # be true)
-      result = request_set.install_into(plugin_gem_path.to_s, true, ignore_dependencies: true)
+      result = request_set.install_into(plugin_gem_path.to_s, true,
+        ignore_dependencies: true,
+        prerelease: Vagrant.prerelease?
+      )
       result = result.map(&:full_spec)
       result
     end
@@ -425,7 +428,8 @@ module Vagrant
 
       def find_all(req)
         @specs.select do |spec|
-          req.match?(spec)
+          allow_prerelease = spec.name == "vagrant" && Vagrant.prerelease?
+          req.match?(spec, allow_prerelease)
         end.map do |spec|
           Gem::Resolver::InstalledSpecification.new(self, spec)
         end
@@ -474,7 +478,7 @@ module Vagrant
       # ignored.
       def load_spec (name, version, platform, source)
         version = Gem::Version.new(version) if !version.is_a?(Gem::Version)
-        @specs.fetch(name, []).detect{|s| s.name == name && s.version = version}
+        @specs.fetch(name, []).detect{|s| s.name == name && s.version == version}
       end
     end
   end

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -102,4 +102,12 @@ module Vagrant
 
     Pathname.new(path).expand_path
   end
+
+  # This returns true/false if the running version of Vagrant is
+  # a pre-release version (development)
+  #
+  # @return [Boolean]
+  def self.prerelease?
+    Gem::Version.new(Vagrant::VERSION).prerelease?
+  end
 end

--- a/test/unit/vagrant/shared_helpers_test.rb
+++ b/test/unit/vagrant/shared_helpers_test.rb
@@ -131,4 +131,16 @@ describe Vagrant do
       end
     end
   end
+
+  describe "#prerelease?" do
+    it "should return true when Vagrant version is development" do
+      stub_const("Vagrant::VERSION", "1.0.0.dev")
+      expect(subject.prerelease?).to be(true)
+    end
+
+    it "should return false when Vagrant version is release" do
+      stub_const("Vagrant::VERSION", "1.0.0")
+      expect(subject.prerelease?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Adds a `Vagrant.prerelease?` helper and supports matching the vagrant spec when running within a prerelease version. This allows plugins to be installed properly when they impose a constraint on the vagrant version itself.