### PR TITLE
Add the "pip_args" option and a new "pip_args_only" install mode

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              if install_mode == :pip
+              if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else
                 machine.communicate.sudo "pacman -Syy --noconfirm"

--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module Arch
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode == :pip
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -9,16 +9,16 @@ module VagrantPlugins
 
 
             def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              if (install_mode == :pip)
-                ansible_pip_install machine, ansible_version, pip_args
+              case install_mode
+              when :pip
+                pip_setup machine
+                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
+              when :pip_args_only
+                pip_setup machine
+                Pip::pip_install machine, "", "", pip_args, false
               else
                 ansible_apt_install machine
               end
-            end
-
-            def self.ansible_pip_install(machine, ansible_version, pip_args)
-              pip_setup machine
-              Pip::pip_install machine, "ansible", ansible_version, pip_args
             end
 
             private

--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -8,17 +8,17 @@ module VagrantPlugins
           module AnsibleInstall
 
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if (install_mode == :pip)
-                ansible_pip_install machine, ansible_version
+                ansible_pip_install machine, ansible_version, pip_args
               else
                 ansible_apt_install machine
               end
             end
 
-            def self.ansible_pip_install(machine, ansible_version)
+            def self.ansible_pip_install(machine, ansible_version, pip_args)
               pip_setup machine
-              Pip::pip_install machine, "ansible", ansible_version
+              Pip::pip_install machine, "ansible", ansible_version, pip_args
             end
 
             private

--- a/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
@@ -9,12 +9,16 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              rpm_package_manager = Facts::rpm_package_manager(machine)
-
-              if install_mode == :pip
+              case install_mode
+              when :pip
                 pip_setup machine
-                Pip::pip_install machine, "ansible", ansible_version, pip_args
+                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
+              when :pip_args_only
+                pip_setup machine
+                Pip::pip_install machine, "", "", pip_args, false
               else
+                rpm_package_manager = Facts::rpm_package_manager(machine)
+
                 machine.communicate.sudo "#{rpm_package_manager} -y install ansible"
               end
             end

--- a/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
@@ -8,12 +8,12 @@ module VagrantPlugins
         module Fedora
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               rpm_package_manager = Facts::rpm_package_manager(machine)
 
               if install_mode == :pip
                 pip_setup machine
-                Pip::pip_install machine, "ansible", ansible_version
+                Pip::pip_install machine, "ansible", ansible_version, pip_args
               else
                 machine.communicate.sudo "#{rpm_package_manager} -y install ansible"
               end

--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version)
-              if install_mode == :pip
+              if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else
                 machine.communicate.sudo "yes | pkg install ansible"

--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
       module Guest
         module Pip
 
-          def self.pip_install(machine, package, version = "", pip_args = "", upgrade = true)
+          def self.pip_install(machine, package = "", version = "", pip_args = "", upgrade = true)
             upgrade_arg = "--upgrade" if upgrade
             version_arg = ""
 

--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
       module Guest
         module Pip
 
-          def self.pip_install(machine, package, version = "", upgrade = true)
+          def self.pip_install(machine, package, version = "", pip_args = "", upgrade = true)
             upgrade_arg = "--upgrade " if upgrade
             version_arg = ""
 
@@ -13,7 +13,7 @@ module VagrantPlugins
               version_arg = "==#{version}"
             end
 
-            machine.communicate.sudo "pip install #{upgrade_arg}#{package}#{version_arg}"
+            machine.communicate.sudo "pip install #{pip_args} #{upgrade_arg}#{package}#{version_arg}"
           end
 
           def self.get_pip(machine)

--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -6,14 +6,16 @@ module VagrantPlugins
         module Pip
 
           def self.pip_install(machine, package, version = "", pip_args = "", upgrade = true)
-            upgrade_arg = "--upgrade " if upgrade
+            upgrade_arg = "--upgrade" if upgrade
             version_arg = ""
 
             if !version.to_s.empty? && version.to_s.to_sym != :latest
               version_arg = "==#{version}"
             end
 
-            machine.communicate.sudo "pip install #{pip_args} #{upgrade_arg}#{package}#{version_arg}"
+            args_array = [pip_args, upgrade_arg, "#{package}#{version_arg}"]
+
+            machine.communicate.sudo "pip install #{args_array.join(' ')}"
           end
 
           def self.get_pip(machine)

--- a/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
@@ -9,9 +9,13 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              if install_mode == :pip
+              case install_mode
+              when :pip
                 pip_setup machine
-                Pip::pip_install machine, "ansible", ansible_version, pip_args
+                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
+              when :pip_args_only
+                pip_setup machine
+                Pip::pip_install machine, "", "", pip_args, false
               else
                 ansible_rpm_install machine
               end

--- a/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
@@ -8,10 +8,10 @@ module VagrantPlugins
         module RedHat
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode == :pip
                 pip_setup machine
-                Pip::pip_install machine, "ansible", ansible_version
+                Pip::pip_install machine, "ansible", ansible_version, pip_args
               else
                 ansible_rpm_install machine
               end

--- a/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version)
-              if install_mode == :pip
+              if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else
                 machine.communicate.sudo("zypper --non-interactive --quiet install ansible")

--- a/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
@@ -8,8 +8,8 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              if install_mode == :pip
-                Debian::AnsibleInstall::ansible_pip_install machine, ansible_version, pip_args
+              if install_mode != :default
+                Debian::AnsibleInstall::ansible_install machine, install_mode, ansible_version, pip_args
               else
                 ansible_apt_install machine
               end

--- a/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
@@ -7,9 +7,9 @@ module VagrantPlugins
         module Ubuntu
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode == :pip
-                Debian::AnsibleInstall::ansible_pip_install machine, ansible_version
+                Debian::AnsibleInstall::ansible_pip_install machine, ansible_version, pip_args
               else
                 ansible_apt_install machine
               end

--- a/plugins/provisioners/ansible/config/guest.rb
+++ b/plugins/provisioners/ansible/config/guest.rb
@@ -38,8 +38,11 @@ module VagrantPlugins
         def validate(machine)
           super
 
-          if @install_mode.to_s.to_sym == :pip
+          case @install_mode.to_s.to_sym
+          when :pip
             @install_mode = :pip
+          when :pip_args_only
+            @install_mode = :pip_args_only
           else
             @install_mode = :default
           end

--- a/plugins/provisioners/ansible/config/guest.rb
+++ b/plugins/provisioners/ansible/config/guest.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
         attr_accessor :tmp_path
         attr_accessor :install
         attr_accessor :install_mode
+        attr_accessor :pip_args
         attr_accessor :version
 
         def initialize
@@ -17,6 +18,7 @@ module VagrantPlugins
 
           @install           = UNSET_VALUE
           @install_mode      = UNSET_VALUE
+          @pip_args          = UNSET_VALUE
           @provisioning_path = UNSET_VALUE
           @tmp_path          = UNSET_VALUE
           @version           = UNSET_VALUE
@@ -27,6 +29,7 @@ module VagrantPlugins
 
           @install           = true                   if @install           == UNSET_VALUE
           @install_mode      = :default               if @install_mode      == UNSET_VALUE
+          @pip_args          = ""                     if @pip_args          == UNSET_VALUE
           @provisioning_path = "/vagrant"             if provisioning_path  == UNSET_VALUE
           @tmp_path          = "/tmp/vagrant-ansible" if tmp_path           == UNSET_VALUE
           @version           = ""                     if @version           == UNSET_VALUE

--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -49,7 +49,7 @@ module VagrantPlugins
              (config.version.to_s.to_sym == :latest ||
               !@machine.guest.capability(:ansible_installed, config.version))
             @machine.ui.detail I18n.t("vagrant.provisioners.ansible.installing")
-            @machine.guest.capability(:ansible_install, config.install_mode, config.version)
+            @machine.guest.capability(:ansible_install, config.install_mode, config.version, config.pip_args)
           end
 
           # Check that Ansible Playbook command is available on the guest

--- a/test/unit/plugins/provisioners/ansible/config/guest_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/guest_test.rb
@@ -27,6 +27,7 @@ describe VagrantPlugins::Ansible::Config::Guest do
                             install_mode
                             inventory_path
                             limit
+                            pip_args
                             playbook
                             playbook_command
                             provisioning_path

--- a/test/unit/plugins/provisioners/ansible/config/guest_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/guest_test.rb
@@ -81,6 +81,14 @@ describe VagrantPlugins::Ansible::Config::Guest do
       result = subject.validate(machine)
       expect(subject.install_mode).to eql(:pip)
     end
+
+    it "supports :pip_args_only install_mode" do
+      subject.install_mode = "pip_args_only"
+      subject.finalize!
+
+      result = subject.validate(machine)
+      expect(subject.install_mode).to eql(:pip_args_only)
+    end
   end
 
 end

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -69,19 +69,68 @@ This section lists the _specific_ options for the Ansible Local provisioner. In 
 
     **Attention:** There is no guarantee that this automated installation will replace a custom Ansible setup, that might be already present on the Vagrant box.
 
-- `install_mode` (`:default` or `:pip`) - Select the way to automatically install Ansible on the guest system.
+- `install_mode` (`:default`, `:pip`, or `:pip_args_only`) - Select the way to automatically install Ansible on the guest system.
 
   - `:default`: Ansible is installed from the operating system package manager. This mode doesn't support `version` selection. For many platforms (e.g Debian, FreeBSD, OpenSUSE) the official package repository is used, except for the following Linux distributions:
       - On Ubuntu-like systems, the latest Ansible release is installed from the `ppa:ansible/ansible` repository.
       - On RedHat-like systems, the latest Ansible release is installed from the [EPEL](http://fedoraproject.org/wiki/EPEL) repository.
 
-  - `:pip`: Ansible is installed from [PyPI](https://pypi.python.org/pypi) with [pip](https://pip.pypa.io) package installer. With this mode, Vagrant will systematically try to [install the latest pip version](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py). The `:pip` mode can install a specific version of Ansible if such information is specified with the `version` option described below.
+  - `:pip`: Ansible is installed from [PyPI](https://pypi.python.org/pypi) with [pip](https://pip.pypa.io) package installer. With this mode, Vagrant will systematically try to [install the latest pip version](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py). With the `:pip` mode you can optionally install a specific Ansible release by setting the [`version`](#version) option.
 
-    The default value is `:default`, and any invalid value for this option will silently fall back to the default value.
+        Example:
+
+        ```ruby
+        config.vm.provision "ansible_local" do |ansible|
+          ansible.playbook = "playbook.yml"
+          ansible.install_mode = "pip"
+          ansible.version = "2.2.1.0"
+        end
+        ```
+        With this configuration, Vagrant will install `pip` and then execute the command
+
+        ```shell
+        sudo pip install --upgrade ansible==2.2.1.0
+        ```
+
+  - `:pip_args_only`: This mode is very similar to the `:pip` mode, with the difference that in this case no pip arguments will be automatically set by Vagrant.
+
+        Example:
+
+        ```ruby
+        config.vm.provision "ansible_local" do |ansible|
+          ansible.playbook = "playbook.yml"
+          ansible.install_mode = "pip_args_only"
+          ansible.pip_args = "-r /vagrant/requirements.txt"
+        end
+        ```
+
+        With this configuration, Vagrant will install `pip` and then execute the command
+
+        ```shell
+        sudo pip install -r /vagrant/requirements.txt
+        ```
+
+    The default value of `install_mode` is `:default`, and any invalid value for this option will silently fall back to the default value.
 
 - `pip_args` (string) - When Ansible is installed via pip, this option allows the definition of additional pip arguments to be passed along on the command line (for example, [`--index-url`](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i)).
 
     By default, this option is not set.
+
+    Example:
+
+    ```ruby
+    config.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "playbook.yml"
+      ansible.install_mode = :pip
+      ansible.pip_args = "--install-url https://pypi.internal"
+    end
+    ```
+
+    With this configuration, Vagrant will install `pip` and then execute the command
+
+    ```shell
+    sudo pip install --index-url https://pypi.internal --upgrade ansible
+    ```
 
 - `provisioning_path` (string) - An absolute path on the guest machine where the Ansible files are stored. The `ansible-galaxy` and `ansible-playbook` commands are executed from this directory. This is the location to place an [ansible.cfg](http://docs.ansible.com/ansible/intro_configuration.html) file, in case you need it.
 

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -79,8 +79,9 @@ This section lists the _specific_ options for the Ansible Local provisioner. In 
 
     The default value is `:default`, and any invalid value for this option will silently fall back to the default value.
 
-- `pip_args` (string) - When Ansible is installed via pip this option allows the defition of additional pip arguments to be passed along on the
-command line (for example, [--index-url](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i)).
+- `pip_args` (string) - When Ansible is installed via pip, this option allows the definition of additional pip arguments to be passed along on the command line (for example, [`--index-url`](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i)).
+
+    By default, this option is not set.
 
 - `provisioning_path` (string) - An absolute path on the guest machine where the Ansible files are stored. The `ansible-galaxy` and `ansible-playbook` commands are executed from this directory. This is the location to place an [ansible.cfg](http://docs.ansible.com/ansible/intro_configuration.html) file, in case you need it.
 

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -79,6 +79,9 @@ This section lists the _specific_ options for the Ansible Local provisioner. In 
 
     The default value is `:default`, and any invalid value for this option will silently fall back to the default value.
 
+- `pip_args` (string) - When Ansible is installed via pip this option allows the defition of additional pip arguments to be passed along on the
+command line (for example, [--index-url](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-i)).
+
 - `provisioning_path` (string) - An absolute path on the guest machine where the Ansible files are stored. The `ansible-galaxy` and `ansible-playbook` commands are executed from this directory. This is the location to place an [ansible.cfg](http://docs.ansible.com/ansible/intro_configuration.html) file, in case you need it.
 
     The default value is `/vagrant`.


### PR DESCRIPTION
This is first the "final" review and follow up of GH-8170.

With , I also propose the addition of `pip_args_only` installation mode, which was originally motivated by the following use case:

```ruby
config.vm.provision "ansible_local" do |ansible|
  ansible.playbook = "playbook.yml"
  ansible.install_mode = "pip_args_only"
  ansible.pip_args = "http://releases.ansible.com/ansible/ansible-2.3.0.0-0.1.rc1.tar.gz"
end
```
**Attention:** Don't use `2.3.0.0-0.1.rc1` with Vagrant, as inventory management is broken in Ansible 2.3.0RC1 (#8391)

Note that I first though about an even more generic install mode (kind of "custom" allowing to execute any command the user want). But I preferred the `pip_args_only`, with the following argumentation:
- "full custom setup" is easily and better achieved with an additional [`shell`](https://www.vagrantup.com/docs/provisioning/shell.html) provisioner configuration.
- Provide the ability to take full control on "pip" is a good thing, but "advanced pip users" will still appreciate the "pip auto setup" goody and a sweet integration into `Vagrantfile`.

@jamescarr @brandongalbraith could you please give me your thoughts on all this? Many thanks in advance ❤️ 💙 💚 ❗️