### PR TITLE
Add config option omnibus_url for chef provisioners

### DIFF
--- a/plugins/provisioners/chef/cap/debian/chef_install.rb
+++ b/plugins/provisioners/chef/cap/debian/chef_install.rb
@@ -5,11 +5,11 @@ module VagrantPlugins
     module Cap
       module Debian
         module ChefInstall
-          def self.chef_install(machine, project, version, channel, options = {})
+          def self.chef_install(machine, project, version, channel, omnibus_url, options = {})
             machine.communicate.sudo("apt-get update -y -qq")
             machine.communicate.sudo("apt-get install -y -qq curl")
 
-            command = Omnibus.sh_command(project, version, channel, options)
+            command = Omnibus.sh_command(project, version, channel, omnibus_url, options)
             machine.communicate.sudo(command)
           end
         end

--- a/plugins/provisioners/chef/cap/freebsd/chef_install.rb
+++ b/plugins/provisioners/chef/cap/freebsd/chef_install.rb
@@ -5,10 +5,10 @@ module VagrantPlugins
     module Cap
       module FreeBSD
         module ChefInstall
-          def self.chef_install(machine, project, version, channel, options = {})
+          def self.chef_install(machine, project, version, channel, omnibus_url, options = {})
             machine.communicate.sudo("pkg install -y -qq curl bash")
 
-            command = Omnibus.sh_command(project, version, channel, options)
+            command = Omnibus.sh_command(project, version, channel, omnibus_url, options)
             machine.communicate.sudo(command)
           end
         end

--- a/plugins/provisioners/chef/cap/omnios/chef_install.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_install.rb
@@ -5,12 +5,12 @@ module VagrantPlugins
     module Cap
       module OmniOS
         module ChefInstall
-          def self.chef_install(machine, project, version, channel, options = {})
+          def self.chef_install(machine, project, version, channel, omnibus_url, options = {})
             su = machine.config.solaris.suexec_cmd
 
             machine.communicate.execute("#{su} pkg list --no-refresh web/curl > /dev/null 2>&1 || pkg install -q --accept web/curl")
 
-            command = Omnibus.sh_command(project, version, channel, options)
+            command = Omnibus.sh_command(project, version, channel, omnibus_url, options)
             machine.communicate.execute("#{su} #{command}")
           end
         end

--- a/plugins/provisioners/chef/cap/redhat/chef_install.rb
+++ b/plugins/provisioners/chef/cap/redhat/chef_install.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
     module Cap
       module Redhat
         module ChefInstall
-          def self.chef_install(machine, project, version, channel, options = {})
+          def self.chef_install(machine, project, version, channel, omnibus_url, options = {})
             machine.communicate.sudo <<-EOH.gsub(/^ {14}/, '')
               if command -v dnf; then
                 dnf -y install curl
@@ -14,7 +14,7 @@ module VagrantPlugins
               fi
             EOH
 
-            command = Omnibus.sh_command(project, version, channel, options)
+            command = Omnibus.sh_command(project, version, channel, omnibus_url, options)
             machine.communicate.sudo(command)
           end
         end

--- a/plugins/provisioners/chef/cap/suse/chef_install.rb
+++ b/plugins/provisioners/chef/cap/suse/chef_install.rb
@@ -5,13 +5,13 @@ module VagrantPlugins
     module Cap
       module Suse
         module ChefInstall
-          def self.chef_install(machine, project, version, channel, options = {})
+          def self.chef_install(machine, project, version, channel, omnibus_url, options = {})
             unless curl?(machine)
               machine.communicate.sudo("zypper -n -q update")
               machine.communicate.sudo("zypper -n -q install curl")
             end
 
-            command = Omnibus.sh_command(project, version, channel, options)
+            command = Omnibus.sh_command(project, version, channel, omnibus_url, options)
             machine.communicate.sudo(command)
           end
 

--- a/plugins/provisioners/chef/cap/windows/chef_install.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_install.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
     module Cap
       module Windows
         module ChefInstall
-          def self.chef_install(machine, project, version, channel, options = {})
-            command = Omnibus.ps_command(project, version, channel, options)
+          def self.chef_install(machine, project, version, channel, omnibus_url, options = {})
+            command = Omnibus.ps_command(project, version, channel, omnibus_url, options)
             machine.communicate.sudo(command)
           end
         end

--- a/plugins/provisioners/chef/config/base.rb
+++ b/plugins/provisioners/chef/config/base.rb
@@ -56,6 +56,21 @@ module VagrantPlugins
         # @return [String]
         attr_accessor :version
 
+        # Location of Omnibus installation scripts.
+        # This URL specifies the location of install.sh/install.ps1 for
+        # Linux/Unix and Windows respectively.
+        #
+        # It defaults to https://omnitruck.chef.io/. The full URL is then:
+        #  - Linux/Unix: https://omnitruck.chef.io/install.sh
+        #  - Windows: https://omnitruck.chef.io/install.ps1
+        #
+        # If you want to have https://example.com/install.sh as Omnibus script
+        # for your Linux/Unix installations, you should set this option to
+        # https://example.com
+        #
+        # @return [String]
+        attr_accessor :omnibus_url
+
         # The path where the Chef installer will be downloaded to. Only valid if
         # install is true or "force". It defaults to nil, which means that the
         # omnibus installer will choose the destination and you have no control
@@ -74,6 +89,7 @@ module VagrantPlugins
           @log_level   = UNSET_VALUE
           @channel     = UNSET_VALUE
           @version     = UNSET_VALUE
+          @omnibus_url = UNSET_VALUE
           @installer_download_path = UNSET_VALUE
         end
 
@@ -85,6 +101,7 @@ module VagrantPlugins
           @log_level   = :info     if @log_level == UNSET_VALUE
           @channel     = "stable"  if @channel == UNSET_VALUE
           @version     = :latest   if @version == UNSET_VALUE
+          @omnibus_url = 'https://omnitruck.chef.io' if @omnibus_url == UNSET_VALUE
           @installer_download_path = nil  if @installer_download_path == UNSET_VALUE
 
           # Make sure the install is a symbol if it's not a boolean

--- a/plugins/provisioners/chef/installer.rb
+++ b/plugins/provisioners/chef/installer.rb
@@ -2,12 +2,13 @@ module VagrantPlugins
   module Chef
     class Installer
       def initialize(machine, options = {})
-        @machine    = machine
-        @product    = options.fetch(:product)
-        @channel    = options.fetch(:channel)
-        @version    = options.fetch(:version)
-        @force      = options.fetch(:force)
-        @options    = options.dup
+        @machine     = machine
+        @product     = options.fetch(:product)
+        @channel     = options.fetch(:channel)
+        @version     = options.fetch(:version)
+        @force       = options.fetch(:force)
+        @omnibus_url = options.fetch(:omnibus_url)
+        @options     = options.dup
       end
 
       # This handles verifying the Chef installation, installing it if it was
@@ -29,7 +30,7 @@ module VagrantPlugins
 
         @machine.ui.detail(I18n.t("vagrant.chef_installing",
           version: @version.to_s))
-        @machine.guest.capability(:chef_install, @product, @version, @channel, @options)
+        @machine.guest.capability(:chef_install, @product, @version, @channel, @omnibus_url, @options)
 
         if !@machine.guest.capability(:chef_installed, @product, @version)
           raise Provisioner::Base::ChefError, :install_failed

--- a/plugins/provisioners/chef/omnibus.rb
+++ b/plugins/provisioners/chef/omnibus.rb
@@ -5,10 +5,8 @@ module VagrantPlugins
     #   https://docs.chef.io/install_omnibus.html
     #
     module Omnibus
-      OMNITRUCK = "https://omnitruck.chef.io".freeze
-
-      def sh_command(project, version, channel, options = {})
-        command =  "curl -sL #{OMNITRUCK}/install.sh | bash"
+      def sh_command(project, version, channel, omnibus_url, options = {})
+        command =  "curl -sL #{omnibus_url}/install.sh | bash"
         command << " -s -- -P \"#{project}\" -c \"#{channel}\""
 
         if version != :latest
@@ -23,8 +21,8 @@ module VagrantPlugins
       end
       module_function :sh_command
 
-      def ps_command(project, version, channel, options = {})
-        command =  ". { iwr -useb #{OMNITRUCK}/install.ps1 } | iex; install"
+      def ps_command(project, version, channel, omnibus_url, options = {})
+        command =  ". { iwr -useb #{omnibus_url}/install.ps1 } | iex; install"
         command << " -project '#{project}' -channel '#{channel}'"
 
         if version != :latest

--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
             product: config.product,
             channel: config.channel,
             version: config.version,
+            omnibus_url: config.omnibus_url,
             force: config.install == :force,
             download_path:  config.installer_download_path
           )

--- a/test/unit/plugins/provisioners/chef/config/base_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/base_test.rb
@@ -82,4 +82,17 @@ describe VagrantPlugins::Chef::Config::Base do
       expect(subject.installer_download_path).to be(nil)
     end
   end
+
+  describe "#omnibus_url" do
+    it "defaults to https://omnitruck.chef.io" do
+      subject.finalize!
+      expect(subject.omnibus_url).to eq("https://omnitruck.chef.io")
+    end
+
+    it "makes use of the configured url" do
+      subject.omnibus_url = "https://omnitruck.example.com"
+      subject.finalize!
+      expect(subject.omnibus_url).to eq("https://omnitruck.example.com")
+    end
+  end
 end

--- a/test/unit/plugins/provisioners/chef/omnibus_test.rb
+++ b/test/unit/plugins/provisioners/chef/omnibus_test.rb
@@ -5,22 +5,27 @@ require Vagrant.source_root.join("plugins/provisioners/chef/omnibus")
 describe VagrantPlugins::Chef::Omnibus do
   describe "#sh_command" do
     it "includes the project name" do
-      command = described_class.sh_command("chef", nil, "stable")
+      command = described_class.sh_command("chef", nil, "stable", "https://omnitruck.chef.io")
       expect(command).to include %|-P "chef"|
     end
 
     it "includes the channel" do
-      command = described_class.sh_command("chef", nil, "stable")
+      command = described_class.sh_command("chef", nil, "stable", "https://omnitruck.chef.io")
       expect(command).to include %|-c "stable"|
     end
 
     it "includes the version" do
-      command = described_class.sh_command("chef", "1.2.3", "stable")
+      command = described_class.sh_command("chef", "1.2.3", "stable", "https://omnitruck.chef.io")
       expect(command).to include %|-v "1.2.3"|
     end
 
+    it "includes the Omnibus installation URL" do
+      command = described_class.sh_command("chef", "1.2.3", "stable", "https://omnitruck.chef.io")
+      expect(command).to include %|https://omnitruck.chef.io/install.sh|
+    end
+
     it "includes the download path" do
-      command = described_class.sh_command("chef", "1.2.3", "stable",
+      command = described_class.sh_command("chef", "1.2.3", "stable", "https://omnitruck.chef.io",
         download_path: "/some/path",
       )
       expect(command).to include %|-d "/some/path"|
@@ -29,18 +34,23 @@ describe VagrantPlugins::Chef::Omnibus do
 
   describe "#ps_command" do
     it "includes the project name" do
-      command = described_class.ps_command("chef", nil, "stable")
+      command = described_class.ps_command("chef", nil, "stable", "https://omnitruck.chef.io")
       expect(command).to include %|-project 'chef'|
     end
 
     it "includes the channel" do
-      command = described_class.ps_command("chef", nil, "stable")
+      command = described_class.ps_command("chef", nil, "stable", "https://omnitruck.chef.io")
       expect(command).to include %|-channel 'stable'|
     end
 
     it "includes the version" do
-      command = described_class.ps_command("chef", "1.2.3", "stable")
+      command = described_class.ps_command("chef", "1.2.3", "stable", "https://omnitruck.chef.io")
       expect(command).to include %|-version '1.2.3'|
+    end
+
+    it "includes the Omnibus installation URL" do
+      command = described_class.ps_command("chef", "1.2.3", "stable", "https://omnitruck.chef.io")
+      expect(command).to include %|https://omnitruck.chef.io/install.ps1|
     end
   end
 end

--- a/website/source/docs/provisioning/chef_common.html.md
+++ b/website/source/docs/provisioning/chef_common.html.md
@@ -59,12 +59,22 @@ understand their purpose.
   requested version. If they match, no action is taken. If they do not match,
   the value specified in this attribute will be installed in favor of the
   existing version (a message will be displayed).
-  
   You can also specify "latest" (default), which will install the latest
   version of Chef on the system. In this case, Chef will use whatever
   version is on the system. To force the newest version of Chef to be
   installed on every provision, set the [`install`](#install) option to "force".
 
+- `omnibus_url` (string) - Location of Omnibus installation scripts.
+  This URL specifies the location of install.sh/install.ps1 for
+  Linux/Unix and Windows respectively.
+  It defaults to https://omnitruck.chef.io. The full URL is in this case:
+
+   - Linux/Unix: https://omnitruck.chef.io/install.sh
+   - Windows: https://omnitruck.chef.io/install.ps1
+
+  If you want to have https://example.com/install.sh as Omnibus script
+  for your Linux/Unix installations, you should set this option to
+  https://example.com
 
 ## Runner Chef Provisioners
 


### PR DESCRIPTION
This option is useful for internal setups, where own customized
omnibus installation script is used (e.g. to get chef from a mirror)