### PR TITLE
Only rsync-auto current working dir with docker provider

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -218,6 +218,8 @@ en:
       have specified `rsync_auto` to be false.
     rsync_auto_path: |-
       Watching: %{path}
+    rsync_auto_remove_folder: |-
+      Not syncing %{folder} as it is not part of the current working directory.
     rsync_auto_rsync_error: |-
       There was an error while executing rsync. The error is shown below.
       This may not be critical since rsync sometimes fails, but if this message


### PR DESCRIPTION
Prior to this commit, when users invoked the `rsync-auto` command using
the docker provider with boot2docker, vagrant would rsync all known
containers using the boot2docker vm rather than the current working dir.
This commit updates that behavior to ensure that only the current
working dirs vagrant machines will be rsynced.

Fixes #5160