### PR TITLE
Correct box version sorting in box list command's output.

### DIFF
--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           argv = parse_options(opts)
           return if !argv
 
-          boxes = @env.boxes.all.sort
+          boxes = @env.boxes.all
           if boxes.empty?
             return @env.ui.warn(I18n.t("vagrant.commands.box.no_installed_boxes"), prefix: false)
           end


### PR DESCRIPTION
Boxes are already correctly sorted as a result of PRs #7956 and #8334. The extra sort here breaks.