### PR TITLE
fix guest-linux private_key bug

### DIFF
--- a/plugins/guests/linux/cap/public_key.rb
+++ b/plugins/guests/linux/cap/public_key.rb
@@ -53,6 +53,7 @@ module VagrantPlugins
               result=$?
             fi
             rm -f '#{remote_path}'
+            chmod 0600 ~/.ssh/authorized_keys
             exit $result
           EOH
         end


### PR DESCRIPTION
 Default  can't "vagrant up virtual machine".
 So I added chmod permission authorized_keys