### PR TITLE
communicator/ssh: Do not pass empty data to registered blocks

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -519,7 +519,7 @@ module VagrantPlugins
                   end
                 end
 
-                if block_given? && marker_found
+                if block_given? && marker_found && !data.empty?
                   yield :stdout, data
                 end
               end
@@ -540,7 +540,7 @@ module VagrantPlugins
                 end
               end
 
-              if block_given? && marker_found
+              if block_given? && marker_found && !data.empty?
                 yield :stderr, data
               end
             end

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -168,6 +168,24 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       end
     end
 
+    context "with no command output" do
+      let(:command_stdout_data) do
+        "#{command_garbage_marker}"
+      end
+
+      it "does not send empty stdout data string" do
+        empty = true
+        expect(
+          communicator.execute("ls /") do |type, data|
+            if type == :stdout && data.empty?
+              empty = false
+            end
+          end
+        ).to eq(0)
+        expect(empty).to be(true)
+      end
+    end
+
     context "with garbage content prepended to command stderr output" do
       let(:command_stderr_data) do
         "Line of garbage\nMore garbage\n#{command_garbage_marker}bin\ntmp\n"
@@ -183,6 +201,24 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           end
         ).to eq(0)
         expect(stderr).to eq("bin\ntmp\n")
+      end
+    end
+
+    context "with no command output on stderr" do
+      let(:command_stderr_data) do
+        "#{command_garbage_marker}"
+      end
+
+      it "does not send empty stderr data string" do
+        empty = true
+        expect(
+          communicator.execute("ls /") do |type, data|
+            if type == :stderr && data.empty?
+              empty = false
+            end
+          end
+        ).to eq(0)
+        expect(empty).to be(true)
       end
     end
 


### PR DESCRIPTION
Prevent sending empty data strings to defined blocks handling
stderr and stdout output. These can occur when the garbage
marker is identified and collected data pruned, but no remaining
data is left to send.

Fixes #8259