### PR TITLE
Dup string if frozen for line endings

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -265,7 +265,7 @@ module VagrantPlugins
         # or we're running on Windows.
         if !config.binary && @machine.config.vm.communicator != :winrm
           begin
-            script.gsub!(/\r\n?$/, "\n")
+            script = script.gsub(/\r\n?$/, "\n")
           rescue ArgumentError
             script = script.force_encoding("ASCII-8BIT").gsub(/\r\n?$/, "\n")
           end

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -43,6 +43,37 @@ describe "Vagrant::Shell::Provisioner" do
     end
   end
 
+  context "with a script that was set to freeze the string" do
+    TEST_CONSTANT_VARIABLE = <<-TEST_CONSTANT_VARIABLE.freeze
+      echo test
+    TEST_CONSTANT_VARIABLE
+
+    let(:script) { TEST_CONSTANT_VARIABLE }
+    let(:config) {
+      double(
+        :config,
+        :args        => "doesn't matter",
+        :env         => {},
+        :upload_path => "arbitrary",
+        :remote?     => false,
+        :path        => nil,
+        :inline      => script,
+        :binary      => false,
+      )
+    }
+
+    it "does not raise an exception" do
+      vsp = VagrantPlugins::Shell::Provisioner.new(machine, config)
+
+      RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+      # This test should be fine, since we are specifically looking for the
+      # string 'freeze' when RuntimeError is raised
+      expect {
+        vsp.provision
+      }.not_to raise_error(RuntimeError)
+    end
+  end
+
   context "with remote script" do
 
     context "that does not have matching sha1 checksum" do


### PR DESCRIPTION
Prior to this commit, if a user passed in a script that was frozen,
the shell provisioner would fail to modify the script to replace line
endings for windows because the string was immutable. This commit fixes
that by checking to see if the script is frozen, and if so dup it so
that it can have its line endings replaced.

Fixes #8716