### PR TITLE
Remove duplicate export folders before writing /etc/exports

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -468,6 +468,10 @@ module Vagrant
       error_key(:nfs_bad_exports)
     end
 
+    class NFSDupePerms < VagrantError
+      error_key(:nfs_dupe_permissions)
+    end
+
     class NFSExportsFailed < VagrantError
       error_key(:nfs_exports_failed)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -912,6 +912,9 @@ en:
         command: %{command}
         stdout: %{stdout}
         stderr: %{stderr}
+      nfs_dupe_permissions: |-
+        You have attempted to export the same nfs host path at %{hostpath} with
+        different nfs permissions. Please pick one permission and reload your guest.
       nfs_cant_read_exports: |-
         Vagrant can't read your current NFS exports! The exports file should be
         readable by any user. This is usually caused by invalid permissions


### PR DESCRIPTION
Prior to this commit, if you set up multiple folders to export with NFS
on linux with the exact same hostpath, the template used to write
/etc/exports would end up placing the same path with the same IP in
/etc/exports and cause an error preventing the folders from being
properly mounted. This commit fixes that by first looking at which
folders are being exported and if there are any duplicates. If so,
remove the duplicates and only export 1 hostpath folder. If these
duplicate folders have differing nfs linux options, an exception must be
thrown because we cannot assume which options the user intended to
export with.

Fixes #4666