### PR TITLE
winssh communicator: fix public key insertion

### DIFF
--- a/plugins/guests/windows/cap/public_key.rb
+++ b/plugins/guests/windows/cap/public_key.rb
@@ -50,6 +50,7 @@ module VagrantPlugins
           end
           comm.upload(keys_file.path, remote_upload_path)
           keys_file.delete
+          comm.execute("Set-Acl \"#{remote_upload_path}\" (Get-Acl \"#{remote_authkeys_path}\")", shell: "powershell")
           comm.execute("move /y \"#{remote_upload_path}\" \"#{remote_authkeys_path}\"", shell: "cmd")
         end
 
@@ -75,6 +76,7 @@ module VagrantPlugins
             File.write(keys_file.path, current_content.join("\r\n") + "\r\n")
             comm.upload(keys_file.path, remote_upload_path)
             keys_file.delete
+            comm.execute("Set-Acl \"#{remote_upload_path}\" (Get-Acl \"#{remote_authkeys_path}\")", shell: "powershell")
             comm.execute("move /y \"#{remote_upload_path}\" \"#{remote_authkeys_path}\"", shell: "cmd")
           end
         end

--- a/test/unit/plugins/guests/windows/cap/insert_public_key_test.rb
+++ b/test/unit/plugins/guests/windows/cap/insert_public_key_test.rb
@@ -42,7 +42,6 @@ describe "VagrantPlugins::GuestWindows::Cap::InsertPublicKey" do
         expect(comm).to receive(:download)
         expect(comm).to receive(:upload)
         expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
-        expect(comm).to receive(:execute).with(/move .*/, shell: "cmd")
         cap.insert_public_key(machine, "ssh-rsa ...")
         expect(File.read(@tempfile.path)).to include("ssh-rsa ...")
       end
@@ -58,7 +57,6 @@ describe "VagrantPlugins::GuestWindows::Cap::InsertPublicKey" do
         expect(comm).to_not receive(:download)
         expect(comm).to receive(:upload)
         expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
-        expect(comm).to receive(:execute).with(/move .*/, shell: "cmd")
         cap.insert_public_key(machine, "ssh-rsa ...")
         expect(File.read(@tempfile.path)).to include("ssh-rsa ...")
       end

--- a/test/unit/plugins/guests/windows/cap/insert_public_key_test.rb
+++ b/test/unit/plugins/guests/windows/cap/insert_public_key_test.rb
@@ -41,6 +41,7 @@ describe "VagrantPlugins::GuestWindows::Cap::InsertPublicKey" do
       it "inserts the public key" do
         expect(comm).to receive(:download)
         expect(comm).to receive(:upload)
+        expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
         expect(comm).to receive(:execute).with(/move .*/, shell: "cmd")
         cap.insert_public_key(machine, "ssh-rsa ...")
         expect(File.read(@tempfile.path)).to include("ssh-rsa ...")
@@ -56,6 +57,7 @@ describe "VagrantPlugins::GuestWindows::Cap::InsertPublicKey" do
       it "inserts the public key" do
         expect(comm).to_not receive(:download)
         expect(comm).to receive(:upload)
+        expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
         expect(comm).to receive(:execute).with(/move .*/, shell: "cmd")
         cap.insert_public_key(machine, "ssh-rsa ...")
         expect(File.read(@tempfile.path)).to include("ssh-rsa ...")

--- a/test/unit/plugins/guests/windows/cap/remove_public_key_test.rb
+++ b/test/unit/plugins/guests/windows/cap/remove_public_key_test.rb
@@ -27,6 +27,7 @@ describe "VagrantPlugins::GuestWindows::Cap::RemovePublicKey" do
     allow(machine).to receive(:communicate).and_return(comm)
 
     allow(comm).to receive(:execute).with(/echo .+/, shell: "cmd").and_yield(:stdout, "TEMP\r\nHOME\r\n")
+    allow(comm).to receive(:execute).with(/dir .+\.ssh/, shell: "cmd")
     allow(comm).to receive(:execute).with(/dir .+authorized_keys/, shell: "cmd", error_check: false).and_return(auth_keys_check_result)
   end
 
@@ -48,7 +49,6 @@ describe "VagrantPlugins::GuestWindows::Cap::RemovePublicKey" do
         expect(comm).to receive(:download)
         expect(comm).to receive(:upload)
         expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
-        expect(comm).to receive(:execute).with(/move .*/, shell: "cmd")
         cap.remove_public_key(machine, public_key_insecure)
         expect(File.read(@tempfile.path)).to include(public_key_other)
         expect(File.read(@tempfile.path)).to_not include(public_key_insecure)
@@ -58,9 +58,8 @@ describe "VagrantPlugins::GuestWindows::Cap::RemovePublicKey" do
     context "when authorized_keys does not exist on guest" do
       it "does nothing" do
         expect(comm).to_not receive(:download)
-        expect(comm).to_not receive(:upload)
-        expect(comm).to_not receive(:execute).with(/Set-Acl .*/, shell: "powershell")
-        expect(comm).to_not receive(:execute).with(/move .*/, shell: "cmd")
+        expect(comm).to receive(:upload)
+        expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
         cap.remove_public_key(machine, public_key_insecure)
       end
     end

--- a/test/unit/plugins/guests/windows/cap/remove_public_key_test.rb
+++ b/test/unit/plugins/guests/windows/cap/remove_public_key_test.rb
@@ -47,6 +47,7 @@ describe "VagrantPlugins::GuestWindows::Cap::RemovePublicKey" do
       it "removes the public key" do
         expect(comm).to receive(:download)
         expect(comm).to receive(:upload)
+        expect(comm).to receive(:execute).with(/Set-Acl .*/, shell: "powershell")
         expect(comm).to receive(:execute).with(/move .*/, shell: "cmd")
         cap.remove_public_key(machine, public_key_insecure)
         expect(File.read(@tempfile.path)).to include(public_key_other)
@@ -58,6 +59,7 @@ describe "VagrantPlugins::GuestWindows::Cap::RemovePublicKey" do
       it "does nothing" do
         expect(comm).to_not receive(:download)
         expect(comm).to_not receive(:upload)
+        expect(comm).to_not receive(:execute).with(/Set-Acl .*/, shell: "powershell")
         expect(comm).to_not receive(:execute).with(/move .*/, shell: "cmd")
         cap.remove_public_key(machine, public_key_insecure)
       end


### PR DESCRIPTION
we need to retain the authorized_keys file acl permissions because the [OpenSSH v0.0.17.0](https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v0.0.17.0) enforces them by default (and refuses to work without the correct acl).