### PR TITLE
fix `docker-compose` check on `PATH`

### DIFF
--- a/plugins/providers/docker/driver/compose.rb
+++ b/plugins/providers/docker/driver/compose.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
         #
         # @param [Vagrant::Machine] machine Machine instance for this driver
         def initialize(machine)
-          if !Vagrant::Util::Which.which("vagrant-compose")
+          if !Vagrant::Util::Which.which("docker-compose")
             raise Errors::DockerComposeNotInstalledError
           end
           super()


### PR DESCRIPTION
Although `docker-compose` was executable and on the `PATH` the `docker` provider outputted an error indicating that it couldn't find it.

```
Vagrant has been instructed to use to use the Compose driver for the
Docker plugin but was unable to locate the `docker-compose` executable.
Ensure that `docker-compose` is installed and available on the PATH.
```

`vagrant` incorrectly checked for `vagrant-compose` instead of `docker-compose`.
