### PR TITLE
change path to bash to work in ubuntu

### DIFF
--- a/website/source/intro/getting-started/provisioning.html.md
+++ b/website/source/intro/getting-started/provisioning.html.md
@@ -27,7 +27,7 @@ and we will do so using a shell script. Create the following shell script
 and save it as `bootstrap.sh` in the same directory as your Vagrantfile:
 
 ```bash
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 apt-get update
 apt-get install -y apache2


### PR DESCRIPTION
due to the fact that the vagrant box uses ubuntu, the path for the bash was wrong. Copy and paste the script didn't work. Following this guide with the hashicorp/precise64 box causes the error, that script was not loaded. With this change the script loads and apache is installed.