### PR TITLE
Improve `vagrant validate` command

### DIFF
--- a/plugins/commands/validate/command.rb
+++ b/plugins/commands/validate/command.rb
@@ -16,10 +16,10 @@ module VagrantPlugins
         argv = parse_options(opts)
         return if !argv
 
-        # Validate the configuration
-        @env.machine(@env.machine_names.first, @env.default_provider).action_raw(
-          :config_validate,
-          Vagrant::Action::Builtin::ConfigValidate)
+        # Validate the configuration of all machines
+        with_target_vms() do |machine|
+          machine.action_raw(:config_validate, Vagrant::Action::Builtin::ConfigValidate)
+        end
 
         @env.ui.info(I18n.t("vagrant.commands.validate.success"))
 


### PR DESCRIPTION
Prior to this commit, the `vagrant validate` command would only validate
the first machine in a vagrant file. This commit improves that by
validating all known machines in the environment. If one is not found,
it will properly throw an exception instead of a stacktrace.

Fixes #8864