### PR TITLE
fix regex to allow all valid salt minion versions

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -10,7 +10,7 @@ $ServiceName = "salt-minion"
 $startupType = "Manual"
 
 # Version to install - default to latest if there is an issue
-If ($version -notmatch "201[0-9]\.[0-9]\.[0-9](\-\d{1})?"){
+If ($version -notmatch "^20\d{2}\.([1-9]|1[012])\.\d+(\-\d+)?$"){
   $version = '2015.5.2'
 }
 


### PR DESCRIPTION
current regex doesn't match valid versions e.g. 2016.11.3 as described here #8299