### PR TITLE
Remove duplicate stdout, stderr output from salt

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -331,10 +331,15 @@ module VagrantPlugins
 
       def call_overstate
         if @config.run_overstate
+          # If verbose is on, do not duplicate a failed command's output in the error message.
+          ssh_opts = {}
+          if @config.verbose
+            ssh_opts = { error_key: :ssh_bad_exit_status_muted }
+          end
           if @config.install_master
             @machine.env.ui.info "Calling state.overstate... (this may take a while)"
             @machine.communicate.sudo("salt '*' saltutil.sync_all")
-            @machine.communicate.sudo("salt-run state.over") do |type, data|
+            @machine.communicate.sudo("salt-run state.over", ssh_opts) do |type, data|
               if @config.verbose
                 @machine.env.ui.info(data)
               end
@@ -349,12 +354,18 @@ module VagrantPlugins
 
       def call_highstate
         if @config.run_highstate
+          # If verbose is on, do not duplicate a failed command's output in the error message.
+          ssh_opts = {}
+          if @config.verbose
+            ssh_opts = { error_key: :ssh_bad_exit_status_muted }
+          end
+
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
             unless @config.masterless?
               @machine.communicate.sudo("salt '*' saltutil.sync_all")
             end
-            @machine.communicate.sudo("salt '*' state.highstate --verbose#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+            @machine.communicate.sudo("salt '*' state.highstate --verbose#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}", ssh_opts) do |type, data|
             if @config.verbose
                 @machine.env.ui.info(data.rstrip)
             end
@@ -365,6 +376,7 @@ module VagrantPlugins
               unless @config.masterless?
                 @machine.communicate.execute("C:\\salt\\salt-call.bat saltutil.sync_all", opts)
               end
+              # TODO: something equivalent to { error_key: :ssh_bad_exit_status_muted }?
               @machine.communicate.execute("C:\\salt\\salt-call.bat state.highstate --retcode-passthrough#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}", opts) do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
@@ -374,7 +386,7 @@ module VagrantPlugins
               unless @config.masterless?
                 @machine.communicate.sudo("salt-call saltutil.sync_all")
               end
-              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+              @machine.communicate.sudo("salt-call state.highstate --retcode-passthrough#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}", ssh_opts) do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data.rstrip)
                 end
@@ -403,14 +415,20 @@ module VagrantPlugins
           end
         end
 
+        # If verbose is on, do not duplicate a failed command's output in the error message.
+        ssh_opts = {}
+        if @config.verbose
+          ssh_opts = { error_key: :ssh_bad_exit_status_muted }
+        end
+
         @machine.env.ui.info "Running the following orchestrations: #{@config.orchestrations}"
         @machine.env.ui.info "Running saltutil.sync_all before orchestrating"
-        @machine.communicate.sudo("salt '*' saltutil.sync_all", &log_output)
+        @machine.communicate.sudo("salt '*' saltutil.sync_all", ssh_opts, &log_output)
 
         @config.orchestrations.each do |orchestration|
           cmd = "salt-run -l info state.orchestrate #{orchestration}"
           @machine.env.ui.info "Calling #{cmd}... (this may take a while)"
-          @machine.communicate.sudo(cmd, &log_output)
+          @machine.communicate.sudo(cmd, ssh_opts, &log_output)
         end
       end
 


### PR DESCRIPTION
This PR addresses https://github.com/mitchellh/vagrant/issues/8747 by hiding duplicate stdout and stderr output from failed salt runs when verbose mode is on.
