### PR TITLE
Fixed Typo in Fedora commands on /etc/sudoers

### DIFF
--- a/website/source/docs/synced-folders/nfs.html.md
+++ b/website/source/docs/synced-folders/nfs.html.md
@@ -177,7 +177,7 @@ Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/* /etc/exports
 Cmnd_Alias VAGRANT_NFSD_CHECK = /usr/bin/systemctl status --no-pager nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_START = /usr/bin/systemctl start nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
-%vagrant ALL=(root) NOPASSWD: AGRANT_EXPORTS_CHOWN, VAGRANT_EXPORTS_MV, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY
+%vagrant ALL=(root) NOPASSWD: VAGRANT_EXPORTS_CHOWN, VAGRANT_EXPORTS_MV, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY
 ```
 
 If you don't want to edit `/etc/sudoers` directly, you can create


### PR DESCRIPTION
Typo missing out the V on VAGRANT_EXPORTS_CHOWN