### PR TITLE
Refer to a specific vagrant-spec revision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 if File.exist?(File.expand_path("../../vagrant-spec", __FILE__))
   gem 'vagrant-spec', path: "../vagrant-spec"
 else
-  gem 'vagrant-spec', git: "https://github.com/mitchellh/vagrant-spec.git"
+  gem 'vagrant-spec', git: "https://github.com/mitchellh/vagrant-spec.git", :ref => '2f0fb10862b2d19861c584be9d728080ba1f5d33'
 end


### PR DESCRIPTION
vagrant-spec master head has been [recently updated](https://github.com/mitchellh/vagrant-spec/commit/af86757912f7488fe693f52a80175057e6cf3349) to be compatible with
the upcoming upgrade to RSpec 3.5 (See #8850).

This is a temporary solution to keep receiving/building pull requests until the RSpec update hits the master branch.

@chrisroberts @briancain you'll know if this workaround is worth living for a while or not ;-)