### PR TITLE
Fix minor typo in website documentation

### DIFF
--- a/website/source/docs/networking/forwarded_ports.html.md
+++ b/website/source/docs/networking/forwarded_ports.html.md
@@ -67,7 +67,7 @@ there are more detailed examples of using these options.
   that will be allowed through the forwarded port. By default this is "tcp".
 
 * `id` (string) - Name of the rule (can be visible in VirtualBox). By 
-  default this is "protocol""guest" (exemple : "tcp123").
+  default this is "protocol""guest" (example : "tcp123").
 
 ## Forwarded Port Protocols
 


### PR DESCRIPTION
Following up on issue #8803:  Change "exemple" typo to "example".