### PR TITLE
Fix crash when using HyperV

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -15,7 +15,7 @@
     [string]$vmname=$null,
     [string]$auto_start_action=$null,
     [string]$auto_stop_action=$null,
-    [string]$differencing_disk=$null
+    [string]$differencing_disk=$null,
     [string]$enable_virtualization_extensions=$False
 )
 


### PR DESCRIPTION
Fix the error 
```homestead-7: Creating and registering the VM...
An error occurred while executing a PowerShell script. This error
is shown below. Please read the error message and see if this is
a configuration error with your system. If it is not, then please
report a bug.

Script: import_vm_vmcx.ps1
Error:

At C:\Program Files
(x86)\HashiCorp\Vagrant\embedded\gems\gems\vagrant-1.9.4\plugins\providers\hyper                    v\scripts\import_vm_vmcx.ps1:18 char:37
+     [string]$differencing_disk=$null
+                                     ~
Missing ')' in function parameter list.
At C:\Program Files
(x86)\HashiCorp\Vagrant\embedded\gems\gems\vagrant-1.9.4\plugins\providers\hyper                    v\scripts\import_vm_vmcx.ps1:20 char:1
+ )
+ ~
Unexpected token ')' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParseException
    + FullyQualifiedErrorId : MissingEndParenthesisInFunctionParameterList
```