### PR TITLE
Handle box names that are URLs

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -30,6 +30,12 @@ module Vagrant
         def call(env)
           @download_interrupted = false
 
+          unless env[:box_name].nil?
+            if URI.parse(env[:box_name]).kind_of?(URI::HTTP)
+              env[:ui].warn(I18n.t("vagrant.box_add_url_warn"))
+            end
+          end
+
           url = Array(env[:box_url]).map do |u|
             u = u.gsub("\\", "/")
             if Util::Platform.windows? && u =~ /^[a-z]:/i

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -22,6 +22,9 @@ en:
       Successfully added box '%{name}' (v%{version}) for '%{provider}'!
     box_adding_direct: |-
       Box file was not detected as metadata. Adding it directly...
+    box_add_url_warn: |-
+      It looks like you attempted to add a box with a URL for the name...
+      Instead, use box_url instead of box for box URLs.
     box_downloading: |-
       Downloading: %{url}
     box_download_error: |-


### PR DESCRIPTION
Prior to this commit, if a user set a URL for the name of a box, vagrant
would not warn the user about using box_url instead. This would lead to
some difficult user experiences around the various box commands due to
the box name being a full URL. This commit introduces a warning to the
user and lets them know to instead use box_url.