### PR TITLE
Fix #8901

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -397,7 +397,7 @@ module Vagrant
           valid = false
           result = Util::Subprocess.execute("vagrant.exe", "version")
           if result.exit_code == 0
-            windows_version = result.stdout.match(/Installed Version: (?<version>.+$)/)
+            windows_version = result.stdout.match(/Installed Version: (?<version>[\w.-]+)/)
             if windows_version
               windows_version = windows_version[:version].strip
               valid = windows_version == Vagrant::VERSION


### PR DESCRIPTION
Fix WSL bug #8901. Regex `.+$` sometimes can result in version like "1.9.6\e[0m" so it captures some control characters at the end of line. Regex `[\w.-]+` should cover all possible versions according to semver spec.