### PR TITLE
Update NFS control commands for SUSE

### DIFF
--- a/contrib/sudoers/linux-suse
+++ b/contrib/sudoers/linux-suse
@@ -1,6 +1,6 @@
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
-Cmnd_Alias VAGRANT_NFSD_CHECK = /sbin/service nfsserver status
-Cmnd_Alias VAGRANT_NFSD_START = /sbin/service nfsserver start
+Cmnd_Alias VAGRANT_NFSD_CHECK = /usr/bin/systemctl --no-pager status nfsserver.service
+Cmnd_Alias VAGRANT_NFSD_START = /usr/bin/systemctl --no-pager start nfsserver.service
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed -r -e * d -ibak /*/exports
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE_2 = /usr/bin/cp /*/exports /etc/exports

--- a/plugins/hosts/suse/cap/nfs.rb
+++ b/plugins/hosts/suse/cap/nfs.rb
@@ -7,11 +7,11 @@ module VagrantPlugins
         end
 
         def self.nfs_check_command(env)
-          "/sbin/service nfsserver status"
+          "/usr/bin/systemctl --no-pager status nfsserver.service"
         end
 
         def self.nfs_start_command(env)
-          "/sbin/service nfsserver start"
+          "/usr/bin/systemctl --no-pager start nfsserver.service"
         end
       end
     end


### PR DESCRIPTION
Use systemctl directly on SUSE systems (non-systemd SUSE OSes are
so old that there is no chance of anyone trying to run new vagrant
on them), so that we can pass the --no-pager flag to avoid getting
stuck in a pager while checking NFS server status.

Update both plugin and sudoers script.