### PR TITLE
Vagrant Enterprise docs

### DIFF
--- a/website/source/docs/vagrant-cloud/boxes/catalog.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/catalog.html.md
@@ -1,0 +1,46 @@
+---
+layout: "docs"
+page_title: "Discovering Vagrant Boxes"
+sidebar_current: "vagrant-cloud-boxes-catalog"
+---
+
+# Discovering Vagrant Boxes
+
+Atlas serves a public, searchable index of Vagrant boxes. It's easy to find
+boxes you can use with Vagrant that contain the technologies you need
+for a Vagrant environment.
+
+You don't need an Atlas account to use public boxes.
+
+1. Go to the [Box search page](https://vagrantcloud.com/boxes/search)
+
+1. Once you find a box, click its name to learn more about it.
+
+1. When you're ready to use it, copy the name, such as "hashicorp/precise64"
+   and initialize your Vagrant project with `vagrant init hashicorp/precise64`.
+   Or, if you already have a Vagrant project created, modify the Vagrantfile
+   to use the box: `config.vm.box = "hashicorp/precise64"`
+
+## Provider Support
+
+Not all boxes are available for all providers. You may need
+to sort by a provider that you have on your local system
+to narrow down your search.
+
+## Choosing the Right Box
+
+As with all software and configuration used from a public source,
+it's important to keep in mind whose box you're using. Here
+are some things to note when you're choosing a box:
+
+- __The username of the user__. If it's `bento` or `canonical`, you can likely
+trust the box more than an anonymous user
+- __The number of downloads of the box__. Heavily downloaded boxes
+are likely vetted more often by other members of the community. Hashicorp
+responds to reports of malicious software distributed via Atlas
+and takes down boxes
+- __The latest release date__. More up-to-date boxes contain up-to-date
+software
+- __Availability of the box download__. Atlas periodically checks if box
+has is publicly accessible. You can see this information on the box
+page next to the provider

--- a/website/source/docs/vagrant-cloud/boxes/catalog.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/catalog.html.md
@@ -6,11 +6,11 @@ sidebar_current: "vagrant-cloud-boxes-catalog"
 
 # Discovering Vagrant Boxes
 
-Atlas serves a public, searchable index of Vagrant boxes. It's easy to find
+Vagrant Enterprise serves a public, searchable index of Vagrant boxes. It's easy to find
 boxes you can use with Vagrant that contain the technologies you need
 for a Vagrant environment.
 
-You don't need an Atlas account to use public boxes.
+You don't need a Vagrant Enterprise account to use public boxes.
 
 1. Go to the [Box search page](https://vagrantcloud.com/boxes/search)
 
@@ -37,10 +37,10 @@ are some things to note when you're choosing a box:
 trust the box more than an anonymous user
 - __The number of downloads of the box__. Heavily downloaded boxes
 are likely vetted more often by other members of the community. Hashicorp
-responds to reports of malicious software distributed via Atlas
+responds to reports of malicious software distributed via Vagrant Enterprise
 and takes down boxes
 - __The latest release date__. More up-to-date boxes contain up-to-date
 software
-- __Availability of the box download__. Atlas periodically checks if box
+- __Availability of the box download__. Vagrant Enterprise periodically checks if box
 has is publicly accessible. You can see this information on the box
 page next to the provider

--- a/website/source/docs/vagrant-cloud/boxes/create-version.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/create-version.html.md
@@ -1,0 +1,29 @@
+---
+layout: "docs"
+page_title: "Create a New Box Version"
+sidebar_current: "vagrant-cloud-boxes-create-version"
+---
+
+# Create a New Box Version
+
+To release a new version of a box to the public or to your team:
+
+  1. Click on the name of the box you want to release a new version for.
+
+  2. To the right of the box name, there is a dropdown of all the available
+     versions. Click this, and click "Create a New Version"
+
+  3. Enter details for your new version and click "Create Version." Note that
+     after clicking create version, the version is not yet _released_.
+
+  4. Click "Create new provider" on this next page to add at least one
+     provider to the version. Specify the name of the provider (this is the
+     same value you specify to `--provider` when using Vagrant). Then
+     enter the URL to a self-hosted box file or upload a box to us.
+
+  5. Once the provider is created, you now have the option to release the
+     version by clicking "Release now," or you can add more providers.
+
+Once you click "Release now," that version will be available for installation
+with Vagrant. Before clicking this, Vagrant does not know the version even
+exists.

--- a/website/source/docs/vagrant-cloud/boxes/create.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/create.html.md
@@ -6,27 +6,27 @@ sidebar_current: "vagrant-cloud-boxes-create-x"
 
 # Creating a New Vagrant Box
 
-This page will cover creating a new box in Atlas and how to distribute
-it to users. Boxes can be distributed without Atlas, but
+This page will cover creating a new box in Vagrant Enterprise and how to distribute
+it to users. Boxes can be distributed without Vagrant Enterprise, but
 miss out on several [important features](/help/vagrant/boxes).
 
-There are __three ways to create and upload Vagrant Boxes to Atlas__. All
+There are __three ways to create and upload Vagrant Boxes to Vagrant Enterprise__. All
 three options are outlined below.
 
 We recommend using Packer, as is it is fully repeatable and keeps a strong
-history of changes within Atlas. However, for some situations, including
+history of changes within Vagrant Enterprise. However, for some situations, including
 legacy workflows, the Web UI or API will work well.
 
-All three options require you [sign up for Atlas](/account/new).
+All three options require you [sign up for Vagrant Enterprise](/account/new).
 
 ## Creating Boxes with Packer
 
 Using Packer requires more up front effort, but the repeatable and
 automated builds will end any manual management of boxes. Additionally,
-all boxes will be stored and served from Atlas, keeping a history along
+all boxes will be stored and served from Vagrant Enterprise, keeping a history along
  the way.
 
-## Creating Boxes via the Atlas Web Interface
+## Creating Boxes via the Vagrant Enterprise Web Interface
 
 You'll first need to create a box file. This can be done via
 the [vagrant `package` command](http://docs.vagrantup.com/v2/boxes/base.html)
@@ -47,7 +47,7 @@ locally in Vagrant. `virtualbox` is the most common provider.
 1. Upload the `.box` file for each provider, or use a url to the `.box`
 file that is publicly accessible
 
-You can find all of your boxes in the [Vagrant section](/vagrant) of Atlas.
+You can find all of your boxes in the [Vagrant section](/vagrant) of Vagrant Enterprise.
 
 Once you've created and released a box, you can release new versions of
 the box by clicking "Create New Version" under the versions sidebar on

--- a/website/source/docs/vagrant-cloud/boxes/create.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/create.html.md
@@ -8,7 +8,7 @@ sidebar_current: "vagrant-cloud-boxes-create-x"
 
 This page will cover creating a new box in Vagrant Enterprise and how to distribute
 it to users. Boxes can be distributed without Vagrant Enterprise, but
-miss out on several [important features](/help/vagrant/boxes).
+miss out on several [important features](/docs/vagrant-cloud/boxes).
 
 There are __three ways to create and upload Vagrant Boxes to Vagrant Enterprise__. All
 three options are outlined below.
@@ -17,7 +17,7 @@ We recommend using Packer, as is it is fully repeatable and keeps a strong
 history of changes within Vagrant Enterprise. However, for some situations, including
 legacy workflows, the Web UI or API will work well.
 
-All three options require you [sign up for Vagrant Enterprise](/account/new).
+All three options require you [sign up for Vagrant Enterprise](https://vagrantcloud.com/account/new).
 
 ## Creating Boxes with Packer
 
@@ -34,7 +34,7 @@ or with Packer locally.
 
 After you've created the `.box` file, this guide can be followed.
 
-1. Go to the [Create Box](/boxes/new) page.
+1. Go to the [Create Box](https://vagrantcloud.com/boxes/new) page.
 
 1. Name the box and give it a simple description
 
@@ -47,21 +47,21 @@ locally in Vagrant. `virtualbox` is the most common provider.
 1. Upload the `.box` file for each provider, or use a url to the `.box`
 file that is publicly accessible
 
-You can find all of your boxes in the [Vagrant section](/vagrant) of Vagrant Enterprise.
+You can find all of your boxes in the [Vagrant section](https://vagrantcloud.com/vagrant) of Vagrant Enterprise.
 
 Once you've created and released a box, you can release new versions of
 the box by clicking "Create New Version" under the versions sidebar on
 a box page. For more information on the release lifecycle of boxes, see
-the [help page dedicated to box lifecycle](/help/boxes/lifecycle).
+the [help page dedicated to box lifecycle](/docs/vagrant-cloud/boxes/lifecycle.html).
 
 ## Creating Boxes with the API
 
-This example uses the [Boxes API](/docs) to upload boxes with `curl`. To
-get started, you'll need to get an [access token](/settings/tokens).
+This example uses the API to upload boxes with `curl`. To get started, you'll
+need to get an [access token](https://vagrantcloud.com/settings/tokens).
 
 Then, prepare the upload:
 
-    $ curl 'https://atlas.hashicorp.com/api/v1/box/USERNAME/BOX_NAME/version/VERSION/provider/PROVIDER_NAME/upload?access_token=ACCESS_TOKEN'
+    $ curl 'https://vagrantcloud.com/api/v1/box/USERNAME/BOX_NAME/version/VERSION/provider/PROVIDER_NAME/upload?access_token=ACCESS_TOKEN'
 
 This should return something like this:
 
@@ -75,6 +75,6 @@ Then, upload your box with the following command, with the filename in this case
 
 When the upload finishes, you can verify it worked by making this request and matching the `hosted_token` it returns to the previously retrieved upload token.
 
-    $ curl 'https://atlas.hashicorp.com/api/v1/box/USERNAME/BOX_NAME/version/VERSION_NUMBER/provider/PROVIDER_NAME?access_token=ACCESS_TOKEN'
+    $ curl 'https://vagrantcloud.com/api/v1/box/USERNAME/BOX_NAME/version/VERSION_NUMBER/provider/PROVIDER_NAME?access_token=ACCESS_TOKEN'
 
 Your box should then be available for download.

--- a/website/source/docs/vagrant-cloud/boxes/create.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/create.html.md
@@ -1,0 +1,80 @@
+---
+layout: "docs"
+page_title: "Creating a New Vagrant Box"
+sidebar_current: "vagrant-cloud-boxes-create-x"
+---
+
+# Creating a New Vagrant Box
+
+This page will cover creating a new box in Atlas and how to distribute
+it to users. Boxes can be distributed without Atlas, but
+miss out on several [important features](/help/vagrant/boxes).
+
+There are __three ways to create and upload Vagrant Boxes to Atlas__. All
+three options are outlined below.
+
+We recommend using Packer, as is it is fully repeatable and keeps a strong
+history of changes within Atlas. However, for some situations, including
+legacy workflows, the Web UI or API will work well.
+
+All three options require you [sign up for Atlas](/account/new).
+
+## Creating Boxes with Packer
+
+Using Packer requires more up front effort, but the repeatable and
+automated builds will end any manual management of boxes. Additionally,
+all boxes will be stored and served from Atlas, keeping a history along
+ the way.
+
+## Creating Boxes via the Atlas Web Interface
+
+You'll first need to create a box file. This can be done via
+the [vagrant `package` command](http://docs.vagrantup.com/v2/boxes/base.html)
+or with Packer locally.
+
+After you've created the `.box` file, this guide can be followed.
+
+1. Go to the [Create Box](/boxes/new) page.
+
+1. Name the box and give it a simple description
+
+1. Create your first version for the box. This version
+must match the format `[0-9].[0-9].[0-9]`
+
+1. Create a provider for the box, matching the provider you need
+locally in Vagrant. `virtualbox` is the most common provider.
+
+1. Upload the `.box` file for each provider, or use a url to the `.box`
+file that is publicly accessible
+
+You can find all of your boxes in the [Vagrant section](/vagrant) of Atlas.
+
+Once you've created and released a box, you can release new versions of
+the box by clicking "Create New Version" under the versions sidebar on
+a box page. For more information on the release lifecycle of boxes, see
+the [help page dedicated to box lifecycle](/help/boxes/lifecycle).
+
+## Creating Boxes with the API
+
+This example uses the [Boxes API](/docs) to upload boxes with `curl`. To
+get started, you'll need to get an [access token](/settings/tokens).
+
+Then, prepare the upload:
+
+    $ curl 'https://atlas.hashicorp.com/api/v1/box/USERNAME/BOX_NAME/version/VERSION/provider/PROVIDER_NAME/upload?access_token=ACCESS_TOKEN'
+
+This should return something like this:
+
+    {
+      "upload_path": "https://archivist.hashicorp.com/v1/object/630e42d9-2364-2412-4121-18266770468e"
+    }
+
+Then, upload your box with the following command, with the filename in this case being `foo.box`:
+
+    $ curl -X PUT --upload-file foo.box https://archivist.hashicorp.com/v1/object/630e42d9-2364-2412-4121-18266770468e
+
+When the upload finishes, you can verify it worked by making this request and matching the `hosted_token` it returns to the previously retrieved upload token.
+
+    $ curl 'https://atlas.hashicorp.com/api/v1/box/USERNAME/BOX_NAME/version/VERSION_NUMBER/provider/PROVIDER_NAME?access_token=ACCESS_TOKEN'
+
+Your box should then be available for download.

--- a/website/source/docs/vagrant-cloud/boxes/distributing.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/distributing.html.md
@@ -10,14 +10,14 @@ To distribute the box to your team, update your Vagrantfile to reference the
 box on Vagrant Enterprise.
 
     Vagrant.configure(2) do |config|
-      config.vm.box = "ATLAS_USERNAME_HERE/example-box"
+      config.vm.box = "username/example-box"
     end
 
 Now when a team member runs `vagrant up`, the box will be downloaded from Vagrant Enterprise.
 If the box is private, the team member will be prompted to authorize access. Users
 are granted access to private resources by logging in with a Vagrant Enterprise username and
 password or by using a shared Vagrant Enterprise token.
-[Learn more about authorization options here](/help/user-accounts/authentication).
+[Learn more about authorization options here](/docs/vagrant-cloud/users/authentication.html).
 
 ## Private Boxes
 
@@ -45,7 +45,7 @@ and if necessary a collaborator can be removed
 In order to access these private boxes from Vagrant, you'll need to first
 authenticate with your Vagrant Enterprise account.
 
-1. Run `vagrant login` (with [the latest version of Vagrant](/help/intro/updating-tools))
+1. Run `vagrant login`
 2. Enter your credentials
 
 You should now be logged in. We use these credentials to request

--- a/website/source/docs/vagrant-cloud/boxes/distributing.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/distributing.html.md
@@ -7,16 +7,16 @@ sidebar_current: "vagrant-cloud-boxes-distributing"
 ## Distributing Boxes
 
 To distribute the box to your team, update your Vagrantfile to reference the
-box on Atlas.
+box on Vagrant Enterprise.
 
     Vagrant.configure(2) do |config|
       config.vm.box = "ATLAS_USERNAME_HERE/example-box"
     end
 
-Now when a team member runs `vagrant up`, the box will be downloaded from Atlas.
+Now when a team member runs `vagrant up`, the box will be downloaded from Vagrant Enterprise.
 If the box is private, the team member will be prompted to authorize access. Users
-are granted access to private resources by logging in with an Atlas username and
-password or by using a shared Atlas token.
+are granted access to private resources by logging in with a Vagrant Enterprise username and
+password or by using a shared Vagrant Enterprise token.
 [Learn more about authorization options here](/help/user-accounts/authentication).
 
 ## Private Boxes
@@ -43,7 +43,7 @@ and if necessary a collaborator can be removed
 ### Vagrant Login
 
 In order to access these private boxes from Vagrant, you'll need to first
-authenticate with your Atlas account.
+authenticate with your Vagrant Enterprise account.
 
 1. Run `vagrant login` (with [the latest version of Vagrant](/help/intro/updating-tools))
 2. Enter your credentials

--- a/website/source/docs/vagrant-cloud/boxes/distributing.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/distributing.html.md
@@ -1,0 +1,59 @@
+---
+layout: "docs"
+page_title: "Distributing Boxes"
+sidebar_current: "vagrant-cloud-boxes-distributing"
+---
+
+## Distributing Boxes
+
+To distribute the box to your team, update your Vagrantfile to reference the
+box on Atlas.
+
+    Vagrant.configure(2) do |config|
+      config.vm.box = "ATLAS_USERNAME_HERE/example-box"
+    end
+
+Now when a team member runs `vagrant up`, the box will be downloaded from Atlas.
+If the box is private, the team member will be prompted to authorize access. Users
+are granted access to private resources by logging in with an Atlas username and
+password or by using a shared Atlas token.
+[Learn more about authorization options here](/help/user-accounts/authentication).
+
+## Private Boxes
+
+If you create a private box, only you (the owner) and collaborators
+will be able to access it. This is valuable if you
+have information, data or provisioning in your box
+that cannot be public.
+
+Private boxes will be excluded from the box catalog.
+
+### Collaborators
+
+Collaborators can be both teams in
+organizations or individual users.
+
+To add a collaborator:
+
+1. Go to the "Access" page of a box via the sidebar
+2. Enter the username or team name and submit the form
+3. You'll now see an the user or team in the list of collaborators,
+and if necessary a collaborator can be removed
+
+### Vagrant Login
+
+In order to access these private boxes from Vagrant, you'll need to first
+authenticate with your Atlas account.
+
+1. Run `vagrant login` (with [the latest version of Vagrant](/help/intro/updating-tools))
+2. Enter your credentials
+
+You should now be logged in. We use these credentials to request
+a unique authentication token that is stored locally by Vagrant. Your
+username or password is never stored on your machine.
+
+### 404 Not Found
+
+If you don't authenticate, you will likely receive a `404 Not Found`
+error in Vagrant. We return a 404 for security reasons, so a potential
+attacker could not verify if a private box exists.

--- a/website/source/docs/vagrant-cloud/boxes/index.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/index.html.md
@@ -16,14 +16,14 @@ Boxes support versioning so that members of your team using Vagrant can update
 the underlying box easily, and the people who create boxes can push fixes and
 communicate these fixes efficiently.
 
-Atlas makes it easy to manage the versioning of boxes.  Versioning boxes in
-Atlas allows for easy updates, transparent fixes, and clear communication in
+Vagrant Enterprise makes it easy to manage the versioning of boxes.  Versioning boxes in
+Vagrant Enterprise allows for easy updates, transparent fixes, and clear communication in
 changes made. Learn more about the [box release lifecycle
 here](/docs/vagrant-cloud/boxes/lifecycle.html).
 
 ## Vagrant Box Catalog and Discovery
 
-Atlas hosts a catalog of publically available Vagrant Boxes. These are boxes
+Vagrant Enterprise hosts a catalog of publically available Vagrant Boxes. These are boxes
 created by both HashiCorp and community contributions. You can find an owner of
 a box by selecting their username in the URL or on the box page.
 

--- a/website/source/docs/vagrant-cloud/boxes/index.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/index.html.md
@@ -1,0 +1,32 @@
+---
+layout: "docs"
+page_title: "About Vagrant Boxes"
+sidebar_current: "vagrant-cloud-boxes"
+---
+
+# About Vagrant Boxes
+
+Boxes are the package format for [Vagrant](https://vagrantup.com) environments.
+A box can be used on any Vagrant-supported platform to bring up an identical
+working environment across a development team.
+
+## Vagrant Box Creation and Versioning
+
+Boxes support versioning so that members of your team using Vagrant can update
+the underlying box easily, and the people who create boxes can push fixes and
+communicate these fixes efficiently.
+
+Atlas makes it easy to manage the versioning of boxes.  Versioning boxes in
+Atlas allows for easy updates, transparent fixes, and clear communication in
+changes made. Learn more about the [box release lifecycle
+here](/docs/vagrant-cloud/boxes/lifecycle.html).
+
+## Vagrant Box Catalog and Discovery
+
+Atlas hosts a catalog of publically available Vagrant Boxes. These are boxes
+created by both HashiCorp and community contributions. You can find an owner of
+a box by selecting their username in the URL or on the box page.
+
+Public Vagrant boxes let you get up-and-running quickly in unfamiliar
+environments.  This is a popular way to set a base development environment
+launchable in a single command within an organization or community.

--- a/website/source/docs/vagrant-cloud/boxes/lifecycle.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/lifecycle.html.md
@@ -1,0 +1,47 @@
+---
+layout: "docs"
+page_title: "Box Versioning and Lifecycle"
+sidebar_current: "vagrant-cloud-boxes-lifecycle"
+---
+
+# Box Versioning and Lifecycle
+
+Boxes support versioning so that members of your team using Vagrant can
+update the underlying box easily, and the people who create boxes can
+push fixes and communicate these fixes efficiently.
+
+There are multiple components of a box:
+
+- The box itself, comprised of the box name and description.
+- One or more box versions.
+- One or more providers for each box version.
+
+## Vagrant Messaging
+
+Upon `vagrant up` or `vagrant box outdated`, an out-of-date box
+user will see the following message in Vagrant:
+
+    Bringing machine 'default' up with 'virtualbox' provider...
+    ==> default: Checking if box 'hashicorp/example' is up to date...
+    ==> default: A newer version of the box 'hashicorp/example' is available! You currently
+    ==> default: have version '0.0.5'. The latest is version '0.0.6'. Run
+    ==> default: `vagrant box update` to update.
+    ...
+
+## Box Version Release States
+
+Atlas lets you create new versions of boxes without
+releasing them or without Vagrant seeing the update. This lets you prepare
+a box for release slowly. Box versions have three states:
+
+- `unreleased`: Vagrant cannot see this version yet, so it needs
+to be released.  Versions can be released by editing them and clicking
+the release button at the top of the page
+- `active`: Vagrant is able to add and use this box version
+- `revoked`: Vagrant cannot see this version, and it cannot be re-released.
+You must create the version again
+
+### Release Requirements
+
+A box can only be released if it has at least one of each component: a
+box, a version, and a provider.

--- a/website/source/docs/vagrant-cloud/boxes/lifecycle.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/lifecycle.html.md
@@ -30,7 +30,7 @@ user will see the following message in Vagrant:
 
 ## Box Version Release States
 
-Atlas lets you create new versions of boxes without
+Vagrant Enterprise lets you create new versions of boxes without
 releasing them or without Vagrant seeing the update. This lets you prepare
 a box for release slowly. Box versions have three states:
 

--- a/website/source/docs/vagrant-cloud/boxes/private.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/private.html.md
@@ -1,0 +1,44 @@
+---
+layout: "docs"
+page_title: "Private Boxes"
+sidebar_current: "vagrant-cloud-boxes-private"
+---
+
+# Private Boxes
+
+If you create a private box, only you (the owner) and collaborators
+will be able to access it.
+
+## Collaborators
+
+To add a collaborator:
+
+1. Click the gear setting beside the boxes name in order to edit it.
+2. Under the "Add Collaborator" section, enter their username and
+submit the form.
+3. You'll now see a list of collaborators, and if necessary a collaborator
+can be removed.
+
+Collaborators can edit the box, versions and providers. The only
+things they cannot do are:
+
+- Add another collaborator
+- Delete the box
+
+## Vagrant Login
+
+In order to access these boxes from Vagrant, you'll need to first
+authenticate with your Atlas account.
+
+1. Run `vagrant login`
+2. Enter your credentials
+
+You should now be logged in. We use these credentials to request
+a unique authentication token that is stored locally by Vagrant. Your
+username or password is never stored on your machine.
+
+## 404 Not Found
+
+If you don't authenticate, you will likely receive a `404 Not Found`
+error in Vagrant. We return a 404 for security reasons, so a potential
+attacker could not verify if a private box exists.

--- a/website/source/docs/vagrant-cloud/boxes/private.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/private.html.md
@@ -28,7 +28,7 @@ things they cannot do are:
 ## Vagrant Login
 
 In order to access these boxes from Vagrant, you'll need to first
-authenticate with your Atlas account.
+authenticate with your Vagrant Enterprise account.
 
 1. Run `vagrant login`
 2. Enter your credentials

--- a/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
@@ -1,0 +1,24 @@
+---
+layout: "docs"
+page_title: "API Release Workflow"
+sidebar_current: "vagrant-cloud-boxes-release-workflow"
+---
+
+# API Release Workflow
+
+Creating new boxes through their [release lifecycle](/help/boxes/lifecycle)
+is possible through the Atlas website, but you can also automate
+the task via the Atlas API.
+
+1. Create box, or locate a boxes `tag`, like `hashicorp/precise64`
+2. After some event, like the end of a CI build, you may want to
+release a new version of the box. To do this, first use the API to
+create a new version with a version number and a short description
+of the changes
+3. Then, create any providers associated with the version, like
+`virtualbox`
+4. Once your system has made the necessary requests to the API and the
+version is ready, make a request to the `release` endpoint on the version
+5. The version should now be available to users of the box via
+the command `vagrant box outdated` or via the automated checks on
+`vagrant up`

--- a/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
@@ -7,8 +7,8 @@ sidebar_current: "vagrant-cloud-boxes-release-workflow"
 # API Release Workflow
 
 Creating new boxes through their [release lifecycle](/help/boxes/lifecycle)
-is possible through the Atlas website, but you can also automate
-the task via the Atlas API.
+is possible through the Vagrant Enterprise website, but you can also automate
+the task via the Vagrant Enterprise API.
 
 1. Create box, or locate a boxes `tag`, like `hashicorp/precise64`
 2. After some event, like the end of a CI build, you may want to

--- a/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
@@ -6,7 +6,7 @@ sidebar_current: "vagrant-cloud-boxes-release-workflow"
 
 # API Release Workflow
 
-Creating new boxes through their [release lifecycle](/help/boxes/lifecycle)
+Creating new boxes through their [release lifecycle](/docs/vagrant-cloud/boxes/lifecycle.html)
 is possible through the Vagrant Enterprise website, but you can also automate
 the task via the Vagrant Enterprise API.
 

--- a/website/source/docs/vagrant-cloud/boxes/using.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/using.html.md
@@ -6,7 +6,7 @@ sidebar_current: "vagrant-cloud-boxes-using"
 
 # Finding and Using Boxes
 
-A primary use case of Atlas by HashiCorp is to be able to easily find
+A primary use case of Vagrant Enterprise by HashiCorp is to be able to easily find
 boxes you can use with Vagrant that contain the technologies you need
 for a Vagrant environment. We've made it extremely easy to do that:
 

--- a/website/source/docs/vagrant-cloud/boxes/using.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/using.html.md
@@ -1,0 +1,23 @@
+---
+layout: "docs"
+page_title: "Finding and Using Boxes"
+sidebar_current: "vagrant-cloud-boxes-using"
+---
+
+# Finding and Using Boxes
+
+A primary use case of Atlas by HashiCorp is to be able to easily find
+boxes you can use with Vagrant that contain the technologies you need
+for a Vagrant environment. We've made it extremely easy to do that:
+
+1. Go to the [Discover page](/discover)
+
+2. Search for any box you want, or use the navigation on the left
+   to see [featured](/discover/featured) boxes.
+
+3. Once you find a box, click its name to learn more about it.
+
+4. When you're ready to use it, copy the name, such as "hashicorp/precise64"
+   and initialize your Vagrant project with `vagrant init hashicorp/precise64`.
+   Or, if you already have a Vagrant project created, modify the Vagrantfile
+   to use the box: `config.vm.box = "hashicorp/precise64"`

--- a/website/source/docs/vagrant-cloud/boxes/using.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/using.html.md
@@ -10,14 +10,12 @@ A primary use case of Vagrant Enterprise by HashiCorp is to be able to easily fi
 boxes you can use with Vagrant that contain the technologies you need
 for a Vagrant environment. We've made it extremely easy to do that:
 
-1. Go to the [Discover page](/discover)
+1. Go to the [Discover page](https://vagrantcloud.com/discover), and search for
+   any box you want.
 
-2. Search for any box you want, or use the navigation on the left
-   to see [featured](/discover/featured) boxes.
+1. Once you find a box, click its name to learn more about it.
 
-3. Once you find a box, click its name to learn more about it.
-
-4. When you're ready to use it, copy the name, such as "hashicorp/precise64"
+1. When you're ready to use it, copy the name, such as "hashicorp/precise64"
    and initialize your Vagrant project with `vagrant init hashicorp/precise64`.
    Or, if you already have a Vagrant project created, modify the Vagrantfile
    to use the box: `config.vm.box = "hashicorp/precise64"`

--- a/website/source/docs/vagrant-cloud/index.html.md
+++ b/website/source/docs/vagrant-cloud/index.html.md
@@ -1,0 +1,13 @@
+---
+layout: "docs"
+page_title: "Vagrant Enterprise"
+sidebar_current: "vagrant-cloud"
+---
+
+# Vagrant Enterprise
+
+Vagrant Enterprise provides the following features for Vagrant:
+
+- [Vagrant Box Catalog](/docs/vagrant-cloud/boxes/catalog.html)
+- [Vagrant Box Creation](/docs/vagrant-cloud/boxes/create.html)
+- [Vagrant Box Versioning](/docs/vagrant-cloud/boxes/lifecycle.html)

--- a/website/source/docs/vagrant-cloud/organizations/authentication-policy.html.md
+++ b/website/source/docs/vagrant-cloud/organizations/authentication-policy.html.md
@@ -1,0 +1,30 @@
+---
+layout: "docs"
+page_title: "Organization Authentication Policy"
+sidebar_current: "vagrant-cloud-organizations-authentication-policy"
+---
+
+
+# Set an Organization Authentication Policy
+
+Because organization membership affords members access to potentially sensitive
+resources, owners can set organization-wide authentication policy in Vagrant
+Enterprise.
+
+## Requiring Two-Factor Authentication
+
+Organization owners can require that all organization team members use
+[two-factor authentication](/docs/enterprise/user-accounts/authentication.html).
+Those that lack two-factor authentication will be locked out of the web
+interface until they enable it or leave the organization.
+
+Visit your organization's configuration page to enable this feature. All
+organization owners must have two-factor authentication enabled to require the
+practice organization-wide. Note: locked-out users are still be able to interact
+with Vagrant Enterprise using their `ATLAS_TOKEN`.
+
+## Disabling Two-Factor Authentication Requirement
+
+Organization owners can disable the two-factor authentication requirement from
+their organization's configuration page. Locked-out team members (those who have
+not enabled two-factor authentication) will have their memberships reinstated.

--- a/website/source/docs/vagrant-cloud/organizations/authentication-policy.html.md
+++ b/website/source/docs/vagrant-cloud/organizations/authentication-policy.html.md
@@ -14,7 +14,7 @@ Enterprise.
 ## Requiring Two-Factor Authentication
 
 Organization owners can require that all organization team members use
-[two-factor authentication](/docs/enterprise/user-accounts/authentication.html).
+[two-factor authentication](/docs/vagrant-cloud/users/authentication.html).
 Those that lack two-factor authentication will be locked out of the web
 interface until they enable it or leave the organization.
 

--- a/website/source/docs/vagrant-cloud/organizations/create.html.md
+++ b/website/source/docs/vagrant-cloud/organizations/create.html.md
@@ -1,0 +1,15 @@
+---
+layout: "docs"
+page_title: "Create an Organization"
+sidebar_current: "vagrant-cloud-organizations-create"
+---
+
+# Create an Organization
+
+To create an organization:
+
+1. Create a personal account. You'll use this to create and administrate the
+organization. You'll be able to add other users as owners of the organization,
+so it won't be tied solely to your account.
+
+1. Visit your new organization page to create the organization.

--- a/website/source/docs/vagrant-cloud/organizations/index.html.md
+++ b/website/source/docs/vagrant-cloud/organizations/index.html.md
@@ -1,0 +1,14 @@
+---
+layout: "docs"
+page_page_title: "Organizations in Vagrant Enterprise"
+sidebar_current: "vagrant-cloud-organizations"
+---
+
+## Organizations in Vagrant Enterprise
+
+Organizations are a group of users in Vagrant Enterprise that have access and
+ownership over shared resources. When operating within a team, we recommend
+creating an organization to manage access control, auditing, billing and
+authorization.
+
+Each individual member of your organization should have their own account.

--- a/website/source/docs/vagrant-cloud/organizations/migrate.html.md
+++ b/website/source/docs/vagrant-cloud/organizations/migrate.html.md
@@ -1,0 +1,24 @@
+---
+layout: "docs"
+page_title: "Migrate User to Organization"
+sidebar_current: "vagrant-cloud-organizations-migrate"
+---
+
+# Migrate User to Organization
+
+To migrate an existing user account to an organization:
+
+1. Create or retrieve the username of a new personal account. You'll add this
+account as an "owner" for the new organization during the migration process. If
+you already have another account, write down your username.
+
+2. Sign in as the account you wish to migrate and visit the migration page.
+
+3. Put the username of the personal account you wish to make an owner of the
+organization into the username text field and press "Migrate".
+
+4. You should now be logged out and receive a confirmation email with the
+personal account you migrated to.
+
+5. Now, sign in with your personal account. If you visit you settings page, you
+should see your migrated organization available to administrate.

--- a/website/source/docs/vagrant-cloud/request-limits.html.md
+++ b/website/source/docs/vagrant-cloud/request-limits.html.md
@@ -1,0 +1,31 @@
+---
+layout: "docs"
+page_title: "Request Limits"
+sidebar_current: "vagrant-cloud-request-limits"
+---
+
+# Request Limits
+
+## What is Rate Limiting?
+
+Rate limiting is a process to protect our quality of service we provide to you. Rate limiting will limit the number of requests a client may send to services over a set time interval. We track requests by IP address origin of the request.
+
+## How many requests can I make?
+
+You can make a set amount of requests per minute from a single IP address. This rate can vary per resource but the current value is returned in the HTTP headers of your request.  For the most up to date rate limiting for your requests please view the information in the headers of your response.
+
+## Why are you rate limiting my requests?
+
+We have detected a request rate in excess of our current threshold. To provide a high quality of services to all users, your request may have been rate limited.
+
+## How do I know if I have been rate limited?
+
+If you have received a 429 HTTP status code in the response to your request, your request has likely been rate limited. There is some additional information in the headers that will help you determine if this is the case. Each request response will include the headers:  X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset.
+
+- **X-RateLimit-Limit**: The current maximum number of requests allowed from your client.
+- **X-RateLimit-Remaining**: How many requests you have remaining in the time window.
+- **X-RateLimit-Reset**: The unix timestamp for when the window resets.
+
+## My use case requires more requests.  What do I do?
+
+Please contact support@hashicorp.com.

--- a/website/source/docs/vagrant-cloud/support.html.md
+++ b/website/source/docs/vagrant-cloud/support.html.md
@@ -1,0 +1,36 @@
+---
+layout: "docs"
+page_title: "Vagrant Enterprise Support"
+sidebar_current: "vagrant-cloud-support"
+---
+
+# Contacting Support
+
+All users of Vagrant Enterprise are urged to email feedback, questions or
+requests to the HashiCorp team.
+
+### Free Support
+
+We do not currently publish support SLAs for free accounts, but endeavor to
+respond as quickly as possible. We respond to most requests within less than 24
+hours.
+
+## HashiCorp Tools Support
+
+It's often the case that Vagrant Enterprise questions or feedback relates to
+the HashiCorp tooling. We encourage all Vagrant Enterprise users to search for
+related issues and problems in the open source repositories and mailing lists
+prior to contacting us to help make our support more efficient and to help
+resolve problems faster.
+
+Visit the updating tools section for a list of our tools and their project
+websites.
+
+## Documentation Feedback
+
+Due to the dynamic nature of Vagrant Enterprise and the broad set of features
+it provides, there may be information lacking in the documentation.
+
+In this case, we appreciate any feedback to be emailed to us so
+we can make improvements. Please email feedback to
+<a href="mailto:support@hashicorp.com">support@hashicorp.com</a>.

--- a/website/source/docs/vagrant-cloud/users/authentication.html.md
+++ b/website/source/docs/vagrant-cloud/users/authentication.html.md
@@ -1,0 +1,56 @@
+---
+layout: "docs"
+page_title: "Authentication"
+sidebar_current: "vagrant-cloud-users-authentication"
+---
+
+# Authentication
+
+Vagrant Enterprise requires a username and password to sign up and login.
+However, there are several ways to authenticate with your account.
+
+### Authentication Tokens
+
+Authentication tokens are keys used to access your account via tools or over the
+various APIs used in Vagrant Enterprise.
+
+You can create new tokens in the token section of your account settings. It's
+important to keep tokens secure, as they are essentially a password and can be
+used to access your account or resources. Additionally, token authentication
+bypasses two factor authentication.
+
+### Authenticating Tools
+
+All HashiCorp tools look for the `ATLAS_TOKEN` environment variable:
+
+```shell
+$ export ATLAS_TOKEN=TOKEN
+```
+
+This will automatically authenticate all requests against this token. This is
+the recommended way to authenticate with our various tools. Care should be given
+to how this token is stored, as it is as good as a password.
+
+### Two Factor Authentication
+
+You can optionally enable Two Factor authentication, requiring an SMS or TOTP
+one-time code every time you log in, after entering your username and password.
+
+You can enable Two Factor authentication in the security section of your account
+settings.
+
+Be sure to save the generated recovery codes. Each backup code can be used once
+to sign in if you do not have access to your two-factor authentication device.
+
+### Sudo Mode
+
+When accessing certain admin-level pages (adjusting your user profile, for
+example), you may notice that you're prompted for your password, even though
+you're already logged in. This is by design, and aims to help guard protect you
+if your screen is unlocked and unattended.
+
+### Session Management
+
+You can see a list of your active sessions on your security settings page. From
+here, you can revoke sessions, in case you have lost access to a machine from
+which you were accessing.

--- a/website/source/docs/vagrant-cloud/users/index.html.md
+++ b/website/source/docs/vagrant-cloud/users/index.html.md
@@ -1,0 +1,11 @@
+---
+layout: "docs"
+page_title: "User Accounts" 
+sidebar_current: "vagrant-cloud-users"
+---
+
+# User Accounts
+
+Users are the main identity system in Vagrant Enterprise. A user can be a
+member of multiple [organizations](/docs/enterprise/organizations/index.html),
+as well as individually collaborate on various resources.

--- a/website/source/docs/vagrant-cloud/users/index.html.md
+++ b/website/source/docs/vagrant-cloud/users/index.html.md
@@ -7,5 +7,5 @@ sidebar_current: "vagrant-cloud-users"
 # User Accounts
 
 Users are the main identity system in Vagrant Enterprise. A user can be a
-member of multiple [organizations](/docs/enterprise/organizations/index.html),
+member of multiple [organizations](/docs/vagrant-cloud/organizations/index.html),
 as well as individually collaborate on various resources.

--- a/website/source/docs/vagrant-cloud/users/recovery.html.md
+++ b/website/source/docs/vagrant-cloud/users/recovery.html.md
@@ -1,0 +1,13 @@
+---
+layout: "docs"
+page_title: "Account Recovery"
+sidebar_current: "vagrant-cloud-users-recovery"
+---
+
+# Account Recovery
+
+If you have lost access to your Vagrant Enterprise account, use the reset
+password form on the login page to send yourself a link to reset your password.
+
+If an email is unknown, [contact us](mailto:support@hashicorp.com) for further
+help.

--- a/website/source/docs/vagrant-cloud/vagrant-cloud-migration.html.md
+++ b/website/source/docs/vagrant-cloud/vagrant-cloud-migration.html.md
@@ -1,0 +1,25 @@
+---
+layout: "docs"
+page_title: "Vagrant Cloud Migration"
+sidebar_current: "vagrant-cloud-migration"
+---
+
+# Vagrant Cloud Migration
+
+Vagrant-related functionality will be moved from Terraform Enterprise into its own product, Vagrant Cloud.
+This migration is currently planned for **June 27th, 2017**.
+
+All existing Vagrant boxes will be moved to the new system on that date.
+All users, organizations, and teams will be copied as well.
+
+## Authentication Tokens
+
+No existing Terraform Enterprise authentication tokens will be transferred.
+To prevent a disruption of service for Vagrant-related operations, users must create a new authentication token and check "Migrate to Vagrant Cloud" and begin using these tokens for creating and modifying Vagrant boxes.
+These tokens will be moved on the migration date.
+
+Creating a token via `vagrant login` will also mark a token as "Migrate to Vagrant Cloud".
+
+## More Information
+
+At least 1 month prior to the migration, we will be releasing more information on the specifics and impact of the migration.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -214,6 +214,27 @@
           <li<%= sidebar_current("other-wsl") %>><a href="/docs/other/wsl.html">WSL</a></li>
         </ul>
       </li>
+
+      <hr />
+
+      <li<%= sidebar_current("vagrant-cloud") %>>
+        <a href="/docs/vagrant-cloud/">Vagrant Enterprise</a>
+        <ul class="nav">
+          <li<%= sidebar_current("vagrant-cloud-boxes") %>>
+            <a href="/docs/vagrant-cloud/boxes/index.html">Boxes</a>
+            <ul class="nav">
+              <li<%= sidebar_current("vagrant-cloud-boxes-catalog") %>><a href="/docs/vagrant-cloud/boxes/catalog.html">Catalog</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-create-x") %>><a href="/docs/vagrant-cloud/boxes/create.html">Creating a New Box</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-create-version") %>><a href="/docs/vagrant-cloud/boxes/create-version.html">Creating a New Version</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-distributing") %>><a href="/docs/vagrant-cloud/boxes/distributing.html">Distributing</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-lifecycle") %>><a href="/docs/vagrant-cloud/boxes/lifecycle.html">Lifecycle</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-private") %>><a href="/docs/vagrant-cloud/boxes/private.html">Private Boxes</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-release-workflow") %>><a href="/docs/vagrant-cloud/boxes/release-workflow.html">Release Workflow</a></li>
+              <li<%= sidebar_current("vagrant-cloud-boxes-using") %>><a href="/docs/vagrant-cloud/boxes/using.html">Finding & Using Boxes</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
     </ul>
   <% end %>
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -243,6 +243,14 @@
             </ul>
           </li>
 
+          <li<%= sidebar_current("vagrant-cloud-users") %>>
+            <a href="/docs/vagrant-cloud/users/index.html">Users</a>
+            <ul class="nav">
+              <li<%= sidebar_current("vagrant-cloud-users-authentication") %>><a href="/docs/vagrant-cloud/users/authentication.html">Authentication</a></li>
+              <li<%= sidebar_current("vagrant-cloud-users-recovery") %>><a href="/docs/vagrant-cloud/users/recovery.html">Account Recovery</a></li>
+            </ul>
+          </li>
+
           <li<%= sidebar_current("vagrant-cloud-request-limits") %>><a href="/docs/vagrant-cloud/request-limits.html">Request Limits</a></li>
           <li<%= sidebar_current("vagrant-cloud-support") %>><a href="/docs/vagrant-cloud/support.html">Support</a></li>
         </ul>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -233,6 +233,16 @@
               <li<%= sidebar_current("vagrant-cloud-boxes-using") %>><a href="/docs/vagrant-cloud/boxes/using.html">Finding & Using Boxes</a></li>
             </ul>
           </li>
+
+          <li<%= sidebar_current("vagrant-cloud-organizations") %>>
+            <a href="/docs/vagrant-cloud/organizations/index.html">Organizations</a>
+            <ul class="nav">
+              <li<%= sidebar_current("vagrant-cloud-organizations-create") %>><a href="/docs/vagrant-cloud/organizations/create.html">Create an Organization</a></li>
+              <li<%= sidebar_current("vagrant-cloud-organizations-migrate") %>><a href="/docs/vagrant-cloud/organizations/migrate.html">Migrate User to Organization</a></li>
+              <li<%= sidebar_current("vagrant-cloud-organizations-authentication-policy") %>><a href="/docs/vagrant-cloud/organizations/authentication-policy.html">Authentication Policy</a></li>
+            </ul>
+          </li>
+
           <li<%= sidebar_current("vagrant-cloud-request-limits") %>><a href="/docs/vagrant-cloud/request-limits.html">Request Limits</a></li>
         </ul>
       </li>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -244,6 +244,7 @@
           </li>
 
           <li<%= sidebar_current("vagrant-cloud-request-limits") %>><a href="/docs/vagrant-cloud/request-limits.html">Request Limits</a></li>
+          <li<%= sidebar_current("vagrant-cloud-support") %>><a href="/docs/vagrant-cloud/support.html">Support</a></li>
         </ul>
       </li>
     </ul>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -233,6 +233,7 @@
               <li<%= sidebar_current("vagrant-cloud-boxes-using") %>><a href="/docs/vagrant-cloud/boxes/using.html">Finding & Using Boxes</a></li>
             </ul>
           </li>
+          <li<%= sidebar_current("vagrant-cloud-request-limits") %>><a href="/docs/vagrant-cloud/request-limits.html">Request Limits</a></li>
         </ul>
       </li>
     </ul>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -253,6 +253,7 @@
 
           <li<%= sidebar_current("vagrant-cloud-request-limits") %>><a href="/docs/vagrant-cloud/request-limits.html">Request Limits</a></li>
           <li<%= sidebar_current("vagrant-cloud-support") %>><a href="/docs/vagrant-cloud/support.html">Support</a></li>
+          <li<%= sidebar_current("vagrant-cloud-migration") %>><a href="/docs/vagrant-cloud/vagrant-cloud-migration.html">Vagrant Cloud Migration</a></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
This extracts (most of) the Vagrant Enterprise docs from their current location at https://atlas.hashicorp.com/help/vagrant

```
vagrant-cloud
├── index.html.md ✅
├── features.html.md 🚮 Moved to index
├── request-limits.html.md ✅
├── glossary.html.md 🚮 Not enough content
├── support.html.md ✅
├── vagrant-cloud-migration.html.md ✅
├── boxes
│   ├── index.html.md ✅
│   ├── catalog.html.md ✅
│   ├── create-version.html.md ✅
│   ├── create.html.md ✅
│   ├── distributing.html.md ✅
│   ├── lifecycle.html.md ✅
│   ├── private.html.md ✅
│   ├── release-workflow.html.md ✅
│   ├── using.html.md ✅
│   └── what.html.md 🚮 No contents
├── organizations
│   ├── index.html.md ✅
│   ├── authentication-policy.html.md ✅
│   ├── create.html.md ✅
│   ├── credit-card.html.md 🚮 No billing right now
│   ├── migrate.html.md ✅
│   └── trials.html.md 🚮 No billing right now
├── shares 🚮 Removed as per deprecation of Atlas share driver
└── users
    ├── index.html.md ✅
    ├── authentication.html.md ✅
    └── recovery.html.md ✅
```