### PR TITLE
Raise exception for unsupported snapshot providers and improve snapshot plugin testing

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -656,6 +656,10 @@ module Vagrant
       error_key(:snapshot_force)
     end
 
+    class SnapshotNotSupported < VagrantError
+      error_key(:snapshot_not_supported)
+    end
+
     class SSHAuthenticationFailed < VagrantError
       error_key(:ssh_authentication_failed)
     end

--- a/plugins/commands/snapshot/command/list.rb
+++ b/plugins/commands/snapshot/command/list.rb
@@ -22,8 +22,7 @@ module VagrantPlugins
             end
 
             if !vm.provider.capability?(:snapshot_list)
-              vm.ui.info(I18n.t("vagrant.commands.snapshot.not_supported"))
-              next
+              raise Vagrant::Errors::SnapshotNotSupported
             end
 
             snapshots = vm.provider.capability(:snapshot_list)

--- a/plugins/commands/snapshot/command/save.rb
+++ b/plugins/commands/snapshot/command/save.rb
@@ -34,8 +34,7 @@ module VagrantPlugins
           name = argv.pop
           with_target_vms(argv) do |vm|
             if !vm.provider.capability?(:snapshot_list)
-              vm.ui.info(I18n.t("vagrant.commands.snapshot.not_supported"))
-              next
+              raise Vagrant::Errors::SnapshotNotSupported
             end
 
             snapshot_list = vm.provider.capability(:snapshot_list)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1158,6 +1158,12 @@ en:
         guest system. Please report a bug with your Vagrantfile and debug log.
       snapshot_force: |-
         You must include the `--force` option to replace an existing snapshot.
+      snapshot_not_supported: |-
+        This provider doesn't support snapshots.
+
+        This may be intentional or this may be a bug. If this provider
+        should support snapshots, then please report this as a bug to the
+        maintainer of the provider.
       ssh_authentication_failed: |-
         SSH authentication failed! This is typically caused by the public/private
         keypair for the SSH user not being properly set on the guest VM. Please

--- a/test/unit/plugins/commands/snapshot/command/list_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/list_test.rb
@@ -1,0 +1,83 @@
+require File.expand_path("../../../../../base", __FILE__)
+
+require Vagrant.source_root.join("plugins/commands/snapshot/command/list")
+
+describe VagrantPlugins::CommandSnapshot::Command::List do
+  include_context "unit"
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:guest)   { double("guest") }
+  let(:host)    { double("host") }
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+
+  let(:argv) { [] }
+
+  subject { described_class.new(argv, iso_env) }
+
+  before do
+    allow(machine.provider).to receive(:capability?).with(:snapshot_list).
+      and_return(true)
+
+    allow(machine.provider).to receive(:capability).with(:snapshot_list).
+      and_return([])
+
+    allow(subject).to receive(:with_target_vms) { |&block| block.call machine }
+  end
+
+  describe "execute" do
+    context "with an unsupported provider" do
+      let(:argv)     { ["foo"] }
+
+      before do
+        allow(machine.provider).to receive(:capability?).with(:snapshot_list).
+          and_return(false)
+      end
+
+      it "raises an exception" do
+        machine.id = "foo"
+        expect { subject.execute }.
+          to raise_error(Vagrant::Errors::SnapshotNotSupported)
+      end
+    end
+
+    context "with a vm given" do
+      let(:argv)     { ["foo"] }
+
+      it "prints a message if the vm does not exist" do
+        machine.id = nil
+
+        expect(iso_env.ui).to receive(:info).with { |message, _|
+          expect(message).to include("VM not created")
+        }
+        expect(machine).to_not receive(:action)
+        expect(subject.execute).to eq(0)
+      end
+
+      it "prints a message if no snapshots have been taken" do
+        machine.id = "foo"
+
+        expect(iso_env.ui).to receive(:output)
+          .with(/No snapshots have been taken yet!/, anything)
+        expect(subject.execute).to eq(0)
+      end
+
+      it "prints a list of snapshots" do
+        machine.id = "foo"
+
+        allow(machine.provider).to receive(:capability).with(:snapshot_list).
+          and_return(["foo", "bar", "baz"])
+
+        expect(iso_env.ui).to receive(:output).with(/foo/, anything)
+        expect(iso_env.ui).to receive(:output).with(/bar/, anything)
+        expect(iso_env.ui).to receive(:output).with(/baz/, anything)
+        expect(subject.execute).to eq(0)
+      end
+    end
+  end
+end

--- a/test/unit/plugins/commands/snapshot/command/save_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/save_test.rb
@@ -38,6 +38,21 @@ describe VagrantPlugins::CommandSnapshot::Command::Save do
       end
     end
 
+    context "with an unsupported provider" do
+      let(:argv)     { ["test"] }
+
+      before do
+        allow(machine.provider).to receive(:capability?).with(:snapshot_list).
+          and_return(false)
+      end
+
+      it "raises an exception" do
+        machine.id = "foo"
+        expect { subject.execute }.
+          to raise_error(Vagrant::Errors::SnapshotNotSupported)
+      end
+    end
+
     context "with a snapshot name given" do
       let(:argv)     { ["test"] }
       it "calls snapshot_save with a snapshot name" do


### PR DESCRIPTION
This pull request changes the behavior of the snapshot command in that it will raise an exception if the `snapshot/save` and `snapshot/list` commands are invoked on an unsupported provider. It also introduces a new test for the `snapshot/list` command.