### PR TITLE
Format windows paths for ssh_config command

### DIFF
--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -5,7 +5,26 @@ require "vagrant/util/platform"
 describe Vagrant::Util::Platform do
   include_context "unit"
 
+
   subject { described_class }
+
+  describe "#cygwin_path" do
+    let(:path) { "C:\\msys2\\home\\vagrant" }
+    let(:updated_path) { "/home/vagrant" }
+    let(:subprocess_result) do
+      double("subprocess_result").tap do |result|
+        allow(result).to receive(:exit_code).and_return(0)
+        allow(result).to receive(:stdout).and_return(updated_path)
+      end
+    end
+
+    it "takes a windows path and returns a formatted path" do
+      allow(Vagrant::Util::Which).to receive(:which).and_return("C:/msys2/cygpath")
+      allow(Vagrant::Util::Subprocess).to receive(:execute).and_return(subprocess_result)
+
+      expect(subject.cygwin_path(path)).to eq("/home/vagrant")
+    end
+  end
 
   describe "#cygwin?" do
     before do
@@ -48,6 +67,50 @@ describe Vagrant::Util::Platform do
 
     it "returns false if nothing is available" do
       expect(subject).to_not be_cygwin
+    end
+  end
+
+  describe "#msys?" do
+    before do
+      allow(subject).to receive(:platform).and_return("test")
+      described_class.reset!
+    end
+
+    after do
+      described_class.reset!
+    end
+
+    around do |example|
+      with_temp_env(VAGRANT_DETECTED_OS: "nope", PATH: "") do
+        example.run
+      end
+    end
+
+    it "returns true if VAGRANT_DETECTED_OS includes msys" do
+      with_temp_env(VAGRANT_DETECTED_OS: "msys") do
+        expect(subject).to be_msys
+      end
+    end
+
+    it "returns true if OSTYPE includes msys" do
+      with_temp_env(OSTYPE: "msys") do
+        expect(subject).to be_msys
+      end
+    end
+
+    it "returns true if platform has msys" do
+      allow(subject).to receive(:platform).and_return("msys")
+      expect(subject).to be_msys
+    end
+
+    it "returns false if the PATH contains msys" do
+      with_temp_env(PATH: "C:/msys") do
+        expect(subject).to_not be_msys
+      end
+    end
+
+    it "returns false if nothing is available" do
+      expect(subject).to_not be_msys
     end
   end
 


### PR DESCRIPTION
Prior to this commit, if the ssh-config command was invoked within
cygwin or msys2, it would show a regular windows style path for private
keys rather than a path that could be used within msys2 or cygwin. This
commit updates that behavior by converting all of the private key paths
to the proper msys2 or cygwin path if the platform is windows and the
command was invoked from one of those two shells.

Fixes #6656