### PR TITLE
Use proper snapshot subcommand anchors

### DIFF
--- a/website/source/docs/cli/snapshot.html.md
+++ b/website/source/docs/cli/snapshot.html.md
@@ -21,12 +21,12 @@ Vagrant will give you an error message.
 
 The main functionality of this command is exposed via even more subcommands:
 
-* `push`
-* `pop`
-* `save`
-* `restore`
-* `list`
-* `delete`
+* [`push`](#snapshot-push)
+* [`pop`](#snapshot-pop)
+* [`save`](#snapshot-save)
+* [`restore`](#snapshot-restore)
+* [`list`](#snapshot-list)
+* [`delete`](#snapshot-delete)
 
 # Snapshot Push
 


### PR DESCRIPTION
Fixes the website's anchors for the snapshot subcommands as they currently have invalid targets