### PR TITLE
Salt ver year.month can have 2-digit month

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -10,7 +10,7 @@ $ServiceName = "salt-minion"
 $startupType = "Manual"
 
 # Version to install - default to latest if there is an issue
-If ($version -notmatch "201[0-9]\.[0-9]\.[0-9](\-\d{1})?"){
+If ($version -notmatch "2\d{3}\.\d{1,2}\.\d+(\-\d{1})?"){
   $version = '2015.5.2'
 }
 


### PR DESCRIPTION
e.g. 2016.11.3 won't deploy with current match