### PR TITLE
Update guest IP address discovery for hyper-v guests.

### DIFF
--- a/plugins/providers/hyperv/action/wait_for_ip_address.rb
+++ b/plugins/providers/hyperv/action/wait_for_ip_address.rb
@@ -23,19 +23,23 @@ module VagrantPlugins
               return if env[:interrupted]
 
               # Try to get the IP
-              network_info = env[:machine].provider.driver.read_guest_ip
-              guest_ip = network_info["ip"]
+              begin
+                network_info = env[:machine].provider.driver.read_guest_ip
+                guest_ip = network_info["ip"]
 
-              if guest_ip
-                begin
-                  IPAddr.new(guest_ip)
-                  break
-                rescue IPAddr::InvalidAddressError
-                  # Ignore, continue looking.
-                  @logger.warn("Invalid IP address returned: #{guest_ip}")
+                if guest_ip
+                  begin
+                    IPAddr.new(guest_ip)
+                    break
+                  rescue IPAddr::InvalidAddressError
+                    # Ignore, continue looking.
+                    @logger.warn("Invalid IP address returned: #{guest_ip}")
+                  end
                 end
+              rescue Errors::PowerShellError
+                # Ignore, continue looking.
+                @logger.warn("Failed to read guest IP.")
               end
-
               sleep 1
             end
           end


### PR DESCRIPTION
Powershell helper script now returns error when guest IP address
cannot be discovered. When reading addresses from a network
device both IPv4 and IPv6 are stored and the IPv4 address has
precedence on returned address.

Fixes #8759