### PR TITLE
Update hyperv and docker providers to raise exception on SSH when machine is not ready

### DIFF
--- a/plugins/providers/docker/action.rb
+++ b/plugins/providers/docker/action.rb
@@ -177,14 +177,12 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use Call, IsState, :not_created do |env, b2|
             if env[:result]
-              b2.use Message, I18n.t("docker_provider.messages.not_created")
-              next
+              raise Errors::ContainerNotCreatedError
             end
 
             b2.use Call, IsState, :running do |env2, b3|
               if !env2[:result]
-                b3.use Message, I18n.t("docker_provider.messages.not_running")
-                next
+                raise Errors::ContainerNotRunningError
               end
 
               b3.use PrepareSSH
@@ -199,13 +197,12 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use Call, IsState, :not_created do |env, b2|
             if env[:result]
-              b2.use Message, I18n.t("docker_provider.messages.not_created")
-              next
+              raise Errors::ContainerNotCreatedError
             end
 
             b2.use Call, IsState, :running do |env2, b3|
               if !env2[:result]
-                raise Vagrant::Errors::VMNotRunningError
+                raise Errors::ContainerNotRunningError
               end
 
               b3.use SSHRun

--- a/plugins/providers/docker/errors.rb
+++ b/plugins/providers/docker/errors.rb
@@ -9,6 +9,14 @@ module VagrantPlugins
         error_key(:communicator_non_docker)
       end
 
+      class ContainerNotRunningError < DockerError
+        error_key(:not_running)
+      end
+
+      class ContainerNotCreatedError < DockerError
+        error_key(:not_created)
+      end
+
       class ExecuteError < DockerError
         error_key(:execute_error)
       end

--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -178,14 +178,12 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use Call, IsState, :not_created do |env, b2|
             if env[:result]
-              b2.use Message, I18n.t("vagrant_hyperv.message_not_created")
-              next
+              raise Vagrant::Errors::VMNotCreatedError
             end
 
             b2.use Call, IsState, :running do |env1, b3|
               if !env1[:result]
-                b3.use Message, I18n.t("vagrant_hyperv.message_not_running")
-                next
+                raise Vagrant::Errors::VMNotRunningError
               end
 
               b3.use SSHExec
@@ -199,14 +197,12 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use Call, IsState, :not_created do |env, b2|
             if env[:result]
-              b2.use Message, I18n.t("vagrant_hyperv.message_not_created")
-              next
+              raise Vagrant::Errors::VMNotCreatedError
             end
 
             b2.use Call, IsState, :running do |env1, b3|
               if !env1[:result]
-                b3.use Message, I18n.t("vagrant_hyperv.message_not_running")
-                next
+                raise Vagrant::Errors::VMNotRunningError
               end
 
               b3.use SSHRun

--- a/templates/locales/providers_docker.yml
+++ b/templates/locales/providers_docker.yml
@@ -117,6 +117,10 @@ en:
         run exits and doesn't keep running.
 
     errors:
+      not_created: |-
+        The container hasn't been created yet.
+      not_running: |-
+        The container is not currently running.
       communicator_non_docker: |-
         The "docker_hostvm" communicator was specified on a machine that
         is not provided by the Docker provider. This is a bug with your


### PR DESCRIPTION
This makes the behavior of the docker and hyperv provider consistent with the
virtualbox provider by raising an error on ssh actions if the machine is not
created or not running.

Fixes #8508