### PR TITLE
Enable capabilities for winssh communicator

### DIFF
--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
         }.merge(opts)
 
         sudo  = opts[:sudo]
+        shell = (opts[:shell] || machine_config_ssh.shell).to_s
 
         @logger.info("Execute: #{command} (sudo=#{sudo.inspect})")
         exit_status = nil
@@ -31,10 +32,10 @@ module VagrantPlugins
           stderr_data_buffer = ''
 
           tfile = Tempfile.new('vagrant-ssh')
-          remote_ext = machine_config_ssh.shell.to_s == "powershell" ? "ps1" : "bat"
+          remote_ext = shell == "powershell" ? "ps1" : "bat"
           remote_name = "C:\\Windows\\Temp\\#{File.basename(tfile.path)}.#{remote_ext}"
 
-          if machine_config_ssh.shell.to_s == "powershell"
+          if shell == "powershell"
             base_cmd = "powershell -File #{remote_name}"
             tfile.puts <<-SCRIPT.force_encoding('ASCII-8BIT')
 Remove-Item #{remote_name}

--- a/plugins/guests/windows/cap/configure_networks.rb
+++ b/plugins/guests/windows/cap/configure_networks.rb
@@ -9,10 +9,6 @@ module VagrantPlugins
         @@logger = Log4r::Logger.new("vagrant::guest::windows::configure_networks")
 
         def self.configure_networks(machine, networks)
-          if machine.config.vm.communicator != :winrm
-            raise Errors::NetworkWinRMRequired
-          end
-
           @@logger.debug("Networks: #{networks.inspect}")
 
           guest_network = GuestNetwork.new(machine.communicate)

--- a/plugins/guests/windows/cap/mount_shared_folder.rb
+++ b/plugins/guests/windows/cap/mount_shared_folder.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
             vm_provider_unc_path: vm_provider_unc_base + name,
           })
 
-          if machine.config.vm.communicator == :winrm
+          if machine.config.vm.communicator == :winrm || machine.config.vm.communicator == :winssh
             machine.communicate.execute(script, shell: :powershell)
           else
             # Convert script to double byte unicode string then base64 encode

--- a/plugins/guests/windows/scripts/mount_volume.ps1.erb
+++ b/plugins/guests/windows/scripts/mount_volume.ps1.erb
@@ -28,7 +28,7 @@ if( (Test-Path "$MountPoint") -and (Test-ReparsePoint "$MountPoint") )
 }
 elseif(Test-Path $MountPoint)
 {
-  Write-Debug "Mount point already exists and is not a symbolic link"
+  Write-Error "Mount point already exists and is not a symbolic link"
   exit 1
 }
 


### PR DESCRIPTION
Allows the #execute method on the communicator to accept custom shell values. Also enables mounting of shared folders and network configuration.