### PR TITLE
Warn about changes to cwd for every machine action

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -170,6 +170,8 @@ module Vagrant
       # Extra env keys are the remaining opts
       extra_env = opts.dup
 
+      check_cwd
+
       # Create a deterministic ID for this machine
       vf = nil
       vf = @env.vagrantfile_name[0] if @env.vagrantfile_name
@@ -558,6 +560,26 @@ module Vagrant
     def uid_file
       return nil if !@data_dir
       @data_dir.join("creator_uid")
+    end
+
+    def check_cwd
+      vagrant_cwd_filepath = @data_dir.join('vagrant_cwd')
+      vagrant_cwd = if File.exist?(vagrant_cwd_filepath)
+        File.read(vagrant_cwd_filepath).chomp
+      end
+
+      if vagrant_cwd
+        if vagrant_cwd != @env.cwd.to_s
+          ui.warn(I18n.t(
+            'vagrant.moved_cwd',
+            old_wd:     vagrant_cwd,
+            current_wd: @env.cwd.to_s))
+
+          File.write(vagrant_cwd_filepath, @env.cwd)
+        end
+      else
+        File.write(vagrant_cwd_filepath, @env.cwd)
+      end
     end
   end
 end

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -562,22 +562,23 @@ module Vagrant
       @data_dir.join("creator_uid")
     end
 
+    # Checks the current directory for a given machine
+    # and displays a warning if that machine has moved
+    # from its previous location on disk. If the machine
+    # has moved, it prints a warning to the user.
     def check_cwd
       vagrant_cwd_filepath = @data_dir.join('vagrant_cwd')
       vagrant_cwd = if File.exist?(vagrant_cwd_filepath)
         File.read(vagrant_cwd_filepath).chomp
       end
 
-      if vagrant_cwd
-        if vagrant_cwd != @env.cwd.to_s
-          ui.warn(I18n.t(
-            'vagrant.moved_cwd',
-            old_wd:     vagrant_cwd,
-            current_wd: @env.cwd.to_s))
-
-          File.write(vagrant_cwd_filepath, @env.cwd)
-        end
-      else
+      if vagrant_cwd.nil?
+        File.write(vagrant_cwd_filepath, @env.cwd)
+      elsif vagrant_cwd != @env.cwd.to_s
+        ui.warn(I18n.t(
+          'vagrant.moved_cwd',
+          old_wd:     vagrant_cwd,
+          current_wd: @env.cwd.to_s))
         File.write(vagrant_cwd_filepath, @env.cwd)
       end
     end

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -170,7 +170,7 @@ module Vagrant
       # Extra env keys are the remaining opts
       extra_env = opts.dup
 
-      check_cwd
+      check_cwd # Warns the UI if the machine was last used on a different dir
 
       # Create a deterministic ID for this machine
       vf = nil

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -165,6 +165,10 @@ en:
       description of what they do.
 
       %{list}
+    moved_cwd: |-
+      This machine used to live in %{old_wd} but it's now at %{current_wd}.
+      Please change the name of the machine if you want to run it as a different
+      machine.
     guest_deb_installing_smb: |-
       Installing SMB "mount.cifs"...
     global_status_footer: |-

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -307,6 +307,28 @@ describe Vagrant::Machine do
       expect { instance.action(action_name) }.
         to raise_error(Vagrant::Errors::UnimplementedProviderAction)
     end
+
+    it 'should warn if the machine was last run under a different directory' do
+      action_name  = :up
+      callable     = lambda { |_env| }
+      original_cwd = env.cwd.to_s
+
+      allow(provider).to receive(:action).with(action_name).and_return(callable)
+      allow(subject.ui).to receive(:warn)
+
+      instance.action(action_name)
+
+      expect(subject.ui).to_not have_received(:warn)
+
+      # Whenever the machine is run on a different directory, the user is warned
+      allow(env).to receive(:cwd).and_return('/a/new/path')
+      instance.action(action_name)
+
+      expect(subject.ui).to have_received(:warn) do |warn_msg|
+        expect(warn_msg).to include(original_cwd)
+        expect(warn_msg).to include('/a/new/path')
+      end
+    end
   end
 
   describe "#action_raw" do

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -308,6 +308,23 @@ describe Vagrant::Machine do
         to raise_error(Vagrant::Errors::UnimplementedProviderAction)
     end
 
+    it 'should not warn if the machines cwd has not changed' do
+      initial_action_name  = :up
+      second_action_name  = :reload
+      callable     = lambda { |_env| }
+      original_cwd = env.cwd.to_s
+
+      allow(provider).to receive(:action).with(initial_action_name).and_return(callable)
+      allow(provider).to receive(:action).with(second_action_name).and_return(callable)
+      allow(subject.ui).to receive(:warn)
+
+      instance.action(initial_action_name)
+      expect(subject.ui).to_not have_received(:warn)
+
+      instance.action(second_action_name)
+      expect(subject.ui).to_not have_received(:warn)
+    end
+
     it 'should warn if the machine was last run under a different directory' do
       action_name  = :up
       callable     = lambda { |_env| }


### PR DESCRIPTION
If an existing machine moves locations on disk, vagrant should warn the user about this and inform them to change the name of the machine. This warning is to inform users that if they copy a Vagrantfile to a new location, they are still managing the same vm and not two different vms with the same name.

This PR introduces a new internal state file to keep track of a machines location. Then for each machine action, it will check this state file to see if the location of the machine has changed, and if it has warn the user about this new location.

Replaces #8188 
Fixes #3921 