### PR TITLE
Add a unique identifier to provision objects

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -145,18 +145,16 @@ module VagrantPlugins
           new_provs   = []
           other_provs = other.provisioners.dup
           @provisioners.each do |p|
-            if p.name
-              other_p = other_provs.find { |o| p.name == o.name }
-              if other_p
-                # There is an override. Take it.
-                other_p.config = p.config.merge(other_p.config)
-                other_p.run    ||= p.run
-                next if !other_p.preserve_order
+            other_p = other_provs.find { |o| p.id == o.id }
+            if other_p
+              # There is an override. Take it.
+              other_p.config = p.config.merge(other_p.config)
+              other_p.run    ||= p.run
+              next if !other_p.preserve_order
 
-                # We're preserving order, delete from other
-                p = other_p
-                other_provs.delete(other_p)
-              end
+              # We're preserving order, delete from other
+              p = other_p
+              other_provs.delete(other_p)
             end
 
             # There is an override, merge it into the

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -9,6 +9,15 @@ module VagrantPlugins
       # @return [String]
       attr_reader :name
 
+      # Internal unique name for this provisioner
+      # Set to the given :name if exists, otherwise
+      # it's set as a UUID.
+      #
+      # Note: This is for internal use only.
+      #
+      # @return [String]
+      attr_reader :id
+
       # The type of the provisioner that should be registered
       # as a plugin.
       #
@@ -35,6 +44,7 @@ module VagrantPlugins
         @logger = Log4r::Logger.new("vagrant::config::vm::provisioner")
         @logger.debug("Provisioner defined: #{name}")
 
+        @id = name || SecureRandom.uuid
         @config  = nil
         @invalid = false
         @name    = name


### PR DESCRIPTION
Prior to this commit, Vagrant had no way internally to determine if a
provisioner object was unique if the `name` property was not set.
Because of this, when vagrant went to merge configs it would duplicate
an existing unnamed provisioner since it had no way of determining if a
user actually had added the same provisioner twice. This commit fixes
that by introducing an id which will default to `name` if its set, but
if not will be set by `SecureRandom.uuid`.

Fixes #7685