### PR TITLE
Remove PATH based cygwin detection

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -11,21 +11,12 @@ module Vagrant
     class Platform
       class << self
         def cygwin?
-          return @_cygwin if defined?(@_cygwin)
-          @_cygwin = -> {
-            # Installer detects Cygwin
-            return true if ENV["VAGRANT_DETECTED_OS"] &&
-              ENV["VAGRANT_DETECTED_OS"].downcase.include?("cygwin")
-
-            # Ruby running in Cygwin
-            return true if platform.include?("cygwin")
-
-            # Heuristic. If the path contains Cygwin, we just assume we're
-            # in Cygwin. It is generally a safe bet.
-            path = ENV["PATH"] || ""
-            return path.include?("cygwin")
-          }.call
-          return @_cygwin
+          if !defined?(@_cygwin)
+            @_cygwin = ENV["VAGRANT_DETECTED_OS"].to_s.downcase.include?("cygwin") ||
+              platform.include?("cygwin") ||
+              ENV["OSTYPE"].to_s.downcase.include?("cygwin")
+          end
+          @_cygwin
         end
 
         def wsl?

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -29,14 +29,20 @@ describe Vagrant::Util::Platform do
       end
     end
 
+    it "returns true if OSTYPE includes cygwin" do
+      with_temp_env(OSTYPE: "cygwin") do
+        expect(subject).to be_cygwin
+      end
+    end
+
     it "returns true if platform has cygwin" do
       allow(subject).to receive(:platform).and_return("cygwin")
       expect(subject).to be_cygwin
     end
 
-    it "returns true if the PATH contains cygwin" do
+    it "returns false if the PATH contains cygwin" do
       with_temp_env(PATH: "C:/cygwin") do
-        expect(subject).to be_cygwin
+        expect(subject).to_not be_cygwin
       end
     end
 


### PR DESCRIPTION
Detecting cygwin via PATH contents can result in false positives
resulting in errors when using Vagrant on Windows outside of a
cygwin shell. Use environment based detection instead.

Fixes #6788