### PR TITLE
Invoke tee from specific path

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -111,7 +111,7 @@ module VagrantPlugins
             line = Vagrant::Util::ShellQuote.escape(line, "'")
             system(
               "echo '#{line}' | " +
-              "#{sudo_command}tee -a /etc/exports >/dev/null")
+              "#{sudo_command}/usr/bin/tee -a /etc/exports >/dev/null")
           end
 
           # We run restart here instead of "update" just in case nfsd


### PR DESCRIPTION
This commit updates the use of `tee` to use an explicit path when
invoked rather than relying on where `tee` has been defined in a users
PATH.

Fixes #6913