### PR TITLE
Docs: fix path of Vagrant location for OSX

### DIFF
--- a/website/source/docs/installation/uninstallation.html.md
+++ b/website/source/docs/installation/uninstallation.html.md
@@ -28,7 +28,7 @@ On **Windows**
 On **Mac OS X**:
 
 ```sh
-rm -rf /Applications/Vagrant
+rm -rf /opt/vagrant
 rm -f /usr/local/bin/vagrant
 sudo pkgutil --forget com.vagrant.vagrant
 ```


### PR DESCRIPTION
Fix location of Vagrant directory in OSX uninstall doc.