### PR TITLE
Fix issues with Windows encoding

### DIFF
--- a/lib/vagrant/util/safe_exec.rb
+++ b/lib/vagrant/util/safe_exec.rb
@@ -40,7 +40,15 @@ module Vagrant
               Process.wait(pid)
             end
           else
-            Kernel.exec(command, *args)
+            if Vagrant::Util::Platform.windows?
+              @@logger.debug("Converting command and arguments to single string for exec")
+              @@logger.debug("Command: `#{command.inspect}` Args: `#{args.inspect}`")
+              full_command = "#{command} #{args.join(" ")}"
+              @@logger.debug("Converted command: #{full_command}")
+              Kernel.exec(full_command)
+            else
+              Kernel.exec(command, *args)
+            end
           end
         rescue *rescue_from
           # We retried already, raise the issue and be done

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -25,7 +25,6 @@ module Vagrant
       def initialize(*command)
         @options = command.last.is_a?(Hash) ? command.pop : {}
         @command = command.dup
-        @command = @command.map { |s| s.encode(Encoding.default_external) }
         @command[0] = Which.which(@command[0]) if !File.file?(@command[0])
         if !@command[0]
           raise Errors::CommandUnavailableWindows, file: command[0] if Platform.windows?


### PR DESCRIPTION
Fixes some errors caused by encoding issues when executing remote commands.

Fixes: #8380 #8212 #8207 #7516