### PR TITLE
Added exception if chef.node_path is defined on Vagrantfile but the directory does not exist locally

### DIFF
--- a/plugins/provisioners/chef/config/chef_zero.rb
+++ b/plugins/provisioners/chef/config/chef_zero.rb
@@ -79,6 +79,13 @@ module VagrantPlugins
 
           if !present?(Array(nodes_path))
             errors << I18n.t("vagrant.config.chef.nodes_path_empty")
+          else
+            missing_paths = Array.new
+            nodes_path.each { |dir| missing_paths << dir[1] if !File.exists? dir[1] }
+            # If it exists at least one path on disk it's ok for Chef provisioning
+            if missing_paths.size == nodes_path.size
+              errors << I18n.t("vagrant.config.chef.nodes_path_missing", path: missing_paths.to_s)
+            end
           end
 
           if environment && environments_path.empty?

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -87,7 +87,8 @@ module VagrantPlugins
                 key         = Digest::MD5.hexdigest(local_path)
                 remote_path = "#{guest_provisioning_path}/#{key}"
               else
-                @machine.ui.warn(I18n.t("vagrant.provisioners.chef.cookbook_folder_not_found_warning",
+                appended_folder = "cookbooks" if appended_folder.nil?
+                @machine.ui.warn(I18n.t("vagrant.provisioners.chef.#{appended_folder}_folder_not_found_warning",
                                        path: local_path.to_s))
                 next
               end

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -35,7 +35,6 @@ module VagrantPlugins
           upload_encrypted_data_bag_secret
           setup_json
           setup_zero_config
-          verify_chef_nodes_folder
           run_chef_zero
           delete_encrypted_data_bag_secret
         end
@@ -99,12 +98,6 @@ module VagrantPlugins
             if !@machine.communicate.test("test -d #{folder}", sudo: true)
               raise ChefError, :missing_shared_folders
             end
-          end
-        end
-
-        def verify_chef_nodes_folder
-          if !File.exists? @config.nodes_path[0][1]
-            raise ChefError, :missing_chef_node_folder
           end
         end
 

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -103,7 +103,7 @@ module VagrantPlugins
         end
 
         def verify_chef_nodes_folder
-          if not File.exists? @config.nodes_path[0][1]
+          if !File.exists? @config.nodes_path[0][1]
             raise ChefError, :missing_chef_node_folder
           end
         end

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -35,6 +35,7 @@ module VagrantPlugins
           upload_encrypted_data_bag_secret
           setup_json
           setup_zero_config
+          verify_chef_nodes_folder
           run_chef_zero
           delete_encrypted_data_bag_secret
         end
@@ -98,6 +99,12 @@ module VagrantPlugins
             if !@machine.communicate.test("test -d #{folder}", sudo: true)
               raise ChefError, :missing_shared_folders
             end
+          end
+        end
+
+        def verify_chef_nodes_folder
+          if not File.exists? @config.nodes_path[0][1]
+            raise ChefError, :missing_chef_node_folder
           end
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2192,8 +2192,6 @@ en:
         running_solo_again: "Running chef-solo again (failed to converge)..."
         running_zero: "Running chef-client (local-mode)..."
         running_zero_again: "Running chef-client (local-mode) again (failed to converge)..."
-        missing_chef_node_folder: |-
-          Nodes folder that Chef requires is missing in this Vagrant project
         missing_shared_folders: |-
           Shared folders that Chef requires are missing on the virtual machine.
           This is usually due to configuration changing after already booting the

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1579,6 +1579,8 @@ en:
           Missing required value for `chef.nodes_path'.
         environment_path_missing: |-
           Environment path not found: %{path}
+        nodes_path_missing: |-
+          Path specified for `nodes_path` does not exist: %{path}
         environment_path_required: |-
           When 'environment' is specified, you must provide 'environments_path'.
         cookbooks_path_missing: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2192,6 +2192,8 @@ en:
         running_solo_again: "Running chef-solo again (failed to converge)..."
         running_zero: "Running chef-client (local-mode)..."
         running_zero_again: "Running chef-client (local-mode) again (failed to converge)..."
+        missing_chef_node_folder: |-
+          Nodes folder that Chef requires is missing in this Vagrant project
         missing_shared_folders: |-
           Shared folders that Chef requires are missing on the virtual machine.
           This is usually due to configuration changing after already booting the

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2160,8 +2160,16 @@ en:
           The chef binary (either `chef-solo` or `chef-client`) was not found on
           the VM and is required for chef provisioning. Please verify that chef
           is installed and that the binary is available on the PATH.
-        cookbook_folder_not_found_warning:
+        cookbooks_folder_not_found_warning:
           "The cookbook path '%{path}' doesn't exist. Ignoring..."
+        nodes_folder_not_found_warning:
+          "The node path '%{path}' doesn't exist. Ignoring..."
+        data_bags_folder_not_found_warning:
+          "The databag path '%{path}' doesn't exist. Ignoring..."
+        roles_folder_not_found_warning:
+          "The role path '%{path}' doesn't exist. Ignoring..."
+        environments_folder_not_found_warning:
+          "The environment path '%{path}' doesn't exist. Ignoring..."
         json: "Generating chef JSON and uploading..."
         client_key_folder: "Creating folder to hold client key..."
         generating_node_name: |-

--- a/test/unit/plugins/provisioners/chef/config/chef_zero_test.rb
+++ b/test/unit/plugins/provisioners/chef/config/chef_zero_test.rb
@@ -110,6 +110,17 @@ describe VagrantPlugins::Chef::Config::ChefZero do
       end
     end
 
+    context "when an element of nodes_path does not exist on disk" do
+      it "returns an error" do
+        nodes_path = ["/path/to/nodes/that/will/never/exist"]
+        subject.nodes_path = nodes_path
+        subject.finalize!
+        expect(errors).to include(I18n.t("vagrant.config.chef.nodes_path_missing",
+          path: nodes_path
+        ))
+      end
+    end
+
     context "when the nodes_path is an empty array" do
       it "returns an error" do
         subject.nodes_path = []


### PR DESCRIPTION
If you chef.node_path does not exist locally, the Chef provision generates an error related a chef_server_url instead say the real reason:

==> myvm: Resource Not Found:
==> myvm: -------------------
==> myvm: The server returned a HTTP 404. This usually indicates that your chef_server_url is incorrect.

I wrote a couple of lines for manage this error and warn the user for creating the folder locally.