### PR TITLE
`vagrant login` 2FA support for Vagrant Cloud

### DIFF
--- a/plugins/commands/login/client.rb
+++ b/plugins/commands/login/client.rb
@@ -7,6 +7,9 @@ module VagrantPlugins
     class Client
       include Vagrant::Util::Presence
 
+      attr_accessor :username_or_email
+      attr_accessor :password
+
       # Initializes a login client with the given Vagrant::Environment.
       #
       # @param [Vagrant::Environment] env
@@ -40,11 +43,9 @@ module VagrantPlugins
       # Login logs a user in and returns the token for that user. The token
       # is _not_ stored unless {#store_token} is called.
       #
-      # @param [String] username_or_email
-      # @param [String] password
       # @param [String] description
       # @return [String] token The access token, or nil if auth failed.
-      def login(username_or_email, password, description: nil)
+      def login(description: nil)
         @logger.info("Logging in '#{username_or_email}'")
 
         with_error_handling do

--- a/plugins/commands/login/client.rb
+++ b/plugins/commands/login/client.rb
@@ -5,10 +5,14 @@ require "vagrant/util/presence"
 module VagrantPlugins
   module LoginCommand
     class Client
+      APP = "app".freeze
+
       include Vagrant::Util::Presence
 
       attr_accessor :username_or_email
       attr_accessor :password
+      attr_reader :two_factor_default_delivery_method
+      attr_reader :two_factor_delivery_methods
 
       # Initializes a login client with the given Vagrant::Environment.
       #
@@ -38,27 +42,67 @@ module VagrantPlugins
           RestClient.get(url, content_type: :json)
           true
         end
+      rescue Errors::Unauthorized
+        false
       end
 
       # Login logs a user in and returns the token for that user. The token
       # is _not_ stored unless {#store_token} is called.
       #
       # @param [String] description
+      # @param [String] code
       # @return [String] token The access token, or nil if auth failed.
-      def login(description: nil)
+      def login(description: nil, code: nil)
         @logger.info("Logging in '#{username_or_email}'")
 
-        with_error_handling do
-          url = "#{Vagrant.server_url}/api/v1/authenticate"
-          request = {
+        response = post(
+          "/api/v1/authenticate", {
             user: {
               login: username_or_email,
               password: password
             },
             token: {
               description: description
+            },
+            two_factor: {
+              code: code
             }
           }
+        )
+
+        response["token"]
+      end
+
+      # Requests a 2FA code
+      # @param [String] delivery_method
+      def request_code(delivery_method)
+        @env.ui.warn("Requesting 2FA code via #{delivery_method.upcase}...")
+
+        response = post(
+          "/api/v1/two-factor/request-code", {
+            user: {
+              login: username_or_email,
+              password: password
+            },
+            two_factor: {
+              delivery_method: delivery_method.downcase
+            }
+          }
+        )
+
+        two_factor = response['two_factor']
+        obfuscated_destination = two_factor['obfuscated_destination']
+
+        @env.ui.success("2FA code sent to #{obfuscated_destination}.")
+      end
+
+      # Issues a post to a Vagrant Cloud path with the given payload.
+      # @param [String] path
+      # @param [Hash] payload
+      # @return [Hash] response data
+      def post(path, payload)
+        with_error_handling do
+          url = File.join(Vagrant.server_url, path)
 
           proxy   = nil
           proxy ||= ENV["HTTPS_PROXY"] || ENV["https_proxy"]
@@ -68,7 +112,7 @@ module VagrantPlugins
           response = RestClient::Request.execute(
             method: :post,
             url: url,
-            payload: JSON.dump(request),
+            payload: JSON.dump(payload),
             proxy: proxy,
             headers: {
               accept: :json,
@@ -77,8 +121,7 @@ module VagrantPlugins
             },
           )
 
-          data = JSON.load(response.to_s)
-          data["token"]
+          JSON.load(response.to_s)
         end
       end
 
@@ -139,14 +182,33 @@ EOH
         yield
       rescue RestClient::Unauthorized
         @logger.debug("Unauthorized!")
-        false
+        raise Errors::Unauthorized
+      rescue RestClient::BadRequest => e
+        @logger.debug("Bad request:")
+        @logger.debug(e.message)
+        @logger.debug(e.backtrace.join("\n"))
+        parsed_response = JSON.parse(e.response)
+        errors = parsed_response["errors"].join("\n")
+        raise Errors::ServerError, errors: errors
       rescue RestClient::NotAcceptable => e
         @logger.debug("Got unacceptable response:")
         @logger.debug(e.message)
         @logger.debug(e.backtrace.join("\n"))
 
+        parsed_response = JSON.parse(e.response)
+
+        if two_factor = parsed_response['two_factor']
+          store_two_factor_information two_factor
+
+          if two_factor_default_delivery_method != APP
+            request_code two_factor_default_delivery_method
+          end
+
+          raise Errors::TwoFactorRequired
+        end
+
         begin
-          errors = JSON.parse(e.response)["errors"].join("\n")
+          errors = parsed_response["errors"].join("\n")
           raise Errors::ServerError, errors: errors
         rescue JSON::ParserError; end
 
@@ -158,6 +220,33 @@ EOH
 
       def token_path
         @env.data_dir.join("vagrant_login_token")
+      end
+
+      def store_two_factor_information(two_factor)
+        @two_factor_default_delivery_method =
+          two_factor['default_delivery_method']
+
+        @two_factor_delivery_methods =
+          two_factor['delivery_methods']
+
+        @env.ui.warn "2FA is enabled for your account."
+        if two_factor_default_delivery_method == APP
+          @env.ui.info "Enter the code from your authenticator."
+        else
+          @env.ui.info "Default method is " \
+            "'#{two_factor_default_delivery_method}'."
+        end
+
+        other_delivery_methods =
+          two_factor_delivery_methods - [APP]
+
+        if other_delivery_methods.any?
+          other_delivery_methods_sentence = other_delivery_methods
+            .map { |word| "'#{word}'" }
+            .join(' or ')
+          @env.ui.info "You can also type #{other_delivery_methods_sentence} " \
+            "to request a new code."
+        end
       end
     end
   end

--- a/plugins/commands/login/errors.rb
+++ b/plugins/commands/login/errors.rb
@@ -12,6 +12,13 @@ module VagrantPlugins
       class ServerUnreachable < Error
         error_key(:server_unreachable)
       end
+
+      class Unauthorized < Error
+        error_key(:unauthorized)
+      end
+
+      class TwoFactorRequired < Error
+      end
     end
   end
 end

--- a/plugins/commands/login/locales/en.yml
+++ b/plugins/commands/login/locales/en.yml
@@ -9,6 +9,9 @@ en:
         The Vagrant Cloud server is not currently accepting connections. Please check
         your network connection and try again later.
 
+      unauthorized: |-
+        Invalid username or password. Please try again.
+
     check_logged_in: |-
       You are already logged in.
     check_not_logged_in: |-

--- a/plugins/commands/login/locales/en.yml
+++ b/plugins/commands/login/locales/en.yml
@@ -2,7 +2,7 @@ en:
   login_command:
     errors:
       server_error: |-
-        The Vagrant Cloud server responded with an not-OK response:
+        The Vagrant Cloud server responded with a not-OK response:
 
         %{errors}
       server_unreachable: |-


### PR DESCRIPTION
This adds support for two-factor authentication to `vagrant login`.

Previously, when a user attempted to login and 2FA was enabled on Vagrant Cloud, we returned an error stating to create a token manually in the web UI. This changed code looks for an additional field in the failed login response to detect that 2FA is required, and present the appropriate options to the user. The server changes are backwards-compatible with existing Vagrant versions, as the response code and error text have not changed when 2FA is enabled.

In addition to supporting TOTP application codes via the login endpoint, there is now an additional endpoint to request a code via another method (only SMS is supported as of now within Vagrant Cloud).

Using a TOTP app:

![](http://c.justincampbell.me/0O30001D1C23/Screen%20Shot%202017-08-30%20at%2010.04.20%20AM.png)

When 2FA default is app but SMS is enabled:

![](http://c.justincampbell.me/2Y2E2G0Z3z0H/Screen%20Shot%202017-08-30%20at%2010.07.02%20AM.png)

When 2FA default is SMS:

![](http://c.justincampbell.me/1m2g2l3R3O1g/Screen%20Shot%202017-08-30%20at%2010.08.55%20AM.png)

Invalid username or password:

![](http://c.justincampbell.me/2B2E3b441m3l/Screen%20Shot%202017-08-30%20at%2010.09.19%20AM.png)

Invalid 2FA code:

![](http://c.justincampbell.me/3p2o2V472f3i/Screen%20Shot%202017-08-30%20at%2010.09.52%20AM.png)