### PR TITLE
command/login: Add description to created token

### DIFF
--- a/plugins/commands/login/client.rb
+++ b/plugins/commands/login/client.rb
@@ -40,15 +40,24 @@ module VagrantPlugins
       # Login logs a user in and returns the token for that user. The token
       # is _not_ stored unless {#store_token} is called.
       #
-      # @param [String] user
-      # @param [String] pass
+      # @param [String] username_or_email
+      # @param [String] password
+      # @param [String] description
       # @return [String] token The access token, or nil if auth failed.
-      def login(user, pass)
-        @logger.info("Logging in '#{user}'")
+      def login(username_or_email, password, description: nil)
+        @logger.info("Logging in '#{username_or_email}'")
 
         with_error_handling do
-          url      = "#{Vagrant.server_url}/api/v1/authenticate"
-          request  = { "user" => { "login" => user, "password" => pass } }
+          url = "#{Vagrant.server_url}/api/v1/authenticate"
+          request = {
+            user: {
+              login: username_or_email,
+              password: password
+            },
+            token: {
+              description: description
+            }
+          }
 
           proxy   = nil
           proxy ||= ENV["HTTPS_PROXY"] || ENV["https_proxy"]

--- a/plugins/commands/login/command.rb
+++ b/plugins/commands/login/command.rb
@@ -48,8 +48,9 @@ module VagrantPlugins
         end
 
         # Ask for the username
-        login    = nil
-        password = nil
+        login       = nil
+        password    = nil
+        description = nil
         while !login
           login = @env.ui.ask("Vagrant Cloud Username: ")
         end
@@ -58,7 +59,14 @@ module VagrantPlugins
           password = @env.ui.ask("Password (will be hidden): ", echo: false)
         end
 
-        token = @client.login(login, password)
+        description_default = "Vagrant login"
+        while !description
+          description =
+            @env.ui.ask("Token description (Defaults to #{description_default.inspect}): ")
+        end
+        description = description_default if description.empty?
+
+        token = @client.login(login, password, description: description)
         if !token
           @env.ui.error(I18n.t("login_command.invalid_login"))
           return 1

--- a/plugins/commands/login/command.rb
+++ b/plugins/commands/login/command.rb
@@ -1,3 +1,5 @@
+require 'socket'
+
 module VagrantPlugins
   module LoginCommand
     class Command < Vagrant.plugin("2", "command")
@@ -59,7 +61,7 @@ module VagrantPlugins
           password = @env.ui.ask("Password (will be hidden): ", echo: false)
         end
 
-        description_default = "Vagrant login"
+        description_default = "Vagrant login from #{Socket.gethostname}"
         while !description
           description =
             @env.ui.ask("Token description (Defaults to #{description_default.inspect}): ")

--- a/test/unit/plugins/commands/login/client_test.rb
+++ b/test/unit/plugins/commands/login/client_test.rb
@@ -61,6 +61,9 @@ describe VagrantPlugins::LoginCommand::Client do
           "login" => "foo",
           "password" => "bar",
         },
+        "token" => {
+          "description" => "Token description"
+        }
       }
 
       response = {
@@ -76,7 +79,8 @@ describe VagrantPlugins::LoginCommand::Client do
         with(body: JSON.dump(request), headers: headers).
         to_return(status: 200, body: JSON.dump(response))
 
-      expect(subject.login("foo", "bar")).to eq("baz")
+      expect(subject.login("foo", "bar", description: "Token description"))
+        .to eq("baz")
     end
 
     it "returns nil on bad login" do


### PR DESCRIPTION
This adds a prompt for a token description, which is now supported in
Vagrant Cloud. Pressing enter on the prompt uses the default description
of `"Vagrant login"`.

    $ vagrant login
    In a moment we will ask for your username and password to HashiCorp's
    Vagrant Cloud. After authenticating, we will store an access token locally on
    disk. Your login details will be transmitted over a secure connection, and
    are never stored on disk locally.

    If you do not have an Vagrant Cloud account, sign up at
    https://www.vagrantcloud.com

    Vagrant Cloud Username: justincampbell
    Password (will be hidden):
    Token description (Defaults to "Vagrant login"):
    You are now logged in.
    $

Which created a token with the default description of "Vagrant login":

![](http://c.justincampbell.me/2V0p0T0U0d0O/Screen%20Shot%202017-08-10%20at%205.08.21%20PM.png)

Entering a description:

    Token description (Defaults to "Vagrant login"): Justin's MacBook Pro

![](http://c.justincampbell.me/2m1N0d1M3k3P/Screen%20Shot%202017-08-10%20at%205.09.39%20PM.png)