### PR TITLE
Do not prefix Windows paths if UNC prefix already exists

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -188,11 +188,16 @@ module Vagrant
         def windows_unc_path(path)
           path = path.gsub("/", "\\")
 
-          # If the path is just a drive letter, then return that as-is
-          return path + "\\" if path =~ /^[a-zA-Z]:\\?$/
-
           # Convert to UNC path
-          "\\\\?\\" + path.gsub("/", "\\")
+          if path =~ /^[a-zA-Z]:\\?$/
+            # If the path is just a drive letter, then return that as-is
+            path + "\\"
+          elsif path.start_with?("\\\\")
+            # If the path already starts with `\\` assume UNC and return as-is
+            path
+          else
+            "\\\\?\\" + path.gsub("/", "\\")
+          end
         end
 
         # Returns a boolean noting whether the terminal supports color.

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -55,5 +55,13 @@ describe Vagrant::Util::Platform do
     it "correctly converts a path" do
       expect(described_class.windows_unc_path("c:/foo").to_s).to eql("\\\\?\\c:\\foo")
     end
+
+    context "when given a UNC path" do
+      let(:unc_path){ "\\\\srvname\\path" }
+
+      it "should not modify the path" do
+        expect(described_class.windows_unc_path(unc_path).to_s).to eql(unc_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
While VirtualBox has commented that they do not support UNC remote
paths (but do for long paths) it seems that remote paths can work.
If user provides UNC path, allow it to be used as-is.

Fixes #7011