### PR TITLE
Disable install providers when using global id on vagrant up

### DIFF
--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -78,6 +78,15 @@ module VagrantPlugins
         # Build up the batch job of what we'll do
         machines = []
         if names
+          # To prevent vagrant from attempting to validate a global vms config
+          # (which doesn't exist within the local dir) when attempting to
+          # install a machines provider, this check below will disable the
+          # install_providers function if a user gives us a machine id instead
+          # of the machines name.
+          machine_names = []
+          with_target_vms(names, provider: options[:provider]){|m| machine_names << m.name }
+          options[:install_provider] = false if !(machine_names - names).empty?
+
           # If we're installing providers, then do that. We don't
           # parallelize this step because it is likely the same provider
           # anyways.

--- a/test/unit/plugins/commands/up/command_test.rb
+++ b/test/unit/plugins/commands/up/command_test.rb
@@ -5,6 +5,7 @@ require Vagrant.source_root.join("plugins/commands/up/command")
 describe VagrantPlugins::CommandUp::Command do
   include_context "unit"
 
+  let(:entry_klass) { Vagrant::MachineIndex::Entry }
   let(:argv)     { [] }
   let(:vagrantfile_content){ "" }
   let(:iso_env) do
@@ -16,6 +17,13 @@ describe VagrantPlugins::CommandUp::Command do
   subject { described_class.new(argv, iso_env) }
 
   let(:action_runner) { double("action_runner") }
+
+  def new_entry(name)
+    entry_klass.new.tap do |e|
+      e.name = name
+      e.vagrantfile_path = "/bar"
+    end
+  end
 
   before do
     allow(iso_env).to receive(:action_runner).and_return(action_runner)
@@ -59,6 +67,65 @@ describe VagrantPlugins::CommandUp::Command do
           expect(batch).to receive(:action).with(anything, :up, anything)
           subject.execute
         end
+      end
+    end
+  end
+
+  context "with a global machine" do
+    let(:argv){ ["1234"] }
+
+    it "brings up a vm with an id" do
+
+      global_env = isolated_environment
+      global_env.vagrantfile("Vagrant.configure(2){|config| config.vm.box = 'dummy'}")
+      global_venv = global_env.create_vagrant_env
+      global_machine = global_venv.machine(global_venv.machine_names[0], :dummy)
+      global_machine.id = "1234"
+      global = new_entry(global_machine.name)
+      global.provider = "dummy"
+      global.vagrantfile_path = global_env.workdir
+      locked = iso_env.machine_index.set(global)
+      iso_env.machine_index.release(locked)
+
+      allow(subject).to receive(:with_target_vms) { |&block| block.call global_machine }
+
+
+      batch = double("environment_batch")
+      expect(iso_env).to receive(:batch).and_yield(batch)
+      expect(batch).to receive(:action).with(global_machine, :up, anything) do |machine,action,args|
+        expect(machine).to be_kind_of(Vagrant::Machine)
+        expect(action).to eq(:up)
+      end
+      subject.execute
+    end
+  end
+
+  context "with an argument" do
+    let(:vagrantfile_content) do
+        <<-VF
+        Vagrant.configure("2") do |config|
+          config.vm.define "app"
+          config.vm.define "db"
+        end
+        VF
+    end
+    let(:argv){ ["app"] }
+    let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+
+    it "brings up a vm" do
+      batch = double("environment_batch")
+      expect(iso_env).to receive(:batch).and_yield(batch)
+      expect(batch).to receive(:action).with(machine, :up, anything) do |machine,action,args|
+        expect(machine).to be_kind_of(Vagrant::Machine)
+        expect(action).to eq(:up)
+      end
+      subject.execute
+    end
+
+    context "with an invalid argument" do
+      let(:argv){ ["notweb"] }
+      it "brings up a vm" do
+        expect { subject.execute }.to raise_error(Vagrant::Errors::MachineNotFound)
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, when using a global id to bring up a vagrant vm,
vagrant would fail during the "install provider" step due to the fact
that the global vagrant machine was not configured for the local vagrant
environment. Since this global vm exists elsewhere, we disable the
install provider step so that vagrant can just bring up the global
vagrant machine.

Fixes #8479 