### PR TITLE
Remove curl pipe bash install for salt provisioner

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -2,11 +2,15 @@
 
 # We just download the bootstrap script by default and execute that.
 if [ -x /usr/bin/fetch ]; then
-    /usr/bin/fetch -o - https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh | sh -s -- "$@"
+    /usr/bin/fetch -o bootstrap-salt.sh https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
 elif [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -L https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh | sh -s -- "$@"
+    /usr/bin/curl -L -O https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
 else
-    python \
-        -c 'import urllib; print urllib.urlopen("https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh").read()' \
-        | sh -s -- "$@"
+    python -c 'import urllib; urllib.urlretrieve("https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh", "bootstrap-salt.sh")'
+fi
+
+if [ -e bootstrap-salt.sh ]; then
+  sh bootstrap-salt.sh "$@"
+else
+  exit 1
 fi


### PR DESCRIPTION
Prior to this commit, because of how the bootstrap salt shell file
worked, if github could not be resolved, the installer script would fail
silently with an exit code 0 because `sh` would evalute without any
errors and the curl exit code would be ignored. This commit splits out
the installer to first attempt to save the bash installer, and if it
exists, execute it.

Fixes #8789