### PR TITLE
Fix shell provisioner to execute batch files correctly

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -191,8 +191,11 @@ module VagrantPlugins
             shell_args += " -OutputFormat Text" if config.powershell_args !~ /[-\/]OutputFormat/i
 
             command = "\"#{exec_path}\"#{args}"
-            command = "powershell #{shell_args.to_s} -file #{command}" if
-              File.extname(exec_path).downcase == '.ps1'
+            if File.extname(exec_path).downcase == ".ps1"
+              command = "powershell #{shell_args.to_s} -file #{command}"
+            else
+              command = "cmd /q /c #{command}"
+            end
 
             # Append the environment
             if !env.empty?


### PR DESCRIPTION
Call cmd.exe explicitly when running batch files to easily
manage special characters that may be within the path.

Fixes #8535