### PR TITLE
host_ip while forwarding

### DIFF
--- a/website/source/intro/getting-started/networking.html.md
+++ b/website/source/intro/getting-started/networking.html.md
@@ -34,7 +34,7 @@ is a simple edit to the Vagrantfile, which now looks like this:
 Vagrant.configure("2") do |config|
   config.vm.box = "hashicorp/precise64"
   config.vm.provision :shell, path: "bootstrap.sh"
-  config.vm.network :forwarded_port, guest: 80, host: 4567
+  config.vm.network :forwarded_port, guest: 80, host: 4567, host_ip: "127.0.0.1"
 end
 ```
 


### PR DESCRIPTION
without setting the host_ip paramter an error-message appears (requested address is not valid in its context) on "vagrant up".
setting the host_ip to 127.0.0.1 does the trick.