### PR TITLE
Fix a problem when using rsync folders on windows clients

### DIFF
--- a/plugins/guests/windows/cap/rsync.rb
+++ b/plugins/guests/windows/cap/rsync.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
           machine.communicate.tap do |comm|
             # rsync does not construct any gaps in the path to the target directory
             # make sure that all subdirectories are created
-            comm.execute("mkdir '#{opts[:guestpath]}'")
+            comm.execute("mkdir -p '#{opts[:guestpath]}'")
           end
         end
       end

--- a/test/unit/plugins/guests/windows/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/windows/cap/rsync_test.rb
@@ -19,7 +19,7 @@ describe "VagrantPlugins::GuestWindows::Cap::RSync" do
 
   describe ".rsync_pre" do
     it 'makes the guestpath directory with mkdir' do
-      communicator.expect_command("mkdir '/sync_dir'")
+      communicator.expect_command("mkdir -p '/sync_dir'")
       described_class.rsync_pre(machine, guestpath: '/sync_dir')
     end
   end


### PR DESCRIPTION
Fix a problem with rsync folders on windows guests with cygwin & ssh enabled.

Before the patch this error will happen if the original directory already exists

-------------------------------------------------------------------------------------------------
==> windows: Rsyncing folder: /vhosts/oxfamshop.com.au/ => /cygdrive/c/inetpub/wwwroot
==> windows:   - Exclude: [".vagrant/", ".git/", "target/", "node_modules/"]
==> windows: Showing rsync output...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

mkdir '/cygdrive/c/inetpub/wwwroot'

Stdout from the command:

Stderr from the command:

mkdir: cannot create directory ‘/cygdrive/c/inetpub/wwwroot’: File exists
-------------------------------------------------------------------------------------------------

After the patch, this is result

-------------------------------------------------------------------------------------------------
==> windows: Rsyncing folder: /vhosts/oxfamshop.com.au/ => /cygdrive/c/inetpub/wwwroot
==> windows:   - Exclude: [".vagrant/", ".git/", "target/", "node_modules/"]
==> windows: Showing rsync output...
==> windows: rsync[stdout] -> sending incremental file list
==> windows: rsync[stdout] ->
==> windows: rsync[stdout] -> sent 500855 bytes  received 6635 bytes  78075.38 bytes/sec
==> windows: rsync[stdout] -> total size is 175357552  speedup is 345.54
-------------------------------------------------------------------------------------------------