### PR TITLE
Fixes automatic configuration of networking on amazon linux guests

### DIFF
--- a/plugins/guests/amazon/cap/configure_networks.rb
+++ b/plugins/guests/amazon/cap/configure_networks.rb
@@ -1,0 +1,56 @@
+require "tempfile"
+
+require_relative "../../../../lib/vagrant/util/template_renderer"
+
+module VagrantPlugins
+  module GuestAmazon
+    module Cap
+      class ConfigureNetworks
+        include Vagrant::Util
+
+        def self.configure_networks(machine, networks)
+          comm = machine.communicate
+
+          network_scripts_dir = machine.guest.capability(:network_scripts_dir)
+
+          commands   = []
+          interfaces = machine.guest.capability(:network_interfaces)
+
+          networks.each.with_index do |network, i|
+            network[:device] = interfaces[network[:interface]]
+
+            # Render a new configuration
+            entry = TemplateRenderer.render("guests/redhat/network_#{network[:type]}",
+              options: network,
+            )
+
+            # Upload the new configuration
+            remote_path = "/tmp/vagrant-network-entry-#{network[:device]}-#{Time.now.to_i}-#{i}"
+            Tempfile.open("vagrant-redhat-configure-networks") do |f|
+              f.binmode
+              f.write(entry)
+              f.fsync
+              f.close
+              machine.communicate.upload(f.path, remote_path)
+            end
+
+            # Add the new interface and bring it back up
+            final_path = "#{network_scripts_dir}/ifcfg-#{network[:device]}"
+            commands << <<-EOH.gsub(/^ {14}/, '')
+              # Down the interface before munging the config file. This might
+              # fail if the interface is not actually set up yet so ignore
+              # errors.
+              /sbin/ifdown '#{network[:device]}' || true
+              # Move new config into place
+              mv '#{remote_path}' '#{final_path}'
+              # Bring the interface up
+              ARPCHECK=no /sbin/ifup '#{network[:device]}'
+            EOH
+          end
+
+          comm.sudo(commands.join("\n"))
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/amazon/plugin.rb
+++ b/plugins/guests/amazon/plugin.rb
@@ -15,6 +15,11 @@ module VagrantPlugins
         require_relative "cap/flavor"
         Cap::Flavor
       end
+
+      guest_capability(:amazon, :configure_networks) do
+        require_relative "cap/configure_networks"
+        Cap::ConfigureNetworks
+      end
     end
   end
 end


### PR DESCRIPTION
AWS doesn't have the NetworkManager package, so nmcli isn't available and I'd been running into tons of issues with NFS failing to connect to my OSX Sierra host. I copied the configure_networks capability from version 1.8.6 (since it was the last version not using nmcli) and added this capability for an amazon guest, now my NFS issues are gone in version 1.9.3

Signed-off-by: Kevin <kperrine@gmail.com>