### PR TITLE
Validate powershell prior to powershell use

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -536,6 +536,14 @@ module Vagrant
       error_key(:requires_directory, "vagrant.actions.general.package")
     end
 
+    class PowerShellNotFound < VagrantError
+      error_key(:powershell_not_found)
+    end
+
+    class PowerShellInvalidVersion < VagrantError
+      error_key(:powershell_invalid_version)
+    end
+
     class ProviderCantInstall < VagrantError
       error_key(:provider_cant_install)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1051,6 +1051,17 @@ en:
           %{error_msg}
 
         Source: %{source}
+      powershell_not_found: |-
+        Failed to locate the powershell executable on the available PATH. Please
+        ensure powershell is installed and available on the local PATH, then
+        run the command again.
+      powershell_invalid_version: |-
+        The version of powershell currently installed on this host is less than
+        the required minimum version. Please upgrade the installed version of
+        powershell to the minimum required version and run the command again.
+
+          Installed version: %{installed_version}
+          Minimum required version: %{minimum_version}
       pushes_not_defined: |-
         The Vagrantfile does not define any 'push' strategies. In order to use
         `vagrant push`, you must define at least one push strategy:


### PR DESCRIPTION
Adds powershell validation to ensure powershell is available on
the PATH and checks powershell version to ensure meets the
defined minimum powershell version.