### PR TITLE
Fix vagrant_cwd warnings

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -577,13 +577,13 @@ module Vagrant
       end
 
       if vagrant_cwd.nil?
-        File.write(vagrant_cwd_filepath, @env.cwd)
-      elsif vagrant_cwd != @env.cwd.to_s
+        File.write(vagrant_cwd_filepath, @env.root_path)
+      elsif vagrant_cwd != @env.root_path.to_s
         ui.warn(I18n.t(
           'vagrant.moved_cwd',
           old_wd:     vagrant_cwd,
-          current_wd: @env.cwd.to_s))
-        File.write(vagrant_cwd_filepath, @env.cwd)
+          current_wd: @env.root_path.to_s))
+        File.write(vagrant_cwd_filepath, @env.root_path)
       end
     end
   end

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -338,12 +338,34 @@ describe Vagrant::Machine do
       expect(subject.ui).to_not have_received(:warn)
 
       # Whenever the machine is run on a different directory, the user is warned
-      allow(env).to receive(:cwd).and_return('/a/new/path')
+      allow(env).to receive(:root_path).and_return('/a/new/path')
       instance.action(action_name)
 
       expect(subject.ui).to have_received(:warn) do |warn_msg|
         expect(warn_msg).to include(original_cwd)
         expect(warn_msg).to include('/a/new/path')
+      end
+    end
+
+    context "if in a subdir" do
+      let (:data_dir) { env.cwd }
+
+      it 'should not warn if vagrant is run in subdirectory' do
+        action_name  = :up
+        callable     = lambda { |_env| }
+        original_cwd = env.cwd.to_s
+
+        allow(provider).to receive(:action).with(action_name).and_return(callable)
+        allow(subject.ui).to receive(:warn)
+
+        instance.action(action_name)
+
+        expect(subject.ui).to_not have_received(:warn)
+        # mock out cwd to be subdir and ensure no warn is printed
+        allow(env).to receive(:cwd).and_return("#{original_cwd}/a/new/path")
+
+        instance.action(action_name)
+        expect(subject.ui).to_not have_received(:warn)
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, if a user ran a vagrant command within a subdir,
it would warn about the cwd changing which is not actually the case.
This commit adds an additional check to see if vagrant is being invoked
within a subdirectory so that it doesn't warn the user.