### PR TITLE
Add /bin/docker to path list for installation verification

### DIFF
--- a/plugins/provisioners/docker/cap/linux/docker_installed.rb
+++ b/plugins/provisioners/docker/cap/linux/docker_installed.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
         module DockerInstalled
           def self.docker_installed(machine)
             paths = [
+              "/bin/docker",
               "/usr/bin/docker",
               "/usr/local/bin/docker",
               "/usr/sbin/docker",


### PR DESCRIPTION
Include `/bin/docker` path to check for installation.