### PR TITLE
Update etcd version to version 2 in configure_networks.rb

### DIFF
--- a/plugins/guests/coreos/cap/configure_networks.rb
+++ b/plugins/guests/coreos/cap/configure_networks.rb
@@ -22,12 +22,12 @@ module VagrantPlugins
             primary_machine_ip = get_ip(primary_machine)
             current_ip = get_ip(machine)
             if current_ip == primary_machine_ip
-              entry = TemplateRenderer.render("guests/coreos/etcd.service", options: {
+              entry = TemplateRenderer.render("guests/coreos/etcd2.service", options: {
                 my_ip: current_ip,
               })
             else
               connection_string = "#{primary_machine_ip}:7001"
-              entry = TemplateRenderer.render("guests/coreos/etcd.service", options: {
+              entry = TemplateRenderer.render("guests/coreos/etcd2.service", options: {
                 connection_string: connection_string,
                 my_ip: current_ip,
               })
@@ -38,14 +38,14 @@ module VagrantPlugins
               f.write(entry)
               f.fsync
               f.close
-              comm.upload(f.path, "/tmp/etcd-cluster.service")
+              comm.upload(f.path, "/tmp/etcd2-cluster.service")
             end
 
             # Build a list of commands
             commands = []
 
             # Stop default systemd
-            commands << "systemctl stop etcd"
+            commands << "systemctl stop etcd2"
 
             # Configure interfaces
             # FIXME: fix matching of interfaces with IP adresses
@@ -55,11 +55,11 @@ module VagrantPlugins
             end
 
             commands << <<-EOH.gsub(/^ {14}/, '')
-              mv /tmp/etcd-cluster.service /media/state/units/
+              mv /tmp/etcd2-cluster.service /media/state/units/
               systemctl restart local-enable.service
 
-              # Restart default etcd
-              systemctl start etcd
+              # Restart default etcd2
+              systemctl start etcd2
             EOH
 
             # Run all network configuration commands in one communicator session.


### PR DESCRIPTION
Make etcd2 the default "etcd".

If enable etcd2.service in coreos and build vagrant box using packer.io (coreos_*.iso) we are going to have etcd.service running after vagrant up. 
As etcd is [deprecated](https://coreos.com/os/docs/latest/cloud-config.html) it is better to stick to etcd2 