### PR TITLE
Add support for Kali Linux

### DIFF
--- a/plugins/guests/kali/guest.rb
+++ b/plugins/guests/kali/guest.rb
@@ -1,0 +1,10 @@
+require_relative '../linux/guest'
+
+module VagrantPlugins
+  module GuestKali
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "kali".freeze
+    end
+  end
+end

--- a/plugins/guests/kali/plugin.rb
+++ b/plugins/guests/kali/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestKali
+    class Plugin < Vagrant.plugin("2")
+      name "Kali guest"
+      description "Kali guest support."
+
+      guest(:kali, :debian) do
+        require_relative "guest"
+        Guest
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds OS Detection support for [Kali Linux](https://www.kali.org/)

Kali is a popular pen testing distribution, and is currently a [Debian derivative](https://wiki.debian.org/Derivatives/Census/Kali)

I'm surprised this hasn't been added yet!

Signed-off-by: Brian Dwyer <bdwyer@IEEE.org>