### PR TITLE
Windows UNC path is crashing with \\\\?\\ prefix

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -203,7 +203,7 @@ module Vagrant
           return path + "\\" if path =~ /^[a-zA-Z]:\\?$/
 
           # Convert to UNC path
-          "\\\\?\\" + path.gsub("/", "\\")
+          path.gsub("/", "\\")
         end
 
         # Returns a boolean noting whether the terminal supports color.


### PR DESCRIPTION
With Virtualbox 5.1.16 the windows UNC path for shared folder is registered as \\?\C:\Users\username\git\repository.
Mounting /vagrant fails with The folder ... not found.

By removing the \\\\?\\ prefix in UNC, the path is corretly registered in VirtualBox.