### PR TITLE
Add ssh StrictHostKeyChecking to ansible inventory file

### DIFF
--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -202,7 +202,13 @@ module VagrantPlugins
             forced_remote_user = "ansible_ssh_user='#{ssh_info[:username]}' "
           end
 
-          "#{machine.name} ansible_ssh_host=#{ssh_info[:host]} ansible_ssh_port=#{ssh_info[:port]} #{forced_remote_user}ansible_ssh_private_key_file='#{ssh_info[:private_key_path][0]}'\n"
+          ansible_ssh_common_args = ""
+          if !config.host_key_checking.nil?
+            ansible_ssh_common_args = "ansible_ssh_common_args='-o StrictHostKeyChecking="
+            ansible_ssh_common_args += if config.host_key_checking then "yes'" else "no'" end
+          end
+
+          "#{machine.name} ansible_ssh_host=#{ssh_info[:host]} ansible_ssh_port=#{ssh_info[:port]} #{forced_remote_user}ansible_ssh_private_key_file='#{ssh_info[:private_key_path][0]}' #{ansible_ssh_common_args}\n"
         end
 
         def get_inventory_winrm_machine(machine, winrm_net_info)

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -42,7 +42,8 @@ VF
     private_key_path: ['/path/to/my/key'],
     username: 'testuser',
     host: '127.0.0.1',
-    port: 2223
+    port: 2223,
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
   }}
 
   let(:existing_file) { File.expand_path(__FILE__) }
@@ -171,9 +172,9 @@ VF
         expect(File.exists?(generated_inventory_file)).to be_true
         inventory_content = File.read(generated_inventory_file)
         if with_ssh_user
-          expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_user='#{machine.ssh_info[:username]}' ansible_ssh_private_key_file='#{machine.ssh_info[:private_key_path][0]}'\n")
+          expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_user='#{machine.ssh_info[:username]}' ansible_ssh_private_key_file='#{machine.ssh_info[:private_key_path][0]}' ansible_ssh_common_args='#{machine.ssh_info[:ansible_ssh_common_args]}'\n")
         else
-          expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_private_key_file='#{machine.ssh_info[:private_key_path][0]}'\n")
+          expect(inventory_content).to include("#{machine.name} ansible_ssh_host=#{machine.ssh_info[:host]} ansible_ssh_port=#{machine.ssh_info[:port]} ansible_ssh_private_key_file='#{machine.ssh_info[:private_key_path][0]}' ansible_ssh_common_args='#{machine.ssh_info[:ansible_ssh_common_args]}'\n")
         end
         expect(inventory_content).to include("# MISSING: '#{iso_env.machine_names[1]}' machine was probably removed without using Vagrant. This machine should be recreated.\n")
       }


### PR DESCRIPTION
- Adds "ansible_ssh_common_args='-o StrictHostKeyChecking=no/yes'" to the
  vagrant inventory if ansible.host_key_checking is defined
- ansible-playbook -i <vagrant-inventory> ... won't stop to ask about adding
  the host key to ~/.ssh/known_hosts if ansible.host_key_checking = false

Related issue: #8628 