### PR TITLE
Fix shell_expand_guest_path capability

### DIFF
--- a/plugins/guests/darwin/cap/shell_expand_guest_path.rb
+++ b/plugins/guests/darwin/cap/shell_expand_guest_path.rb
@@ -4,7 +4,8 @@ module VagrantPlugins
       class ShellExpandGuestPath
         def self.shell_expand_guest_path(machine, path)
           real_path = nil
-          machine.communicate.execute("printf \"#{path}\"") do |type, data|
+          path = path.gsub(/ /, '\ ')
+          machine.communicate.execute("printf #{path}") do |type, data|
             if type == :stdout
               real_path ||= ""
               real_path += data

--- a/plugins/guests/freebsd/cap/shell_expand_guest_path.rb
+++ b/plugins/guests/freebsd/cap/shell_expand_guest_path.rb
@@ -4,7 +4,8 @@ module VagrantPlugins
       class ShellExpandGuestPath
         def self.shell_expand_guest_path(machine, path)
           real_path = nil
-          machine.communicate.execute("printf \"#{path}\"",
+          path = path.gsub(/ /, '\ ')
+          machine.communicate.execute("printf #{path}",
                                       shell: "sh") do |type, data|
             if type == :stdout
               real_path ||= ""

--- a/plugins/guests/linux/cap/shell_expand_guest_path.rb
+++ b/plugins/guests/linux/cap/shell_expand_guest_path.rb
@@ -4,7 +4,8 @@ module VagrantPlugins
       class ShellExpandGuestPath
         def self.shell_expand_guest_path(machine, path)
           real_path = nil
-          machine.communicate.execute("echo; printf \"#{path}\"") do |type, data|
+          path = path.gsub(/ /, '\ ')
+          machine.communicate.execute("echo; printf #{path}") do |type, data|
             if type == :stdout
               real_path ||= ""
               real_path += data

--- a/plugins/guests/netbsd/cap/shell_expand_guest_path.rb
+++ b/plugins/guests/netbsd/cap/shell_expand_guest_path.rb
@@ -4,7 +4,8 @@ module VagrantPlugins
       class ShellExpandGuestPath
         def self.shell_expand_guest_path(machine, path)
           real_path = nil
-          machine.communicate.execute("printf \"#{path}\"") do |type, data|
+          path = path.gsub(/ /, '\ ')
+          machine.communicate.execute("printf #{path}") do |type, data|
             if type == :stdout
               real_path ||= ""
               real_path += data

--- a/plugins/guests/openbsd/cap/shell_expand_guest_path.rb
+++ b/plugins/guests/openbsd/cap/shell_expand_guest_path.rb
@@ -4,7 +4,8 @@ module VagrantPlugins
       class ShellExpandGuestPath
         def self.shell_expand_guest_path(machine, path)
           real_path = nil
-          machine.communicate.execute("printf \"#{path}\"") do |type, data|
+          path = path.gsub(/ /, '\ ')
+          machine.communicate.execute("printf #{path}") do |type, data|
             if type == :stdout
               real_path ||= ""
               real_path += data

--- a/test/unit/plugins/guests/darwin/cap/shell_expand_guest_path_test.rb
+++ b/test/unit/plugins/guests/darwin/cap/shell_expand_guest_path_test.rb
@@ -33,10 +33,11 @@ describe "VagrantPlugins::GuestDarwin::Cap::ShellExpandGuestPath" do
 
     it "returns a path with a space in it" do
       path = "/home/vagrant folder/folder"
+      path_with_spaces = "/home/vagrant\\ folder/folder"
       allow(machine.communicate).to receive(:execute).
-        with(any_args).and_yield(:stdout, "/home/vagrant folder/folder")
+        with(any_args).and_yield(:stdout, path_with_spaces)
 
-      expect(machine.communicate).to receive(:execute).with("printf \"#{path}\"")
+      expect(machine.communicate).to receive(:execute).with("printf #{path_with_spaces}")
       cap.shell_expand_guest_path(machine, path)
     end
   end

--- a/test/unit/plugins/guests/freebsd/cap/shell_expand_guest_path_test.rb
+++ b/test/unit/plugins/guests/freebsd/cap/shell_expand_guest_path_test.rb
@@ -33,11 +33,12 @@ describe "VagrantPlugins::GuestFreeBSD::Cap::ShellExpandGuestPath" do
 
     it "returns a path with a space in it" do
       path = "/home/vagrant folder/folder"
+      path_with_spaces = "/home/vagrant\\ folder/folder"
       allow(machine.communicate).to receive(:execute).
-        with(any_args).and_yield(:stdout, "/home/vagrant folder/folder")
+        with(any_args).and_yield(:stdout, path_with_spaces)
 
       expect(machine.communicate).to receive(:execute)
-        .with("printf \"#{path}\"", {:shell=>"sh"})
+        .with("printf #{path_with_spaces}", {:shell=>"sh"})
       cap.shell_expand_guest_path(machine, path)
     end
   end

--- a/test/unit/plugins/guests/linux/cap/shell_expand_guest_path_test.rb
+++ b/test/unit/plugins/guests/linux/cap/shell_expand_guest_path_test.rb
@@ -33,10 +33,11 @@ describe "VagrantPlugins::GuestLinux::Cap::ShellExpandGuestPath" do
 
     it "returns a path with a space in it" do
       path = "/home/vagrant folder/folder"
+      path_with_spaces = "/home/vagrant\\ folder/folder"
       allow(machine.communicate).to receive(:execute).
-        with(any_args).and_yield(:stdout, "/home/vagrant folder/folder")
+        with(any_args).and_yield(:stdout, path_with_spaces)
 
-      expect(machine.communicate).to receive(:execute).with("echo; printf \"#{path}\"")
+      expect(machine.communicate).to receive(:execute).with("echo; printf #{path_with_spaces}")
       cap.shell_expand_guest_path(machine, path)
     end
   end

--- a/test/unit/plugins/guests/netbsd/cap/shell_expand_guest_path_test.rb
+++ b/test/unit/plugins/guests/netbsd/cap/shell_expand_guest_path_test.rb
@@ -33,10 +33,11 @@ describe "VagrantPlugins::GuestNetBSD::Cap::ShellExpandGuestPath" do
 
     it "returns a path with a space in it" do
       path = "/home/vagrant folder/folder"
+      path_with_spaces = "/home/vagrant\\ folder/folder"
       allow(machine.communicate).to receive(:execute).
-        with(any_args).and_yield(:stdout, "/home/vagrant folder/folder")
+        with(any_args).and_yield(:stdout, path_with_spaces)
 
-      expect(machine.communicate).to receive(:execute).with("printf \"#{path}\"")
+      expect(machine.communicate).to receive(:execute).with("printf #{path_with_spaces}")
       cap.shell_expand_guest_path(machine, path)
     end
   end

--- a/test/unit/plugins/guests/openbsd/cap/shell_expand_guest_path_test.rb
+++ b/test/unit/plugins/guests/openbsd/cap/shell_expand_guest_path_test.rb
@@ -33,10 +33,11 @@ describe "VagrantPlugins::GuestOpenBSD::Cap::ShellExpandGuestPath" do
 
     it "returns a path with a space in it" do
       path = "/home/vagrant folder/folder"
+      path_with_spaces = "/home/vagrant\\ folder/folder"
       allow(machine.communicate).to receive(:execute).
-        with(any_args).and_yield(:stdout, "/home/vagrant folder/folder")
+        with(any_args).and_yield(:stdout, path_with_spaces)
 
-      expect(machine.communicate).to receive(:execute).with("printf \"#{path}\"")
+      expect(machine.communicate).to receive(:execute).with("printf #{path_with_spaces}")
       cap.shell_expand_guest_path(machine, path)
     end
   end


### PR DESCRIPTION
Prior to this commit, when the guest capability attempted to expand a
path with spaces it would quote the path passed in. However if the path
also had a relative path those quotes would end up making `printf`
ignore it and not properly expand the path fully. This commit updates
that to first escape the quotes of a path and then pass in the new path
to be expanded.

Fixes #8917