### PR TITLE
guests/smartos: Add/fix various guest capabilities

### DIFF
--- a/test/unit/plugins/guests/smartos/cap/insert_public_key_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/insert_public_key_test.rb
@@ -11,7 +11,7 @@ describe "VagrantPlugins::GuestSmartos::Cap::InsertPublicKey" do
   let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
 
   before do
-    allow(machine).to receive(:communicate).and_return(comm)
+    machine.stub(:communicate).and_return(comm)
   end
 
   after do


### PR DESCRIPTION
This commit adds a variety of fixes for SmartOS guest support:

- Host name setting now works in the global zone and in non-global zones
- NFS now works in the global zone and the non-global zone.
- Tests are updated and moved to the (apparently) more modern style

cc: @sean-