### PR TITLE
Use default cipher list for ssh communicator

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -348,6 +348,14 @@ module VagrantPlugins
         auth_methods << "publickey" if ssh_info[:private_key_path]
         auth_methods << "password" if ssh_info[:password]
 
+        # yanked directly from ruby's Net::SSH, but with `none` last
+        # TODO: Remove this once Vagrant has updated its dependency on Net:SSH
+        # to be > 4.1.0, which should include this fix.
+        cipher_array = Net::SSH::Transport::Algorithms::ALGORITHMS[:encryption].dup
+        if cipher_array.delete("none")
+          cipher_array.push("none")
+        end
+
         # Build the options we'll use to initiate the connection via Net::SSH
         common_connect_opts = {
           auth_methods:          auth_methods,
@@ -361,6 +369,7 @@ module VagrantPlugins
           timeout:               15,
           user_known_hosts_file: [],
           verbose:               :debug,
+          encryption:            cipher_array,
         }
 
         # Connect to SSH, giving it a few tries

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -396,6 +396,20 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
         ).and_return(true)
         communicator.send(:connect)
       end
+
+      it "includes the default cipher array for encryption" do
+        cipher_array = %w(aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
+                         aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
+                         idea-cbc arcfour128 arcfour256 arcfour
+                         aes128-ctr aes192-ctr aes256-ctr
+                         cast128-ctr blowfish-ctr 3des-ctr none)
+        expect(Net::SSH).to receive(:start).with(
+          nil, nil, hash_including(
+            encryption: cipher_array
+          )
+        ).and_return(true)
+        communicator.send(:connect)
+      end
     end
 
     context "with keys_only disabled and paranoid enabled" do


### PR DESCRIPTION
Prior to this commit, the ssh communicator would use the default cipher
list in Net::SSH to negociate which ciphers it should use between hosts.
Due to a bug in Net::SSH and the position of the `none` cipher in its
default cipher list, if a host supported the none cipher, but also
only supported other ciphers that came after none in the default list,
it would accept none and attempt to use that cipher instead of the other
supported ciphers. This commit fixes that behavior by copying the
default cipher list from Net::SSH and placing none last in the list so
that other ciphers can be used in the negotiation before attempting to
use the unsecure none cipher.

Fixes #6640