### PR TITLE
Fixes typo in broken link to documentation

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1539,7 +1539,7 @@ en:
         unexpected errors. To learn more about this, and the options that are available,
         please refer to the Vagrant documentation:
 
-          https://www.vagrantup.com/docs/other/wsl
+          https://www.vagrantup.com/docs/other/wsl.html
       wsl_virtualbox_windows_access: |-
         Vagrant is unable to use the VirtualBox provider from the Windows Subsystem for
         Linux without access to the Windows environment. Enabling this access must be
@@ -1547,7 +1547,7 @@ en:
         on enabing Windows access and using VirtualBox from the Windows Subsystem for
         Linux, please refer to the Vagrant documentation:
 
-          https://www.vagrantup.com/docs/other/wsl
+          https://www.vagrantup.com/docs/other/wsl.html
 #-------------------------------------------------------------------------------
 # Translations for config validation errors
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
I've been trying out the new Vagrant feature which now supports the Windows Subsystem for Linux on Windows 10, I've had an error which pointed me to the documentation, but the documentation link was missing the ".html", which returned a 404 page for me.

This fixes the link to the documentation and points to the right one.

![vagrant_github_02](https://cloud.githubusercontent.com/assets/1094843/26637961/4a9e618a-45f7-11e7-8a59-880ef239ae4e.png)
![vagrant_github_01](https://cloud.githubusercontent.com/assets/1094843/26637962/4a9ffd10-45f7-11e7-9e3f-778e8643d232.PNG)

This is my first PR ever on GitHub so please if I missed something, please tell me.
