### PR TITLE
Retry SSH connection on Errno::ECONNABORTED

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -664,6 +664,10 @@ module Vagrant
       error_key(:ssh_connection_refused)
     end
 
+    class SSHConnectionAborted < VagrantError
+      error_key(:ssh_connection_aborted)
+    end
+
     class SSHConnectionReset < VagrantError
       error_key(:ssh_connection_reset)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1189,6 +1189,13 @@ en:
         If that doesn't work, destroy your VM and recreate it with a `vagrant destroy`
         followed by a `vagrant up`. If that doesn't work, contact a Vagrant
         maintainer (support channels listed on the website) for more assistance.
+      ssh_connection_aborted: |-
+        SSH connection was aborted! This usually happens when the machine is taking
+        too long to reboot or the SSH daemon is not properly configured on the VM.
+        First, try reloading your machine with `vagrant reload`, since a simple
+        restart sometimes fixes things. If that doesn't work, destroy your machine
+        and recreate it with a `vagrant destroy` followed by a `vagrant up`. If that
+        doesn't work, contact support.
       ssh_connection_reset: |-
         SSH connection was reset! This usually happens when the machine is
         taking too long to reboot. First, try reloading your machine with


### PR DESCRIPTION
In some cases the SSH connection may be aborted while waiting
for setup. This includes aborted connections in the list of
applicable exceptions to retry on while waiting for the connection
to become available.

Fixes #8520