### PR TITLE
Catch pip_args in FreeBSD's and SUSE's ansible_install

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module FreeBSD
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
         module SUSE
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else


### PR DESCRIPTION
While neither the FreeBSD provisioner nor the SUSE provisioner support
installing Ansible using pip their ansible_install methods still get
called with that fourth argument. The result being these errors when
Vagrant tries to install Ansible.

    /opt/vagrant/embedded/gems/gems/vagrant-1.9.5/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb:10:in `ansible_install': wrong number of arguments (4 for 3) (ArgumentError)
    /opt/vagrant/embedded/gems/gems/vagrant-1.9.5/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb:9:in `ansible_install': wrong number of arguments (4 for 3) (ArgumentError)

The Arch provider, it too without pip support, already catches the
pip_args argument this way.