### PR TITLE
Fixes #8677 - Detect the result of the has_vmcx_support.ps1 properly

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
             end
           end
 
-          vmcx_support = env[:machine].provider.driver.execute("has_vmcx_support.ps1", {})
+          vmcx_support = env[:machine].provider.driver.execute("has_vmcx_support.ps1", {})['result']
           if vmcx_support
             vm_dir.each_child do |f|
               if f.extname.downcase == '.vmcx'


### PR DESCRIPTION
Fixes #8677

This was found on a windows 2012 R2 box when upgrading to 1.9.5. It's not correctly using the output of the has_vmcx_support check so is trying to use it and giving a very cryptic error message:

Compare-VM : A parameter that is not valid was passed to the operation.
