### PR TITLE
Website: Add Meganav

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.12"
+gem "middleman-hashicorp", "0.3.13"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.12)
+    middleman-hashicorp (0.3.13)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -151,7 +151,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.12)
+  middleman-hashicorp (= 0.3.13)
 
 BUNDLED WITH
    1.14.6

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.12"
+VERSION?="0.3.13"
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/website/packer.json
+++ b/website/packer.json
@@ -8,7 +8,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "hashicorp/middleman-hashicorp:0.3.12",
+      "image": "hashicorp/middleman-hashicorp:0.3.13",
       "discard": "true",
       "run_command": ["-d", "-i", "-t", "{{ .Image }}", "/bin/sh"]
     }

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -3,6 +3,8 @@
 
 //= require lib/_Base
 
+//= require hashicorp/mega-nav
+
 //= require app/_app
 //= require app/_docs
 //= require app/_sidebar

--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -8,8 +8,9 @@ text-rendering: optimizeLegibility;
 }*/
 
 body {
-  font-size: 18px;
   color: $black;
+  font-family: $font-family-open-sans;
+  font-size: 18px;
   font-weight: 400;
 }
 
@@ -32,10 +33,6 @@ h1 + h2 {
 h3 {
   font-size: 24px;
   line-height: 1.2;
-}
-
-p, a {
-  font-family: $font-family-open-sans;
 }
 
 .highlight{

--- a/website/source/assets/stylesheets/_home.scss
+++ b/website/source/assets/stylesheets/_home.scss
@@ -7,10 +7,6 @@
     text-align: center;
   }
 
-  p {
-    color: $purple-text;
-  }
-
   .hero {
     @include padded;
     background: $gray-background image-url("vagrant_header_background.png") no-repeat center -20px;
@@ -66,6 +62,9 @@
       h4 {
         font-size: 20px;
         line-height: $baseline * 1.5;
+      }
+      p {
+        color: $purple-text;
       }
     }
   }

--- a/website/source/assets/stylesheets/_home.scss
+++ b/website/source/assets/stylesheets/_home.scss
@@ -4,7 +4,6 @@
     color: $purple-text;
     font-family: $font-family-klavika;
     text-transform: uppercase;
-    text-align: center;
   }
 
   .hero {
@@ -48,6 +47,8 @@
 
     h2 {
       color: $blue-text;
+      text-align: center;
+
     }
 
     hgroup {
@@ -57,10 +58,12 @@
       h3 {
         font-weight: bold;
         margin-bottom: $baseline;
+        text-align: center;
       }
 
       h4 {
         font-size: 20px;
+        text-align: center;
         line-height: $baseline * 1.5;
       }
       p {
@@ -75,6 +78,7 @@
 
     h2 {
       color: $white;
+      text-align: center;
     }
 
     pre {
@@ -92,6 +96,7 @@
 
     h2 {
       color: $dark-gray-text;
+      text-align: center;
     }
 
     .customer-logos {

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -6,6 +6,9 @@
 @import url("//fonts.googleapis.com/css?family=Open+Sans:300,400,600");
 @import url("//fonts.googleapis.com/css?family=Inconsolata:400,700");
 
+// Mega Nav
+@import 'hashicorp/mega-nav';
+
 // Core variables and mixins
 @import "_variables";
 

--- a/website/source/layouts/_header.erb
+++ b/website/source/layouts/_header.erb
@@ -49,7 +49,6 @@
             <div class="navbar-header">
               <div class="navbar-brand">
                 <a class="logo" href="/">Vagrant</a>
-                <a class="by-hashicorp gray" href="https://www.hashicorp.com/"><span class="svg-wrap">by</span><%= partial "layouts/svg/svg-by-hashicorp" %><%= partial "layouts/svg/svg-hashicorp-logo" %>HashiCorp</a>
               </div>
               <button class="navbar-toggle gray" type="button">
                 <span class="sr-only">Toggle navigation</span>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -1,3 +1,4 @@
+<%= mega_nav :vagrant %>
 <%= partial "layouts/header" %>
 <%= partial "layouts/sidebar" %>
 <%= yield %>


### PR DESCRIPTION
🚧 WIP. Don't merge until final approval

HashiCorp is adding a high-level element to provide navigation and visibility to OSS project sites. We like to call it Mega Nav :zap:. Mega Nav is pulled in from [middleman-hashicorp](https://github.com/hashicorp/middleman-hashicorp) and is positioned above the local nav in the site. It looks like this: 

### Desktop Inactive
<img width="1431" alt="screen shot 2017-03-08 at 10 08 21 am" src="https://cloud.githubusercontent.com/assets/416727/23717336/491ff6ee-03e8-11e7-8d54-ff0dd63b8d7a.png">

### Desktop Active
<img width="1431" alt="screen shot 2017-03-08 at 10 08 32 am" src="https://cloud.githubusercontent.com/assets/416727/23717349/50e9ec5e-03e8-11e7-903b-e6c9dab93ecd.png">

### Mobile Inactive
<img width="399" alt="screen shot 2017-03-08 at 10 08 42 am" src="https://cloud.githubusercontent.com/assets/416727/23717356/57af2536-03e8-11e7-877d-ea15b3f9bc63.png">

### Mobile Active
<img width="399" alt="screen shot 2017-03-08 at 10 21 12 am" src="https://cloud.githubusercontent.com/assets/416727/23717550/1c0bdc12-03e9-11e7-8e7a-b4505edae5af.png">


cc/ @pearkes @hashicorp/design 