### PR TITLE
virtualbox: Fix invalid share names in Windows guests

### DIFF
--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -85,7 +85,7 @@ module VagrantPlugins
       end
 
       def os_friendly_id(id)
-        id.gsub(/[\/]/,'_').sub(/^_/, '')
+        id.gsub(/[\/\\]/,'_').sub(/^_/, '')
       end
 
       # share_folders sets up the shared folder definitions on the


### PR DESCRIPTION
That PR fixes invalid share names in Windows guests, where backward slash character is
used as a path separator.

_Details:_
Currently, if we define the synced folder this way (for Windows guest):
```ruby
config.vm.synced_folder "../", 'C:\Users\vagrant\my_share'
```
then the share id will be this string: `'C:\Users\vagrant\my_share'`
In the guest it will be exposed as `\\VBOXSRV\C:\Users\vagrant\my_share`, which is an invalid path, so the share will not be available.

This Pull-Request adds `\` to the regex, so this char will be replaced with `_`.
The result share id will be `'C:_Users_vagrant_my_share'` and it will be available at `\\VBOXSRV\C:_Users_vagrant_my_share` without any issues.

The similar PR has been sent to Parallels provider: https://github.com/Parallels/vagrant-parallels/pull/296