### PR TITLE
Fix vagrant not being able to list network devices on some FreeBSD boxes.

### DIFF
--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
           # Remove any previous network additions to the configuration file.
           commands << "sed -i'' -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/rc.conf"
 
-          comm.sudo("ifconfig -a | grep -o ^[0-9a-z]* | grep -v '^lo'", options) do |_, stdout|
+          comm.sudo("ifconfig -a | grep -o '^[0-9a-z]*' | grep -v '^lo'", options) do |_, stdout|
             interfaces = stdout.split("\n")
           end
 

--- a/test/unit/plugins/guests/freebsd/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/freebsd/cap/configure_networks_test.rb
@@ -13,7 +13,7 @@ describe "VagrantPlugins::GuestFreeBSD::Cap::ConfigureNetworks" do
 
   before do
     allow(machine).to receive(:communicate).and_return(comm)
-    comm.stub_command("ifconfig -a | grep -o ^[0-9a-z]* | grep -v '^lo'",
+    comm.stub_command("ifconfig -a | grep -o '^[0-9a-z]*' | grep -v '^lo'",
       stdout: "em1\nem2")
   end
 


### PR DESCRIPTION
When attempting to start a new FreeBSD-11.1-RC1 box you are given the following error:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

ifconfig -a | grep -o ^[0-9a-z]* | grep -v '^lo'

Stdout from the command:

Stderr from the command:
```

I ssh'd into the box to make sure the code changes work:

```
vagrant@:~ % ifconfig -a | grep -o ^[0-9a-z]*
grep: No match.
vagrant@:~ % ifconfig -a | grep -o '^[0-9a-z]*'
em0
em1
lo0
```

Sample Vagrantfile:

```
Vagrant.configure("2") do |config|
    config.vm.guest = :freebsd
    config.vm.box = "freebsd/FreeBSD-11.1-RC1"
    config.vm.box_check_update = true
    config.ssh.shell = "sh"
    config.vm.network :private_network, ip: "192.168.10.10"
    config.vm.base_mac = "0800270CA7EB"
    config.vm.synced_folder ".", "/vagrant", disabled: true
end
```